### PR TITLE
Add model items from 'computer://' to desktop window

### DIFF
--- a/filer/desktopwindow.cpp
+++ b/filer/desktopwindow.cpp
@@ -91,6 +91,7 @@ DesktopWindow::DesktopWindow(int screenNum):
         Settings& settings = static_cast<Application* >(qApp)->settings();
 
         model_ = Fm::CachedFolderModel::modelFromPath(fm_path_get_desktop());
+        model_->addComputerFiles();
         folder_ = reinterpret_cast<FmFolder*>(g_object_ref(model_->folder()));
 
         proxyModel_ = new Fm::ProxyFolderModel();

--- a/libfm-qt/foldermodel.h
+++ b/libfm-qt/foldermodel.h
@@ -86,6 +86,8 @@ public:
   void cacheThumbnails(int size);
   void releaseThumbnails(int size);
 
+  void addComputerFiles();
+
 Q_SIGNALS:
   void thumbnailLoaded(const QModelIndex& index, int size);
 
@@ -108,6 +110,7 @@ protected:
 
 private:
   FmFolder* folder_;
+  FmFolder* computerFolder_; // the items added for drives on the desktop
   // FIXME: should we use a hash table here so item lookup becomes much faster?
   QList<FolderModelItem> items;
 


### PR DESCRIPTION
We just append the files manually through an extra function in
FolderModel that's called from desktopwindow.cpp

Signed-off-by: Chris Moore <chris@mooreonline.org>

@probonopd please give this a go...