### PR TITLE
Add .DirInfo metadata storage for saving to non-extattr locations

### DIFF
--- a/filer/metadata.h
+++ b/filer/metadata.h
@@ -19,6 +19,7 @@
 #ifndef PCMANFM_METADATA_H
 #define PCMANFM_METADATA_H
 
+#include <QMap>
 #include <QObject>
 
 class MetaData : public QObject {
@@ -41,9 +42,13 @@ public:
 private:
   int getMetadataInt(const QString& path, const QString& attribute, bool& ok) const;
   void setMetadataInt(const QString& path, const QString& attribute, int value);
+  void loadDirInfo();
+  void saveDirInfo();
+  bool dirInfoDisabledForPath() const;
 
 private:
   QString path_;
+  QMap<QString, QVariant> windowAttributes_;
 };
 
 #endif // PCMANFM_METADATA_H

--- a/filer/preferences.ui
+++ b/filer/preferences.ui
@@ -80,25 +80,11 @@
            <property name="title">
             <string>Browsing</string>
            </property>
-           <layout class="QFormLayout" name="formLayout_5">
+           <layout class="QGridLayout" name="gridLayout">
             <item row="0" column="0">
              <widget class="QCheckBox" name="singleClick">
               <property name="text">
                <string>Open files with single click</string>
-              </property>
-             </widget>
-            </item>
-            <item row="8" column="0">
-             <widget class="QLabel" name="label_11">
-              <property name="text">
-               <string>Default view mode:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <widget class="QCheckBox" name="spatialMode">
-              <property name="text">
-               <string>Spatial browsing mode (folders open in a new window)</string>
               </property>
              </widget>
             </item>
@@ -122,6 +108,23 @@
               </property>
               <property name="singleStep">
                <double>0.100000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QCheckBox" name="spatialMode">
+              <property name="text">
+               <string>Spatial browsing mode (folders open in a new window)</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0" colspan="2">
+             <widget class="QCheckBox" name="dirInfoWrite">
+              <property name="text">
+               <string>Save metadata to directories (.DirInfo files)</string>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
               </property>
              </widget>
             </item>
@@ -151,7 +154,14 @@
               </item>
              </widget>
             </item>
-            <item row="8" column="1">
+            <item row="5" column="0">
+             <widget class="QLabel" name="label_11">
+              <property name="text">
+               <string>Default view mode:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="1">
              <widget class="QComboBox" name="viewMode"/>
             </item>
            </layout>

--- a/filer/preferencesdialog.cpp
+++ b/filer/preferencesdialog.cpp
@@ -184,6 +184,7 @@ void PreferencesDialog::initUiPage(Settings& settings) {
 void PreferencesDialog::initBehaviorPage(Settings& settings) {
   ui.singleClick->setChecked(settings.singleClick());
   ui.spatialMode->setChecked(settings.spatialMode());
+  ui.dirInfoWrite->setChecked(settings.dirInfoWrite());
   ui.autoSelectionDelay->setValue(double(settings.autoSelectionDelay()) / 1000);
 
   ui.bookmarkOpenMethod->setCurrentIndex(settings.bookmarkOpenMethod());
@@ -303,6 +304,7 @@ void PreferencesDialog::applyUiPage(Settings& settings) {
 void PreferencesDialog::applyBehaviorPage(Settings& settings) {
   settings.setSingleClick(ui.singleClick->isChecked());
   settings.setSpatialMode(ui.spatialMode->isChecked());
+  settings.setDirInfoWrite(ui.dirInfoWrite->isChecked());
   settings.setAutoSelectionDelay(int(ui.autoSelectionDelay->value() * 1000));
 
   settings.setBookmarkOpenMethod(OpenDirTargetType(ui.bookmarkOpenMethod->currentIndex()));

--- a/filer/settings.cpp
+++ b/filer/settings.cpp
@@ -86,6 +86,7 @@ Settings::Settings():
   sortFolderFirst_(true),
   showFilter_(false),
   spatialMode_(false),
+  dirInfoWrite_(true),
   // settings for use with libfm
   singleClick_(false),
   autoSelectionDelay_(600),
@@ -165,6 +166,7 @@ bool Settings::loadFile(QString filePath) {
   settings.beginGroup("Behavior");
   bookmarkOpenMethod_ = bookmarkOpenMethodFromString(settings.value("BookmarkOpenMethod").toString());
   spatialMode_ = settings.value("SpatialMode", false).toBool();
+  dirInfoWrite_ = settings.value("DirInfoWrite", true).toBool();
   // settings for use with libfm
   useTrash_ = settings.value("UseTrash", true).toBool();
   singleClick_ = settings.value("SingleClick", false).toBool();
@@ -264,6 +266,7 @@ bool Settings::saveFile(QString filePath) {
   settings.setValue("UseTrash", useTrash_);
   settings.setValue("SingleClick", singleClick_);
   settings.setValue("SpatialMode", spatialMode_);
+  settings.setValue("DirInfoWrite", dirInfoWrite_);
   settings.setValue("AutoSelectionDelay", autoSelectionDelay_);
   settings.setValue("ConfirmDelete", confirmDelete_);
   settings.setValue("NoUsbTrash", noUsbTrash_);

--- a/filer/settings.h
+++ b/filer/settings.h
@@ -362,6 +362,14 @@ public:
     spatialMode_ = value;
   }
 
+  bool dirInfoWrite() const {
+    return dirInfoWrite_;
+  }
+
+  void setDirInfoWrite(bool value) {
+    dirInfoWrite_ = value;
+  }
+
   // settings for use with libfm
   bool singleClick() const {
     return singleClick_;
@@ -590,6 +598,7 @@ private:
   bool sortFolderFirst_;
   bool showFilter_;
   bool spatialMode_;
+  bool dirInfoWrite_;
 
   // settings for use with libfm
   bool singleClick_;


### PR DESCRIPTION
We save in the JSON format specification as detailed in this post:
https://github.com/helloSystem/hello/issues/79#issuecomment-795793702

So far we are only saving four 'Window' attributes.

The logic is that the .DirInfo file is loaded and saved for a path when
the metadata is accessed, but the loaded values are only used when the
extended attributes are not present (e.g. when unpacked from an archive).

There is an option in the preferences dialog to enable this feature and
this is enabled by default.

Signed-off-by: Chris Moore <chris@mooreonline.org>

@probonopd please review