### PR TITLE
mainwindow: remove left margin of frame in spatial mode

### DIFF
--- a/filer/mainwindow.cpp
+++ b/filer/mainwindow.cpp
@@ -208,6 +208,7 @@ MainWindow::MainWindow(FmPath* path):
     ui.tabBar->hide();
     ui.sidePane->hide();
     ui.toolBar->hide();
+    ui.frame->layout()->setContentsMargins(0, 0, 0, 0);
 
     // Set the window position and size
     MetaData metaData(fm_path_to_str(path));
@@ -1266,6 +1267,7 @@ void MainWindow::updateFromSettings(Settings& settings) {
   ui.tabBar->setVisible( ! settings.spatialMode() );
   ui.sidePane->setVisible( ! settings.spatialMode() );
   ui.toolBar->setVisible( ! settings.spatialMode() );
+  ui.frame->layout()->setContentsMargins(settings.spatialMode() ? 0 : 1, 0, 0, 0);
 }
 
 static const char* su_cmd_subst(char opt, gpointer user_data) {


### PR DESCRIPTION
There's a default left margin in the frame (which holds the stacked
widget and filter bar) of 1px. In spatial mode we need to remove this and
re-instate it if the user switches back to browser mode.

Signed-off-by: Chris Moore <chris@mooreonline.org>

https://github.com/helloSystem/Filer/issues/82

@probonopd 