### PR TITLE
metadata: use mirror of read-only parts of filesystem

### DIFF
--- a/filer/metadata.h
+++ b/filer/metadata.h
@@ -39,6 +39,10 @@ public:
   void setWindowWidth(int width);
 
 private:
+  int getMetadataInt(const QString& path, const QString& attribute, bool& ok) const;
+  void setMetadataInt(const QString& path, const QString& attribute, int value);
+
+private:
   QString path_;
 };
 


### PR DESCRIPTION
When extended attributes can't be written to a path (due to
lack of user permissions), they are now written to a mirror
of the directory structure under ~/.config/filer-qt/default/metadata

Likewise, when reading an extended attribute, if the requested path is
not writable, the mirrored structure under filer-metadata is checked.

https://github.com/helloSystem/hello/issues/79

Signed-off-by: Chris Moore <chris@mooreonline.org>