### PR TITLE
desktopwindow: sort devices separate to other files

### DIFF
--- a/filer/desktopwindow.cpp
+++ b/filer/desktopwindow.cpp
@@ -98,14 +98,8 @@ DesktopWindow::DesktopWindow(int screenNum):
         proxyModel_ = new Fm::ProxyFolderModel();
         proxyModel_->setSourceModel(model_);
         proxyModel_->setShowThumbnails(settings.showThumbnails());
-
-        // the following two lines make the devices show first - disable folder first option
-        // or mountpoints are shown last, and then order by owner because the owner for the
-        // file system shows up as a numeric value :) so we have those first followed by the
-        // users name as the owner for all the other items
-        proxyModel_->setFolderFirst(false);
-        proxyModel_->sort(Fm::FolderModel::ColumnFileOwner);
-
+        proxyModel_->sort(Fm::FolderModel::ColumnFileMTime);
+        proxyModel_->setDesktopMode();
         setModel(proxyModel_);
 
         connect(proxyModel_, &Fm::ProxyFolderModel::rowsInserted, this, &DesktopWindow::onRowsInserted);

--- a/libfm-qt/proxyfoldermodel.h
+++ b/libfm-qt/proxyfoldermodel.h
@@ -83,6 +83,8 @@ public:
   void removeFilter(ProxyFolderModelFilter* filter);
   void updateFilters();
 
+  void setDesktopMode();
+
 Q_SIGNALS:
   void sortFilterChanged();
 
@@ -102,6 +104,8 @@ private:
   bool showThumbnails_;
   int thumbnailSize_;
   QList<ProxyFolderModelFilter*> filters_;
+  QString userName_;
+  bool desktopMode_;
 };
 
 }


### PR DESCRIPTION
Add a 'desktopmode' switch to ProxyFolderModel which then causes
the devices to be sorted separately by modification time before
any files/folders in the model.

Signed-off-by: Chris Moore <chris@mooreonline.org>

@probonopd this fixes sorting options for files/folders on the desktop now