### PR TITLE
desktopwindow: keep a separate model for desktop folder

### DIFF
--- a/filer/desktopwindow.h
+++ b/filer/desktopwindow.h
@@ -29,7 +29,7 @@
 #include <xcb/xcb.h>
 
 namespace Fm {
-  class CachedFolderModel;
+  class FolderModel;
   class ProxyFolderModel;
   class FolderViewListView;
 }
@@ -115,7 +115,7 @@ protected Q_SLOTS:
 
 private:
   Fm::ProxyFolderModel* proxyModel_;
-  Fm::CachedFolderModel* model_;
+  Fm::FolderModel* model_;
   FmFolder* folder_;
   Fm::FolderViewListView* listView_;
 

--- a/libfm-qt/foldermodel.h
+++ b/libfm-qt/foldermodel.h
@@ -58,7 +58,7 @@ public:
   FmFolder* folder() {
     return folder_;
   }
-  void setFolder(FmFolder* new_folder);
+  void setFolder(FmFolder* new_folder, bool add_devices = false);
 
   FmPath* path() {
     return folder_ ? fm_folder_get_path(folder_) : NULL;
@@ -85,8 +85,6 @@ public:
 
   void cacheThumbnails(int size);
   void releaseThumbnails(int size);
-
-  void addComputerFiles();
 
 Q_SIGNALS:
   void thumbnailLoaded(const QModelIndex& index, int size);


### PR DESCRIPTION
Avoid adding devices to the cached model by using a separate
FolderModel in desktopwindow. This also allowed some tidying
up of FolderModel - the 'add devices' switch is now an optional
argument of FolderModel::setFolder()

Signed-off-by: Chris Moore <chris@mooreonline.org>

https://github.com/helloSystem/Filer/issues/67

@probonopd  please review