### PR TITLE
Add 'computer://' items before folder items in model

### DIFF
--- a/filer/desktopwindow.cpp
+++ b/filer/desktopwindow.cpp
@@ -90,8 +90,7 @@ DesktopWindow::DesktopWindow(int screenNum):
         loadItemPositions();
         Settings& settings = static_cast<Application* >(qApp)->settings();
 
-        model_ = Fm::CachedFolderModel::modelFromPath(fm_path_get_desktop());
-        model_->addComputerFiles();
+        model_ = Fm::CachedFolderModel::modelFromPath(fm_path_get_desktop(), true);
         folder_ = reinterpret_cast<FmFolder*>(g_object_ref(model_->folder()));
 
         proxyModel_ = new Fm::ProxyFolderModel();
@@ -201,7 +200,7 @@ void DesktopWindow::resizeEvent(QResizeEvent* event) {
 
 void DesktopWindow::setDesktopFolder() {
     FmPath *path = fm_path_new_for_path(XdgDir::readDesktopDir().toStdString().c_str());
-    model_ = Fm::CachedFolderModel::modelFromPath(path);
+    model_ = Fm::CachedFolderModel::modelFromPath(path, true);
     proxyModel_->setSourceModel(model_);
 }
 

--- a/libfm-qt/cachedfoldermodel.cpp
+++ b/libfm-qt/cachedfoldermodel.cpp
@@ -25,17 +25,19 @@ using namespace Fm;
 static GQuark data_id = 0;
 
 
-CachedFolderModel::CachedFolderModel(FmFolder* folder):
+CachedFolderModel::CachedFolderModel(FmFolder* folder, bool addComputerFiles):
   FolderModel(),
   refCount(1) {
 
+  if (addComputerFiles)
+    FolderModel::addComputerFiles();
   FolderModel::setFolder(folder);
 }
 
 CachedFolderModel::~CachedFolderModel() {
 }
 
-CachedFolderModel* CachedFolderModel::modelFromFolder(FmFolder* folder) {
+CachedFolderModel* CachedFolderModel::modelFromFolder(FmFolder* folder, bool addComputerFiles) {
   CachedFolderModel* model = NULL;
   if(!data_id)
     data_id = g_quark_from_static_string("CachedFolderModel");
@@ -46,16 +48,16 @@ CachedFolderModel* CachedFolderModel::modelFromFolder(FmFolder* folder) {
     model->ref();
   }
   else {
-    model = new CachedFolderModel(folder);
+    model = new CachedFolderModel(folder, addComputerFiles);
     g_object_set_qdata(G_OBJECT(folder), data_id, model);
   }
   return model;
 }
 
-CachedFolderModel* CachedFolderModel::modelFromPath(FmPath* path) {
+CachedFolderModel* CachedFolderModel::modelFromPath(FmPath* path, bool addComputerFiles) {
   FmFolder* folder = fm_folder_from_path(path);
   if(folder) {
-    CachedFolderModel* model = modelFromFolder(folder);
+    CachedFolderModel* model = modelFromFolder(folder, addComputerFiles);
     g_object_unref(folder);
     return model;
   }

--- a/libfm-qt/cachedfoldermodel.h
+++ b/libfm-qt/cachedfoldermodel.h
@@ -29,14 +29,14 @@ namespace Fm {
 class LIBFM_QT_API CachedFolderModel : public FolderModel {
   Q_OBJECT
 public:
-  CachedFolderModel(FmFolder* folder);
+  CachedFolderModel(FmFolder* folder, bool addComputerFiles = false);
   void ref() {
     ++refCount;
   }
   void unref();
 
-  static CachedFolderModel* modelFromFolder(FmFolder* folder);
-  static CachedFolderModel* modelFromPath(FmPath* path);
+  static CachedFolderModel* modelFromFolder(FmFolder* folder, bool addComputerFiles = false);
+  static CachedFolderModel* modelFromPath(FmPath* path, bool addComputerFiles = false);
 
 private:
   virtual ~CachedFolderModel();


### PR DESCRIPTION
Reorder to add the computer items before the folder items in the model.

Note that filer will store the previous positions of icons, so to test this is working I had to `rm -rf ~/.config/filer-qt` before running.

Signed-off-by: Chris Moore <chris@mooreonline.org>

https://github.com/helloSystem/Filer/issues/60

@probonopd  please review