### PR TITLE
desktopwindow: retrieve menubar from MainWindow UI

### DIFF
--- a/filer/CMakeLists.txt
+++ b/filer/CMakeLists.txt
@@ -28,6 +28,7 @@ set(filer_SRCS
     preferencesdialog.cpp
     xdgdir.cpp
     desktoppreferencesdialog.cpp
+    desktopmainwindow.cpp
     desktopwindow.cpp
     desktopitemdelegate.cpp
     autorundialog.cpp

--- a/filer/desktopmainwindow.cpp
+++ b/filer/desktopmainwindow.cpp
@@ -1,0 +1,316 @@
+/*
+
+    Copyright (C) 2021 Chris Moore <chris@mooreonline.org>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include <QDebug>
+
+#include "desktopmainwindow.h"
+#include "bookmarkaction.h"
+#include "application.h"
+#include "gotofolderwindow.h"
+
+using namespace Filer;
+
+DesktopMainWindow::DesktopMainWindow(QWidget *parent) : QMainWindow(parent)
+{
+  ui.setupUi(this);
+
+  // Delete the actions that are not applicable to the desktop - they will
+  // be removed from the menubar
+  delete ui.actionNewWin;
+  delete ui.actionCloseTab;
+  delete ui.actionCloseWindow;
+  delete ui.actionIconView;
+  delete ui.actionCompactView;
+  delete ui.actionDetailedList;
+  delete ui.actionThumbnailView;
+  delete ui.actionFilter;
+  delete ui.actionGoBack;
+  delete ui.actionGoForward;
+  delete ui.actionGo;
+  delete ui.actionOpenAsRoot;
+
+  // load bookmark menu
+  bookmarks = fm_bookmarks_dup();
+  g_signal_connect(bookmarks, "changed", G_CALLBACK(onBookmarksChanged), this);
+  loadBookmarksMenu();
+}
+
+QMenuBar *DesktopMainWindow::getMenuBar() const
+{
+  return ui.menubar;
+}
+
+void DesktopMainWindow::setShowHidden(bool hidden)
+{
+  ui.actionShowHidden->setChecked(hidden);
+}
+
+void DesktopMainWindow::setSortColumn(int column)
+{
+  ui.actionByFileName->setChecked(column == 0);
+  ui.actionByFileType->setChecked(column == 1);
+  ui.actionByFileSize->setChecked(column == 2);
+  ui.actionByMTime->setChecked(column == 3);
+  ui.actionByOwner->setChecked(column == 4);
+}
+
+void DesktopMainWindow::setSortOrder(Qt::SortOrder order)
+{
+  ui.actionAscending->setChecked(order == Qt::AscendingOrder);
+  ui.actionDescending->setChecked(order == Qt::DescendingOrder);
+}
+
+void DesktopMainWindow::setFolderFirst(bool first)
+{
+  ui.actionFolderFirst->setChecked(first);
+}
+
+void DesktopMainWindow::setCaseSensitive(Qt::CaseSensitivity sensitivity)
+{
+  ui.actionCaseSensitive->setChecked(sensitivity == Qt::CaseSensitive);
+}
+
+void DesktopMainWindow::on_actionNewFolder_triggered()
+{
+  Q_EMIT newFolder();
+}
+
+void DesktopMainWindow::on_actionNewBlankFile_triggered()
+{
+  Q_EMIT newBlankFile();
+}
+
+void DesktopMainWindow::on_actionFileProperties_triggered()
+{
+  Q_EMIT fileProperties();
+}
+
+void DesktopMainWindow::on_actionCut_triggered()
+{
+  Q_EMIT cut();
+}
+
+void DesktopMainWindow::on_actionCopy_triggered()
+{
+  Q_EMIT copy();
+}
+
+void DesktopMainWindow::on_actionPaste_triggered()
+{
+  Q_EMIT paste();
+}
+
+void DesktopMainWindow::on_actionDelete_triggered()
+{
+  Q_EMIT del();
+}
+
+void DesktopMainWindow::on_actionRename_triggered()
+{
+  Q_EMIT rename();
+}
+
+void DesktopMainWindow::on_actionSelectAll_triggered()
+{
+  Q_EMIT selectAll();
+}
+
+void DesktopMainWindow::on_actionInvertSelection_triggered()
+{
+  Q_EMIT invert();
+}
+
+void DesktopMainWindow::on_actionPreferences_triggered()
+{
+  Q_EMIT preferences();
+}
+
+void DesktopMainWindow::on_actionGoUp_triggered()
+{
+  Q_EMIT goUp();
+}
+
+void DesktopMainWindow::on_actionHome_triggered()
+{
+  Q_EMIT openHome();
+}
+
+void DesktopMainWindow::on_actionReload_triggered()
+{
+  Q_EMIT reload();
+}
+
+void DesktopMainWindow::on_actionGoToFolder_triggered()
+{
+  GotoFolderDialog* gotoFolderDialog = new GotoFolderDialog(this);
+  int code = gotoFolderDialog->exec();
+  if (code == QDialog::Accepted) {
+    Q_EMIT openFolder(gotoFolderDialog->getPath());
+  }
+}
+
+void DesktopMainWindow::on_actionShowHidden_triggered(bool check)
+{
+  Q_EMIT showHidden(check);
+}
+
+void DesktopMainWindow::on_actionByFileName_triggered(bool checked)
+{
+  Q_EMIT sortColumn(0);
+}
+
+void DesktopMainWindow::on_actionByMTime_triggered(bool checked)
+{
+  Q_EMIT sortColumn(3);
+}
+
+void DesktopMainWindow::on_actionByOwner_triggered(bool checked)
+{
+  Q_EMIT sortColumn(4);
+}
+
+void DesktopMainWindow::on_actionByFileType_triggered(bool checked)
+{
+  Q_EMIT sortColumn(1);
+}
+
+void DesktopMainWindow::on_actionByFileSize_triggered(bool checked)
+{
+  Q_EMIT sortColumn(2);
+}
+
+void DesktopMainWindow::on_actionAscending_triggered(bool checked)
+{
+  Q_EMIT sortOrder(Qt::AscendingOrder);
+}
+
+void DesktopMainWindow::on_actionDescending_triggered(bool checked)
+{
+  Q_EMIT sortOrder(Qt::DescendingOrder);
+}
+
+void DesktopMainWindow::on_actionFolderFirst_triggered(bool checked)
+{
+  Q_EMIT folderFirst(checked);
+}
+
+void DesktopMainWindow::on_actionCaseSensitive_triggered(bool checked)
+{
+  Q_EMIT caseSensitive(checked ? Qt::CaseSensitive : Qt::CaseInsensitive);
+}
+
+void DesktopMainWindow::on_actionApplications_triggered()
+{
+  Q_EMIT openFolder(QString("file:///Applications"));
+}
+
+void DesktopMainWindow::on_actionUtilities_triggered()
+{
+  Q_EMIT openFolder(QString("file:///Applications/Utilities"));
+}
+
+void DesktopMainWindow::on_actionDocuments_triggered()
+{
+  Q_EMIT openDocuments();
+}
+
+void DesktopMainWindow::on_actionDownloads_triggered()
+{
+  Q_EMIT openDownloads();
+}
+
+void DesktopMainWindow::on_actionComputer_triggered()
+{
+  Q_EMIT openFolder(QString("computer:///"));
+}
+
+void DesktopMainWindow::on_actionTrash_triggered()
+{
+  Q_EMIT openTrash();
+}
+
+void DesktopMainWindow::on_actionNetwork_triggered()
+{
+  Q_EMIT openFolder(QString("network:///"));
+}
+
+void DesktopMainWindow::on_actionDesktop_triggered()
+{
+  Q_EMIT openDesktop();
+}
+
+void DesktopMainWindow::on_actionEditBookmarks_triggered()
+{
+  Q_EMIT editBookmarks();
+}
+
+void DesktopMainWindow::on_actionOpenTerminal_triggered()
+{
+  Q_EMIT openTerminal();
+}
+
+void DesktopMainWindow::on_actionFindFiles_triggered()
+{
+  Q_EMIT search();
+}
+
+void DesktopMainWindow::on_actionAbout_triggered()
+{
+  Q_EMIT about();
+}
+
+void DesktopMainWindow::onBookmarkActionTriggered()
+{
+  Fm::BookmarkAction* action = static_cast<Fm::BookmarkAction*>(sender());
+  FmPath* path = action->path();
+  if(path) {
+    qDebug() << "bookmark path: " << fm_path_to_str(path);
+    Q_EMIT openFolder(fm_path_to_str(path));
+  }
+}
+
+void DesktopMainWindow::onBookmarksChanged(FmBookmarks* bookmarks, DesktopMainWindow* pThis) {
+  // delete existing items
+  QList<QAction*> actions = pThis->ui.menu_Bookmarks->actions();
+  QList<QAction*>::const_iterator it = actions.begin();
+  QList<QAction*>::const_iterator last_it = actions.end() - 2;
+
+  while(it != last_it) {
+    QAction* action = *it;
+    ++it;
+    pThis->ui.menu_Bookmarks->removeAction(action);
+  }
+
+  pThis->loadBookmarksMenu();
+}
+
+void DesktopMainWindow::loadBookmarksMenu() {
+  GList* allBookmarks = fm_bookmarks_get_all(bookmarks);
+  QAction* before = ui.actionAddToBookmarks;
+
+  for(GList* l = allBookmarks; l; l = l->next) {
+    FmBookmarkItem* item = reinterpret_cast<FmBookmarkItem*>(l->data);
+    Fm::BookmarkAction* action = new Fm::BookmarkAction(item, ui.menu_Bookmarks);
+    connect(action, &QAction::triggered, this, &DesktopMainWindow::onBookmarkActionTriggered);
+    ui.menu_Bookmarks->insertAction(before, action);
+  }
+
+  ui.menu_Bookmarks->insertSeparator(before);
+  g_list_free_full(allBookmarks, (GDestroyNotify)fm_bookmark_item_unref);
+}

--- a/filer/desktopmainwindow.h
+++ b/filer/desktopmainwindow.h
@@ -1,0 +1,139 @@
+/*
+
+    Copyright (C) 2013  Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef DESKTOPMAINWINDOW_H
+#define DESKTOPMAINWINDOW_H
+
+#include "ui_main-win.h"
+#include <QMainWindow>
+
+namespace Filer {
+
+/*
+ * We need to re-use the menubar from the UI of MainWindow for the desktop, so
+ * this class sets up the same UI, removes actions from the menubar that are not
+ * applicable to the desktop and then emits signals for the ones that are.
+ * DesktopWindow then takes the actions for those signals.
+ */
+class DesktopMainWindow : public QMainWindow
+{
+  Q_OBJECT
+public:
+  explicit DesktopMainWindow(QWidget *parent = nullptr);
+
+  QMenuBar* getMenuBar() const;
+
+  void setShowHidden(bool hidden);
+  void setSortColumn(int column);
+  void setSortOrder(Qt::SortOrder order);
+  void setFolderFirst(bool first);
+  void setCaseSensitive(Qt::CaseSensitivity sensitivity);
+
+protected Q_SLOTS:
+  void on_actionNewFolder_triggered();
+  void on_actionNewBlankFile_triggered();
+  void on_actionFileProperties_triggered();
+
+  void on_actionCut_triggered();
+  void on_actionCopy_triggered();
+  void on_actionPaste_triggered();
+  void on_actionDelete_triggered();
+  void on_actionRename_triggered();
+  void on_actionSelectAll_triggered();
+  void on_actionInvertSelection_triggered();
+  void on_actionPreferences_triggered();
+
+  void on_actionGoUp_triggered();
+  void on_actionHome_triggered();
+  void on_actionReload_triggered();
+
+  void on_actionGoToFolder_triggered();
+
+  void on_actionShowHidden_triggered(bool check);
+
+  void on_actionByFileName_triggered(bool checked);
+  void on_actionByMTime_triggered(bool checked);
+  void on_actionByOwner_triggered(bool checked);
+  void on_actionByFileType_triggered(bool checked);
+  void on_actionByFileSize_triggered(bool checked);
+  void on_actionAscending_triggered(bool checked);
+  void on_actionDescending_triggered(bool checked);
+  void on_actionFolderFirst_triggered(bool checked);
+  void on_actionCaseSensitive_triggered(bool checked);
+
+  void on_actionApplications_triggered();
+  void on_actionUtilities_triggered();
+  void on_actionDocuments_triggered();
+  void on_actionDownloads_triggered();
+  void on_actionComputer_triggered();
+  void on_actionTrash_triggered();
+  void on_actionNetwork_triggered();
+  void on_actionDesktop_triggered();
+  void on_actionEditBookmarks_triggered();
+
+  void on_actionOpenTerminal_triggered();
+  void on_actionFindFiles_triggered();
+
+  void on_actionAbout_triggered();
+
+  void onBookmarkActionTriggered();
+
+Q_SIGNALS:
+  void newFolder();
+  void newBlankFile();
+  void fileProperties();
+  void preferences();
+  void openFolder(QString folder);
+  void openTrash();
+  void openDesktop();
+  void openDocuments();
+  void openDownloads();
+  void openHome();
+  void goUp();
+  void cut();
+  void copy();
+  void paste();
+  void rename();
+  void del();
+  void selectAll();
+  void invert();
+  void openTerminal();
+  void search();
+  void about();
+  void editBookmarks();
+  void showHidden(bool hidden);
+  void sortColumn(int column);
+  void sortOrder(Qt::SortOrder order);
+  void folderFirst(bool first);
+  void caseSensitive(Qt::CaseSensitivity sensitive);
+  void reload();
+
+private:
+  static void onBookmarksChanged(FmBookmarks* bookmarks, DesktopMainWindow* pThis);
+  void loadBookmarksMenu();
+
+private:
+    Ui::MainWindow ui;
+    FmBookmarks* bookmarks;
+};
+
+
+}
+
+#endif // DESKTOPMAINWINDOW_H

--- a/filer/desktopwindow.h
+++ b/filer/desktopwindow.h
@@ -28,6 +28,8 @@
 #include <QByteArray>
 #include <xcb/xcb.h>
 
+class QMenuBar;
+
 namespace Fm {
   class FolderModel;
   class ProxyFolderModel;
@@ -37,6 +39,7 @@ namespace Fm {
 namespace Filer {
 
 class DesktopItemDelegate;
+class DesktopMainWindow;
 class Settings;
 
 class DesktopWindow : public View {
@@ -92,8 +95,31 @@ protected:
   virtual void closeEvent(QCloseEvent *event);
 
 protected Q_SLOTS:
+  void onOpenFolder(QString folder);
+  void onOpenTrash();
+  void onOpenDesktop();
+  void onOpenDocuments();
+  void onOpenDownloads();
+  void onOpenHome();
   void onOpenDirRequested(FmPath* path, int target);
   void onDesktopPreferences();
+  void onFilerPreferences();
+  void onGoUp();
+  void onNewFolder();
+  void onNewBlankFile();
+  void onOpenTerminal();
+  void onFindFiles();
+  void onAbout();
+  void onEditBookmarks();
+
+  void onShowHidden(bool hidden);
+  void onSortColumn(int column);
+  void onSortOrder(Qt::SortOrder order);
+  void onFolderFirst(bool first);
+  void onCaseSensitive(Qt::CaseSensitivity sensitivity);
+  void onReload();
+
+  void updateMenu();
 
   void onRowsAboutToBeRemoved(const QModelIndex& parent, int start, int end);
   void onRowsInserted(const QModelIndex& parent, int start, int end);
@@ -131,6 +157,7 @@ private:
   int screenNum_;
   QHash<QByteArray, QPoint> customItemPos_;
   QTimer* relayoutTimer_;
+  DesktopMainWindow* desktopMainWindow_;
 };
 
 }

--- a/filer/mainwindow.cpp
+++ b/filer/mainwindow.cpp
@@ -1090,6 +1090,9 @@ void MainWindow::loadBookmarksMenu() {
 
 void MainWindow::onBookmarksChanged(FmBookmarks* bookmarks, MainWindow* pThis) {
   // delete existing items
+  if ( ! pThis->ui.menu_Bookmarks )
+    return;
+
   QList<QAction*> actions = pThis->ui.menu_Bookmarks->actions();
   QList<QAction*>::const_iterator it = actions.begin();
   QList<QAction*>::const_iterator last_it = actions.end() - 2;


### PR DESCRIPTION
We create a new QMainMenu class that takes the UI from MainWindow
and removes the non-relevant menu items for the desktop. All actions
are then implemented in DesktopWindow and is kept in sync with the
context menu (e.g. sort order, hidden etc.)

Signed-off-by: Chris Moore <chris@mooreonline.org>

https://github.com/helloSystem/Filer/issues/18

@probonopd  please review