### PR TITLE
Add initial 'spatial mode' option

### DIFF
--- a/filer/CMakeLists.txt
+++ b/filer/CMakeLists.txt
@@ -33,6 +33,7 @@ set(filer_SRCS
     autorundialog.cpp
     settings.cpp
     metadata.cpp
+    windowregistry.cpp
 )
 
 qt5_add_dbus_adaptor(filer_SRCS

--- a/filer/CMakeLists.txt
+++ b/filer/CMakeLists.txt
@@ -32,6 +32,7 @@ set(filer_SRCS
     desktopitemdelegate.cpp
     autorundialog.cpp
     settings.cpp
+    metadata.cpp
 )
 
 qt5_add_dbus_adaptor(filer_SRCS

--- a/filer/launcher.cpp
+++ b/filer/launcher.cpp
@@ -51,15 +51,22 @@ bool Launcher::openFolder(GAppLaunchContext* ctx, GList* folder_infos, GError** 
         mainWindow->setWindowState(mainWindow->windowState() | Qt::WindowMaximized);
     }
   }
-  else
-    mainWindow->chdir(fm_file_info_get_path(fi));
+  else {
+    if (app->settings().spatialMode())
+        mainWindow->addWindow(fm_file_info_get_path(fi));
+    else
+        mainWindow->chdir(fm_file_info_get_path(fi));
+  }
   l = l->next;
   for(; l; l = l->next) {
     fi = FM_FILE_INFO(l->data);
     mainWindow->addTab(fm_file_info_get_path(fi));
   }
   mainWindow->show();
-  mainWindow->raise();
+
+  // otherwise the 'parent' window gets raised again on opening a child
+  if (! app->settings().spatialMode())
+    mainWindow->raise();
   return true;
 }
 

--- a/filer/launcher.cpp
+++ b/filer/launcher.cpp
@@ -21,6 +21,7 @@
 #include "launcher.h"
 #include "mainwindow.h"
 #include "application.h"
+#include "windowregistry.h"
 
 namespace Filer {
 
@@ -39,8 +40,15 @@ Launcher::~Launcher() {
 bool Launcher::openFolder(GAppLaunchContext* ctx, GList* folder_infos, GError** err) {
   qDebug("probono: Launcher::openFolder called");
   qDebug("probono: ffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+
   GList* l = folder_infos;
   FmFileInfo* fi = FM_FILE_INFO(l->data);
+
+  // just raise the window if it's already open
+  if (WindowRegistry::instance().checkPathAndRaise(fm_path_to_str(fm_file_info_get_path(fi)))) {
+    return true;
+  }
+
   Application* app = static_cast<Application*>(qApp);
   MainWindow* mainWindow = mainWindow_;
   if(!mainWindow) {

--- a/filer/mainwindow.h
+++ b/filer/mainwindow.h
@@ -144,6 +144,8 @@ protected Q_SLOTS:
 
   void onBackForwardContextMenu(QPoint pos);
 
+  void onRaiseWindow(const QString& path);
+
 protected:
   // void changeEvent( QEvent * event);
   void closeTab(int index);

--- a/filer/mainwindow.h
+++ b/filer/mainwindow.h
@@ -46,6 +46,7 @@ public:
 
   void chdir(FmPath* path);
   void addTab(FmPath* path);
+  void addWindow(FmPath* path);
 
   TabPage* currentPage() {
     return reinterpret_cast<TabPage*>(ui.stackedWidget->currentWidget());
@@ -147,6 +148,7 @@ protected:
   // void changeEvent( QEvent * event);
   void closeTab(int index);
   virtual void resizeEvent(QResizeEvent *event);
+  virtual void moveEvent(QMoveEvent* event);
   virtual void closeEvent(QCloseEvent *event);
 
 private:

--- a/filer/metadata.cpp
+++ b/filer/metadata.cpp
@@ -1,0 +1,136 @@
+/*
+ *    Copyright (C) 2021 Chris Moore <chris@mooreonline.org>
+ *
+ *    This program is free software; you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation; either version 2 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License along
+ *    with this program; if not, write to the Free Software Foundation, Inc.,
+ *    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "metadata.h"
+#include <sys/extattr.h>
+#include <QDebug>
+
+namespace {
+
+static const int ATTR_VAL_SIZE        = 10;
+static const QString WINDOW_ORIGIN_X  = "window.originx";
+static const QString WINDOW_ORIGIN_Y  = "window.originy";
+static const QString WINDOW_HEIGHT    = "window.height";
+static const QString WINDOW_WIDTH     = "window.width";
+
+/*
+ * get the attibute value from the extended attribute for the path as int
+ */
+int getAttributeValueInt(const QString& path, const QString& attribute, bool& ok) {
+  int value = 0;
+
+  // get the value from the extended attribute for the path
+  char data[ATTR_VAL_SIZE];
+  ssize_t bytesRetrieved = extattr_get_file(path.toLatin1().data(), EXTATTR_NAMESPACE_USER,
+                                            attribute.toLatin1().data(), data, ATTR_VAL_SIZE);
+  // check if we got the attribute value
+  if (bytesRetrieved <= 0)
+    ok = false;
+  else {
+    // convert the value to int via QString
+    QString strValue(data);
+    bool intOK;
+    int val = strValue.toInt(&intOK);
+    if (intOK) {
+      ok = true;
+      value = val;
+    }
+  }
+  return value;
+}
+
+/*
+ * set the attibute value in the extended attribute for the path as int
+ */
+bool setAttributeValueInt(const QString& path, const QString& attribute, int value) {
+  // set the value from the extended attribute for the path
+  QString data = QString::number(value);
+  ssize_t bytesSet = extattr_set_file(path.toLatin1().data(), EXTATTR_NAMESPACE_USER,
+                                      attribute.toLatin1().data(), data.toLatin1().data(),
+                                      data.length() + 1); // include \0 termination char
+  // check if we set the attribute value
+  return (bytesSet > 0);
+}
+
+} // anonymous namespace
+
+MetaData::MetaData(const QString &path):
+  QObject(),
+  path_(path) {
+  // do nothing
+}
+
+MetaData::~MetaData() {
+  // do nothing
+}
+
+int MetaData::getWindowOriginX(bool &ok) const
+{
+  int val = getAttributeValueInt(path_, WINDOW_ORIGIN_X, ok);
+  return val;
+}
+
+int MetaData::getWindowOriginY(bool& ok) const
+{
+  int val = getAttributeValueInt(path_, WINDOW_ORIGIN_Y, ok);
+  return val;
+}
+
+int MetaData::getWindowHeight(bool& ok) const
+{
+  int val = getAttributeValueInt(path_, WINDOW_HEIGHT, ok);
+  return val;
+}
+
+int MetaData::getWindowWidth(bool& ok) const
+{
+  int val = getAttributeValueInt(path_, WINDOW_WIDTH, ok);
+  return val;
+}
+
+void MetaData::setWindowOriginX(int x)
+{
+  bool success = setAttributeValueInt(path_, WINDOW_ORIGIN_X, x);
+  if ( ! success ) {
+    qWarning() << "MetaData::setWindowOriginX: unable to set attribute";
+  }
+}
+
+void MetaData::setWindowOriginY(int y)
+{
+  bool success = setAttributeValueInt(path_, WINDOW_ORIGIN_Y, y);
+  if ( ! success ) {
+    qWarning() << "MetaData::setWindowOriginX: unable to set attribute";
+  }
+}
+
+void MetaData::setWindowHeight(int height)
+{
+  bool success = setAttributeValueInt(path_, WINDOW_HEIGHT, height);
+  if ( ! success ) {
+    qWarning() << "MetaData::setWindowOriginX: unable to set attribute";
+  }
+}
+
+void MetaData::setWindowWidth(int width)
+{
+  bool success = setAttributeValueInt(path_, WINDOW_WIDTH, width);
+  if ( ! success ) {
+    qWarning() << "MetaData::setWindowOriginX: unable to set attribute";
+  }
+}

--- a/filer/metadata.h
+++ b/filer/metadata.h
@@ -1,0 +1,45 @@
+/*
+ *    Copyright (C) 2021 Chris Moore <chris@mooreonline.org>
+ *
+ *    This program is free software; you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation; either version 2 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License along
+ *    with this program; if not, write to the Free Software Foundation, Inc.,
+ *    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef PCMANFM_METADATA_H
+#define PCMANFM_METADATA_H
+
+#include <QObject>
+
+class MetaData : public QObject {
+  Q_OBJECT
+
+public:
+  explicit MetaData(const QString& path);
+  virtual ~MetaData();
+
+  int getWindowOriginX(bool& ok) const;
+  int getWindowOriginY(bool& ok) const;
+  int getWindowHeight(bool& ok) const;
+  int getWindowWidth(bool& ok) const;
+
+  void setWindowOriginX(int x);
+  void setWindowOriginY(int y);
+  void setWindowHeight(int height);
+  void setWindowWidth(int width);
+
+private:
+  QString path_;
+};
+
+#endif // PCMANFM_METADATA_H

--- a/filer/preferences.ui
+++ b/filer/preferences.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>685</width>
+    <width>701</width>
     <height>440</height>
    </rect>
   </property>
@@ -81,13 +81,24 @@
             <string>Browsing</string>
            </property>
            <layout class="QFormLayout" name="formLayout_5">
-            <property name="fieldGrowthPolicy">
-             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-            </property>
-            <item row="0" column="0" colspan="2">
+            <item row="0" column="0">
              <widget class="QCheckBox" name="singleClick">
               <property name="text">
                <string>Open files with single click</string>
+              </property>
+             </widget>
+            </item>
+            <item row="8" column="0">
+             <widget class="QLabel" name="label_11">
+              <property name="text">
+               <string>Default view mode:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QCheckBox" name="spatialMode">
+              <property name="text">
+               <string>Spatial browsing mode (folders open in a new window)</string>
               </property>
              </widget>
             </item>
@@ -100,16 +111,6 @@
                <string>Delay of auto-selection in single click mode (0 to disable)</string>
               </property>
              </widget>
-            </item>
-            <item row="3" column="0">
-             <widget class="QLabel" name="label_11">
-              <property name="text">
-               <string>Default view mode:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="1">
-             <widget class="QComboBox" name="viewMode"/>
             </item>
             <item row="1" column="1">
              <widget class="QDoubleSpinBox" name="autoSelectionDelay">
@@ -124,14 +125,14 @@
               </property>
              </widget>
             </item>
-            <item row="2" column="0">
+            <item row="4" column="0">
              <widget class="QLabel" name="label_2">
               <property name="text">
                <string>Bookmarks:</string>
               </property>
              </widget>
             </item>
-            <item row="2" column="1">
+            <item row="4" column="1">
              <widget class="QComboBox" name="bookmarkOpenMethod">
               <item>
                <property name="text">
@@ -149,6 +150,9 @@
                </property>
               </item>
              </widget>
+            </item>
+            <item row="8" column="1">
+             <widget class="QComboBox" name="viewMode"/>
             </item>
            </layout>
           </widget>
@@ -424,8 +428,7 @@
                </property>
                <property name="icon">
                 <iconset theme="user-home">
-                 <normaloff/>
-                </iconset>
+                 <normaloff>.</normaloff>.</iconset>
                </property>
               </item>
               <item>
@@ -437,8 +440,7 @@
                </property>
                <property name="icon">
                 <iconset theme="user-desktop">
-                 <normaloff/>
-                </iconset>
+                 <normaloff>.</normaloff>.</iconset>
                </property>
               </item>
               <item>
@@ -450,8 +452,7 @@
                </property>
                <property name="icon">
                 <iconset theme="user-trash">
-                 <normaloff/>
-                </iconset>
+                 <normaloff>.</normaloff>.</iconset>
                </property>
               </item>
               <item>
@@ -463,8 +464,7 @@
                </property>
                <property name="icon">
                 <iconset theme="computer">
-                 <normaloff/>
-                </iconset>
+                 <normaloff>.</normaloff>.</iconset>
                </property>
               </item>
               <item>
@@ -492,8 +492,7 @@
                </property>
                <property name="icon">
                 <iconset theme="folder-network">
-                 <normaloff/>
-                </iconset>
+                 <normaloff>.</normaloff>.</iconset>
                </property>
               </item>
              </widget>
@@ -777,8 +776,6 @@
   <tabstop>fixedWindowWidth</tabstop>
   <tabstop>fixedWindowHeight</tabstop>
   <tabstop>singleClick</tabstop>
-  <tabstop>autoSelectionDelay</tabstop>
-  <tabstop>viewMode</tabstop>
   <tabstop>configmDelete</tabstop>
   <tabstop>useTrash</tabstop>
   <tabstop>mountOnStartup</tabstop>

--- a/filer/preferencesdialog.cpp
+++ b/filer/preferencesdialog.cpp
@@ -183,6 +183,7 @@ void PreferencesDialog::initUiPage(Settings& settings) {
 
 void PreferencesDialog::initBehaviorPage(Settings& settings) {
   ui.singleClick->setChecked(settings.singleClick());
+  ui.spatialMode->setChecked(settings.spatialMode());
   ui.autoSelectionDelay->setValue(double(settings.autoSelectionDelay()) / 1000);
 
   ui.bookmarkOpenMethod->setCurrentIndex(settings.bookmarkOpenMethod());
@@ -301,6 +302,7 @@ void PreferencesDialog::applyUiPage(Settings& settings) {
 
 void PreferencesDialog::applyBehaviorPage(Settings& settings) {
   settings.setSingleClick(ui.singleClick->isChecked());
+  settings.setSpatialMode(ui.spatialMode->isChecked());
   settings.setAutoSelectionDelay(int(ui.autoSelectionDelay->value() * 1000));
 
   settings.setBookmarkOpenMethod(OpenDirTargetType(ui.bookmarkOpenMethod->currentIndex()));

--- a/filer/settings.cpp
+++ b/filer/settings.cpp
@@ -85,6 +85,7 @@ Settings::Settings():
   sortColumn_(Fm::FolderModel::ColumnFileName),
   sortFolderFirst_(true),
   showFilter_(false),
+  spatialMode_(false),
   // settings for use with libfm
   singleClick_(false),
   autoSelectionDelay_(600),
@@ -163,6 +164,7 @@ bool Settings::loadFile(QString filePath) {
 
   settings.beginGroup("Behavior");
   bookmarkOpenMethod_ = bookmarkOpenMethodFromString(settings.value("BookmarkOpenMethod").toString());
+  spatialMode_ = settings.value("SpatialMode", false).toBool();
   // settings for use with libfm
   useTrash_ = settings.value("UseTrash", true).toBool();
   singleClick_ = settings.value("SingleClick", false).toBool();
@@ -261,6 +263,7 @@ bool Settings::saveFile(QString filePath) {
   // settings for use with libfm
   settings.setValue("UseTrash", useTrash_);
   settings.setValue("SingleClick", singleClick_);
+  settings.setValue("SpatialMode", spatialMode_);
   settings.setValue("AutoSelectionDelay", autoSelectionDelay_);
   settings.setValue("ConfirmDelete", confirmDelete_);
   settings.setValue("NoUsbTrash", noUsbTrash_);

--- a/filer/settings.h
+++ b/filer/settings.h
@@ -354,6 +354,14 @@ public:
     showFilter_ = value;
   }
 
+  bool spatialMode() const {
+    return spatialMode_;
+  }
+
+  void setSpatialMode(bool value) {
+    spatialMode_ = value;
+  }
+
   // settings for use with libfm
   bool singleClick() const {
     return singleClick_;
@@ -581,6 +589,7 @@ private:
   Fm::FolderModel::ColumnId sortColumn_;
   bool sortFolderFirst_;
   bool showFilter_;
+  bool spatialMode_;
 
   // settings for use with libfm
   bool singleClick_;

--- a/filer/tabpage.cpp
+++ b/filer/tabpage.cpp
@@ -22,6 +22,7 @@
 #include "filelauncher.h"
 #include "filemenu.h"
 #include "mountoperation.h"
+#include "windowregistry.h"
 #include <QApplication>
 #include <QCursor>
 #include <QMessageBox>
@@ -328,6 +329,10 @@ void TabPage::chdir(FmPath* newPath, bool addHistory) {
     // we're already in the specified dir
     if(fm_path_equal(newPath, fm_folder_get_path(folder_)))
       return;
+
+    // update registry
+    QString oldPath = fm_path_to_str(fm_folder_get_path(folder_));
+    WindowRegistry::instance().updatePath(oldPath, fm_path_to_str(newPath));
 
     if(addHistory) {
       // store current scroll pos in the browse history

--- a/filer/windowregistry.cpp
+++ b/filer/windowregistry.cpp
@@ -1,0 +1,54 @@
+/*
+ *    Copyright (C) 2021 Chris Moore <chris@mooreonline.org>
+ *
+ *    This program is free software; you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation; either version 2 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License along
+ *    with this program; if not, write to the Free Software Foundation, Inc.,
+ *    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "windowregistry.h"
+
+WindowRegistry::~WindowRegistry() {
+  // do nothing
+}
+
+void WindowRegistry::registerPath(const QString& path)
+{
+  registry_.insert(path);
+}
+
+void WindowRegistry::updatePath(const QString& fromPath, const QString& toPath)
+{
+  registry_.remove(fromPath);
+  registry_.insert(toPath);
+}
+
+void WindowRegistry::deregisterPath(const QString& path)
+{
+  registry_.remove(path);
+}
+
+bool WindowRegistry::checkPathAndRaise(const QString& path)
+{
+  if (registry_.contains(path)) {
+    Q_EMIT raiseWindow(path);
+    return true;
+  }
+  return false;
+}
+
+WindowRegistry::WindowRegistry(QObject* parent):
+  QObject(),
+  registry_() {
+  // do nothing
+}

--- a/filer/windowregistry.h
+++ b/filer/windowregistry.h
@@ -1,0 +1,59 @@
+/*
+ *    Copyright (C) 2021 Chris Moore <chris@mooreonline.org>
+ *
+ *    This program is free software; you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation; either version 2 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License along
+ *    with this program; if not, write to the Free Software Foundation, Inc.,
+ *    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef WINDOWREGISTRY_H
+#define WINDOWREGISTRY_H
+
+#include <QObject>
+#include <QSet>
+#include <QString>
+
+class WindowRegistry : public QObject {
+  Q_OBJECT
+
+public:
+  virtual ~WindowRegistry();
+
+  // singleton function
+  static WindowRegistry& instance()
+  {
+    static WindowRegistry instance;
+    return instance;
+  }
+
+  void registerPath(const QString& path);
+  void updatePath(const QString& fromPath, const QString& toPath);
+  void deregisterPath(const QString& path);
+
+  /*
+   * if the window is in the registry, raise the window
+   * and return true; otherwise return false
+   */
+  bool checkPathAndRaise(const QString& path);
+
+Q_SIGNALS:
+  void raiseWindow(const QString& path);
+
+private: // functions
+  explicit WindowRegistry(QObject* parent = nullptr);
+
+private: // data
+  QSet<QString> registry_; // set of paths of open windows
+};
+
+#endif // WINDOWREGISTRY_H


### PR DESCRIPTION
Add an option for a 'spatial mode' (might be a more user friendly description here) in the preferences.

This enables the storing of window position and size in extended attributes for the particular folder open. The folders are opened in new windows and will remember the position and size if you move and resize them.

Signed-off-by: Chris Moore <chris@mooreonline.org>