### PR TITLE
desktopwindow: sort devices first

### DIFF
--- a/filer/desktopwindow.cpp
+++ b/filer/desktopwindow.cpp
@@ -97,7 +97,14 @@ DesktopWindow::DesktopWindow(int screenNum):
         proxyModel_ = new Fm::ProxyFolderModel();
         proxyModel_->setSourceModel(model_);
         proxyModel_->setShowThumbnails(settings.showThumbnails());
-        proxyModel_->sort(Fm::FolderModel::ColumnFileMTime);
+
+        // the following two lines make the devices show first - disable folder first option
+        // or mountpoints are shown last, and then order by owner because the owner for the
+        // file system shows up as a numeric value :) so we have those first followed by the
+        // users name as the owner for all the other items
+        proxyModel_->setFolderFirst(false);
+        proxyModel_->sort(Fm::FolderModel::ColumnFileOwner);
+
         setModel(proxyModel_);
 
         connect(proxyModel_, &Fm::ProxyFolderModel::rowsInserted, this, &DesktopWindow::onRowsInserted);


### PR DESCRIPTION
It's not the nicest way, but it works and I couldn't find another way of sorting within the model. Essentially we stop the 'folder first' option for the desktop, as otherwise the 'mountpoint' devices are shown last after all the folders. Then we sort by owner, because devices happen to have a numeric value for the owner and the rest have the user's name. So they appear first...

Signed-off-by: Chris Moore <chris@mooreonline.org>

https://github.com/helloSystem/Filer/issues/60

@probonopd  please review