### PR TITLE
desktopwindow: switch to updating stylesheet for background

### DIFF
--- a/filer/desktopitemdelegate.h
+++ b/filer/desktopitemdelegate.h
@@ -46,10 +46,23 @@ public:
     return shadowColor_;
   }
 
+  void setTextColor(const QColor& textColor) {
+    textColor_ = textColor;
+  }
+  const QColor& textColor() const {
+    return textColor_;
+  }
+
+  void setFont(const QFont& font) {
+    font_ = font;
+  }
+
 private:
   QListView* view_;
   QIcon symlinkIcon_;
   QColor shadowColor_;
+  QColor textColor_;
+  QFont font_;
 };
 
 }

--- a/filer/desktopwindow.h
+++ b/filer/desktopwindow.h
@@ -124,7 +124,6 @@ private:
   QColor shadowColor_;
   QString wallpaperFile_;
   WallpaperMode wallpaperMode_;
-  QPixmap wallpaperPixmap_;
   DesktopItemDelegate* delegate_;
   Launcher fileLauncher_;
   bool showWmMenu_;


### PR DESCRIPTION
Instead of using setPalette() to set the background colour or image
use setStyleSheet() to update. Looks like it is mostly working, but
I can't find an equivalent to 'fit' the image rather than stretch.

Signed-off-by: Chris Moore <chris@mooreonline.org>

@probonopd please can you have a look at this and see what you think?

The problem is that setPalette() doesn't work if there's a stylesheet, so this commit uses updates to the stylesheet to set the wallpaper instead.

https://github.com/helloSystem/Filer/pull/76
https://github.com/helloSystem/QtPlugin/issues/2