### PR TITLE
Store view mode and ordering of a folder in the metadata

### DIFF
--- a/filer/mainwindow.h
+++ b/filer/mainwindow.h
@@ -160,6 +160,7 @@ private:
   void updateUIForCurrentPage();
   void updateViewMenuForCurrentPage();
   void updateStatusBarForCurrentPage();
+  bool isSpatialMode() const;
 
 private:
   Ui::MainWindow ui;

--- a/filer/metadata.cpp
+++ b/filer/metadata.cpp
@@ -46,6 +46,12 @@ static const QString WINDOW_ORIGIN_X            = "WindowX";
 static const QString WINDOW_ORIGIN_Y            = "WindowY";
 static const QString WINDOW_HEIGHT              = "WindowHeight";
 static const QString WINDOW_WIDTH               = "WindowWidth";
+static const QString WINDOW_VIEW                = "WindowView";
+static const QString WINDOW_SORT_ITEM           = "WindowSortItem";
+static const QString WINDOW_SORT_ORDER          = "WindowSortOrder";
+static const QString WINDOW_SORT_CASE           = "WindowSortCase";
+static const QString WINDOW_SORT_FOLDER_FIRST   = "WindowSortFolderFirst";
+static const QString WINDOW_FILTER              = "WindowFilter";
 static const QString XATTR_NAMESPACE            = "user";
 
 /*
@@ -157,6 +163,66 @@ int MetaData::getWindowWidth(bool& ok) const
   return val;
 }
 
+MetaData::FolderView MetaData::getWindowView(bool& ok) const
+{
+  int val = getMetadataInt(path_, WINDOW_VIEW, ok);
+  if (!ok) {
+    ok = windowAttributes_.contains(WINDOW_VIEW);
+    val = windowAttributes_[WINDOW_VIEW].toInt();
+  }
+  return static_cast<MetaData::FolderView>(val);
+}
+
+MetaData::SortItem MetaData::getWindowSortItem(bool& ok) const
+{
+  int val = getMetadataInt(path_, WINDOW_SORT_ITEM, ok);
+  if (!ok) {
+    ok = windowAttributes_.contains(WINDOW_SORT_ITEM);
+    val = windowAttributes_[WINDOW_SORT_ITEM].toInt();
+  }
+  return static_cast<MetaData::SortItem>(val);
+}
+
+MetaData::SortOrder MetaData::getWindowSortOrder(bool& ok) const
+{
+  int val = getMetadataInt(path_, WINDOW_SORT_ORDER, ok);
+  if (!ok) {
+    ok = windowAttributes_.contains(WINDOW_SORT_ORDER);
+    val = windowAttributes_[WINDOW_SORT_ORDER].toInt();
+  }
+  return static_cast<MetaData::SortOrder>(val);
+}
+
+MetaData::SortCase MetaData::getWindowSortCase(bool& ok) const
+{
+  int val = getMetadataInt(path_, WINDOW_SORT_CASE, ok);
+  if (!ok) {
+    ok = windowAttributes_.contains(WINDOW_SORT_CASE);
+    val = windowAttributes_[WINDOW_SORT_CASE].toInt();
+  }
+  return static_cast<MetaData::SortCase>(val);
+}
+
+MetaData::SortFolderFirst MetaData::getWindowSortFolderFirst(bool& ok) const
+{
+  int val = getMetadataInt(path_, WINDOW_SORT_FOLDER_FIRST, ok);
+  if (!ok) {
+    ok = windowAttributes_.contains(WINDOW_SORT_FOLDER_FIRST);
+    val = windowAttributes_[WINDOW_SORT_FOLDER_FIRST].toInt();
+  }
+  return static_cast<MetaData::SortFolderFirst>(val);
+}
+
+MetaData::Filter MetaData::getWindowFilter(bool &ok) const
+{
+  int val = getMetadataInt(path_, WINDOW_FILTER, ok);
+  if (!ok) {
+    ok = windowAttributes_.contains(WINDOW_FILTER);
+    val = windowAttributes_[WINDOW_FILTER].toInt();
+  }
+  return static_cast<MetaData::Filter>(val);
+}
+
 void MetaData::setWindowOriginX(int x)
 {
   setMetadataInt(path_, WINDOW_ORIGIN_X, x);
@@ -179,6 +245,42 @@ void MetaData::setWindowWidth(int width)
 {
   setMetadataInt(path_, WINDOW_WIDTH, width);
   windowAttributes_[WINDOW_WIDTH] = width;
+}
+
+void MetaData::setWindowView(MetaData::FolderView view)
+{
+  setMetadataInt(path_, WINDOW_VIEW, static_cast<int>(view));
+  windowAttributes_[WINDOW_VIEW] = view;
+}
+
+void MetaData::setWindowSortItem(MetaData::SortItem sortItem)
+{
+  setMetadataInt(path_, WINDOW_SORT_ITEM, static_cast<int>(sortItem));
+  windowAttributes_[WINDOW_SORT_ITEM] = sortItem;
+}
+
+void MetaData::setWindowSortOrder(MetaData::SortOrder sortOrder)
+{
+  setMetadataInt(path_, WINDOW_SORT_ORDER, static_cast<int>(sortOrder));
+  windowAttributes_[WINDOW_SORT_ORDER] = sortOrder;
+}
+
+void MetaData::setWindowSortCase(MetaData::SortCase sortCase)
+{
+  setMetadataInt(path_, WINDOW_SORT_CASE, static_cast<int>(sortCase));
+  windowAttributes_[WINDOW_SORT_CASE] = sortCase;
+}
+
+void MetaData::setWindowSortFolderFirst(MetaData::SortFolderFirst sortFolderFirst)
+{
+  setMetadataInt(path_, WINDOW_SORT_FOLDER_FIRST, static_cast<int>(sortFolderFirst));
+  windowAttributes_[WINDOW_SORT_FOLDER_FIRST] = sortFolderFirst;
+}
+
+void MetaData::setWindowFilter(MetaData::Filter filter)
+{
+  setMetadataInt(path_, WINDOW_FILTER, static_cast<int>(filter));
+  windowAttributes_[WINDOW_FILTER] = filter;
 }
 
 int MetaData::getMetadataInt(const QString& path, const QString& attribute, bool &ok) const
@@ -242,6 +344,24 @@ void MetaData::loadDirInfo()
 
     if (windowJson.contains(WINDOW_WIDTH) && windowJson[WINDOW_WIDTH].isDouble())
       windowAttributes_.insert(WINDOW_WIDTH, windowJson[WINDOW_WIDTH].toInt());
+
+    if (windowJson.contains(WINDOW_VIEW) && windowJson[WINDOW_VIEW].isDouble())
+      windowAttributes_.insert(WINDOW_VIEW, windowJson[WINDOW_VIEW].toInt());
+
+    if (windowJson.contains(WINDOW_SORT_ITEM) && windowJson[WINDOW_SORT_ITEM].isDouble())
+      windowAttributes_.insert(WINDOW_SORT_ITEM, windowJson[WINDOW_SORT_ITEM].toInt());
+
+    if (windowJson.contains(WINDOW_SORT_ORDER) && windowJson[WINDOW_SORT_ORDER].isDouble())
+      windowAttributes_.insert(WINDOW_SORT_ORDER, windowJson[WINDOW_SORT_ORDER].toInt());
+
+    if (windowJson.contains(WINDOW_SORT_CASE) && windowJson[WINDOW_SORT_CASE].isDouble())
+      windowAttributes_.insert(WINDOW_SORT_CASE, windowJson[WINDOW_SORT_CASE].toInt());
+
+    if (windowJson.contains(WINDOW_SORT_FOLDER_FIRST) && windowJson[WINDOW_SORT_FOLDER_FIRST].isDouble())
+      windowAttributes_.insert(WINDOW_SORT_FOLDER_FIRST, windowJson[WINDOW_SORT_FOLDER_FIRST].toInt());
+
+    if (windowJson.contains(WINDOW_FILTER) && windowJson[WINDOW_FILTER].isDouble())
+      windowAttributes_.insert(WINDOW_FILTER, windowJson[WINDOW_FILTER].toInt());
   }
 }
 
@@ -285,6 +405,24 @@ void MetaData::saveDirInfo()
 
   if (windowAttributes_.contains(WINDOW_WIDTH))
     windowJson[WINDOW_WIDTH] = windowAttributes_[WINDOW_WIDTH].toInt();
+
+  if (windowAttributes_.contains(WINDOW_VIEW))
+    windowJson[WINDOW_VIEW] = windowAttributes_[WINDOW_VIEW].toInt();
+
+  if (windowAttributes_.contains(WINDOW_SORT_ITEM))
+    windowJson[WINDOW_SORT_ITEM] = windowAttributes_[WINDOW_SORT_ITEM].toInt();
+
+  if (windowAttributes_.contains(WINDOW_SORT_ORDER))
+    windowJson[WINDOW_SORT_ORDER] = windowAttributes_[WINDOW_SORT_ORDER].toInt();
+
+  if (windowAttributes_.contains(WINDOW_SORT_CASE))
+    windowJson[WINDOW_SORT_CASE] = windowAttributes_[WINDOW_SORT_CASE].toInt();
+
+  if (windowAttributes_.contains(WINDOW_SORT_FOLDER_FIRST))
+    windowJson[WINDOW_SORT_FOLDER_FIRST] = windowAttributes_[WINDOW_SORT_FOLDER_FIRST].toInt();
+
+  if (windowAttributes_.contains(WINDOW_FILTER))
+    windowJson[WINDOW_FILTER] = windowAttributes_[WINDOW_FILTER].toInt();
 
   json["Window"] = windowJson;
   QJsonDocument dirInfoDoc(json);

--- a/filer/metadata.h
+++ b/filer/metadata.h
@@ -26,6 +26,43 @@ class MetaData : public QObject {
   Q_OBJECT
 
 public:
+
+  enum FolderView {
+    Icons = 1,
+    Compact = 2,
+    List = 3,
+    Thumbnail = 4,
+    Columns = 5
+  };
+
+  enum SortItem {
+    FileName = 1,
+    FileType = 2,
+    FileSize = 3,
+    ModifiedTime = 4,
+    Owner = 5
+  };
+
+  enum SortOrder {
+    Ascending = 1,
+    Descending = 2
+  };
+
+  enum SortCase {
+    CaseSensitive = 1,
+    NotCaseSensitive = 2
+  };
+
+  enum SortFolderFirst {
+    FoldersFirst = 1,
+    NotFoldersFirst = 2
+  };
+
+  enum Filter {
+    FilterActive = 1,
+    FilterInactive = 2
+  };
+
   explicit MetaData(const QString& path);
   virtual ~MetaData();
 
@@ -34,10 +71,24 @@ public:
   int getWindowHeight(bool& ok) const;
   int getWindowWidth(bool& ok) const;
 
+  FolderView getWindowView(bool& ok) const;
+  SortItem getWindowSortItem(bool& ok) const;
+  SortOrder getWindowSortOrder(bool& ok) const;
+  SortCase getWindowSortCase(bool& ok) const;
+  SortFolderFirst getWindowSortFolderFirst(bool& ok) const;
+  Filter getWindowFilter(bool& ok) const;
+
   void setWindowOriginX(int x);
   void setWindowOriginY(int y);
   void setWindowHeight(int height);
   void setWindowWidth(int width);
+
+  void setWindowView(FolderView view);
+  void setWindowSortItem(SortItem sortItem);
+  void setWindowSortOrder(SortOrder sortOrder);
+  void setWindowSortCase(SortCase sortCase);
+  void setWindowSortFolderFirst(SortFolderFirst sortFolderFirst);
+  void setWindowFilter(Filter filter);
 
 private:
   int getMetadataInt(const QString& path, const QString& attribute, bool& ok) const;


### PR DESCRIPTION
We now store the folder view mode, sort column, sort order
and folders first option in the metadata for that folder.
We retrieve and apply the metadata on opening the folder
window again.

Filter enabled/disabled is not yet stored due to complications
with the global settings of this option being affected leading
to undesired behaviour at the moment (e.g. if you set the filter
on for one window and off for another, all following windows that
haven't had the metadata saved with continue with the last option
set by the metadata).

I'm not sure the 'case sensitive' option seems to do anything, but
we do store/set this one too...

Signed-off-by: Chris Moore <chris@mooreonline.org>

@probonopd please review