### PR TITLE
desktopwindow: fix crash on stylesheet loading

### DIFF
--- a/filer/desktopwindow.cpp
+++ b/filer/desktopwindow.cpp
@@ -757,7 +757,7 @@ bool DesktopWindow::eventFilter(QObject * watched, QEvent * event) {
             break;
         }
     }
-    else if(watched == listView_->viewport()) {
+    else if(listView_ && (watched == listView_->viewport())) {
         switch(event->type()) {
         case QEvent::MouseButtonPress:
         case QEvent::MouseButtonRelease:


### PR DESCRIPTION
This caused the eventFilter() function to be called as part of
the application of the stylesheet, and listView_ was a NULL
pointer, hence the segfault. Fixed by checking the pointer
before dereferencing.

Signed-off-by: Chris Moore <chris@mooreonline.org>

https://github.com/helloSystem/QtPlugin/issues/2

@probonopd please review