### PR TITLE
mainwindow: un-minimize and restore maximized/normal state of window

### DIFF
--- a/filer/mainwindow.cpp
+++ b/filer/mainwindow.cpp
@@ -1225,6 +1225,12 @@ void MainWindow::onRaiseWindow(const QString& path)
       if (path == ourPath) {
         raise();
         activateWindow();
+        bool maximized = isMaximized();
+        if (isMinimized()) {
+          showNormal();
+          if (maximized) // window was maximized before being minimized - showNormal restores it
+            showMaximized();
+        }
         break;
       }
     }


### PR DESCRIPTION
When raising/activating, check if minimized and call showNormal() to restore
the non-minimized state. Also check if it was maximized before being minimized
in which case, restore the maximized state also.

Signed-off-by: Chris Moore <chris@mooreonline.org>

https://github.com/helloSystem/Filer/issues/79

@probonopd 