### PR TITLE
foldermodel: fix missing devices on refresh of desktop

### DIFF
--- a/libfm-qt/foldermodel.h
+++ b/libfm-qt/foldermodel.h
@@ -58,6 +58,11 @@ public:
   FmFolder* folder() {
     return folder_;
   }
+
+  FmFolder* computerFolder() {
+    return computerFolder_;
+  }
+
   void setFolder(FmFolder* new_folder, bool add_devices = false);
 
   FmPath* path() {


### PR DESCRIPTION
Refreshing the desktop folder from another view caused all
items to be removed in onStartLoading(), so in this specific
case we need to handle adding the devices back again in
onFilesAdded().

Signed-off-by: Chris Moore <chris@mooreonline.org>

@probonopd - I have tested this for a while and I'm pretty sure the problem is solved now.