### PR TITLE
Add the missing libfm-qt files

### DIFF
--- a/libfm-qt/core/archiver.cpp
+++ b/libfm-qt/core/archiver.cpp
@@ -1,0 +1,173 @@
+#include "libfmqtglobals.h"
+#include "archiver.h"
+
+#include <cstring>
+#include <glib.h>
+#include <gio/gdesktopappinfo.h>
+
+#include <string>
+
+namespace Fm {
+
+Archiver* Archiver::defaultArchiver_ = nullptr;  // static
+std::vector<std::unique_ptr<Archiver>> Archiver::allArchivers_;  // static
+
+Archiver::Archiver() {
+}
+
+bool Archiver::isMimeTypeSupported(const char* type) {
+    char** p;
+    if(G_UNLIKELY(!type)) {
+        return false;
+    }
+    for(p = mimeTypes_.get(); *p; ++p) {
+        if(strcmp(*p, type) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool Archiver::launchProgram(GAppLaunchContext* ctx, const char* cmd, const FilePathList& files, const FilePath& dir) {
+    char* _cmd = nullptr;
+    const char* dir_place_holder;
+    GKeyFile* dummy;
+
+    if(dir.isValid() && (dir_place_holder = strstr(cmd, "%d"))) {
+        CStrPtr dir_str;
+        int len;
+        if(strstr(cmd, "%U") || strstr(cmd, "%u")) { /* supports URI */
+            dir_str = dir.uri();
+        }
+        else {
+            dir_str = dir.localPath();
+        }
+
+        // FIXME: remove libfm dependency here
+        /* replace all % with %% so encoded URI can be handled correctly when parsing Exec key. */
+        std::string percentEscapedDir;
+        for(auto p = dir_str.get(); *p; ++p) {
+            percentEscapedDir += *p;
+            if(*p == '%') {
+                percentEscapedDir += '%';
+            }
+        }
+
+        /* quote the path or URI */
+        dir_str = CStrPtr{g_shell_quote(percentEscapedDir.c_str())};
+
+        len = strlen(cmd) - 2 + strlen(dir_str.get()) + 1;
+        _cmd = (char*)g_malloc(len);
+        len = (dir_place_holder - cmd);
+        strncpy(_cmd, cmd, len);
+        strcpy(_cmd + len, dir_str.get());
+        strcat(_cmd, dir_place_holder + 2);
+        cmd = _cmd;
+    }
+
+    /* create a fake key file to cheat GDesktopAppInfo */
+    dummy = g_key_file_new();
+    g_key_file_set_string(dummy, G_KEY_FILE_DESKTOP_GROUP, "Type", "Application");
+    g_key_file_set_string(dummy, G_KEY_FILE_DESKTOP_GROUP, "Name", program_.get());
+
+    /* replace all % with %% so encoded URI can be handled correctly when parsing Exec key. */
+    g_key_file_set_string(dummy, G_KEY_FILE_DESKTOP_GROUP, "Exec", cmd);
+    GAppInfoPtr app{reinterpret_cast<GAppInfo*>(g_desktop_app_info_new_from_keyfile(dummy)), false};
+
+    g_key_file_free(dummy);
+    g_debug("cmd = %s", cmd);
+    if(app) {
+        GList* uris = nullptr;
+        for(auto& file: files) {
+            uris = g_list_prepend(uris, g_strdup(file.uri().get()));
+        }
+        g_app_info_launch_uris(app.get(), uris, ctx, nullptr);
+        g_list_free_full(uris, g_free);
+    }
+    g_free(_cmd);
+    return true;
+}
+
+bool Archiver::createArchive(GAppLaunchContext* ctx, const FilePathList& files) {
+    if(createCmd_ && !files.empty()) {
+        launchProgram(ctx, createCmd_.get(), files, FilePath{});
+    }
+    return false;
+}
+
+bool Archiver::extractArchives(GAppLaunchContext* ctx, const FilePathList& files) {
+    if(extractCmd_ && !files.empty()) {
+        launchProgram(ctx, extractCmd_.get(), files, FilePath{});
+    }
+    return false;
+}
+
+bool Archiver::extractArchivesTo(GAppLaunchContext* ctx, const FilePathList& files, const FilePath& dest_dir) {
+    if(extractToCmd_ && !files.empty()) {
+        launchProgram(ctx, extractToCmd_.get(), files, dest_dir);
+    }
+    return false;
+}
+
+// static
+Archiver* Archiver::defaultArchiver() {
+    allArchivers(); // to have a preliminary default archiver
+    return defaultArchiver_;
+}
+
+void Archiver::setDefaultArchiverByName(const char *name) {
+    if(name) {
+        auto& all = allArchivers();
+        for(auto& archiver: all) {
+            if(archiver->program_ && strcmp(archiver->program_.get(), name) == 0) {
+                defaultArchiver_ = archiver.get();
+                break;
+            }
+        }
+    }
+}
+
+// static
+void Archiver::setDefaultArchiver(Archiver* archiver) {
+    if(archiver) {
+        defaultArchiver_ = archiver;
+    }
+}
+
+// static
+const std::vector<std::unique_ptr<Archiver> >& Archiver::allArchivers() {
+    // load all archivers on demand
+    if(allArchivers_.empty()) {
+        GKeyFile* kf = g_key_file_new();
+        if(g_key_file_load_from_file(kf, LIBFM_QT_DATA_DIR "/archivers.list", G_KEY_FILE_NONE, nullptr)) {
+            gsize n_archivers;
+            CStrArrayPtr programs{g_key_file_get_groups(kf, &n_archivers)};
+            if(programs) {
+                gsize i;
+                for(i = 0; i < n_archivers; ++i) {
+                    auto program = programs[i];
+                    std::unique_ptr<Archiver> archiver{new Archiver{}};
+                    archiver->createCmd_ = CStrPtr{g_key_file_get_string(kf, program, "create", nullptr)};
+                    archiver->extractCmd_ = CStrPtr{g_key_file_get_string(kf, program, "extract", nullptr)};
+                    archiver->extractToCmd_ = CStrPtr{g_key_file_get_string(kf, program, "extract_to", nullptr)};
+                    archiver->mimeTypes_ = CStrArrayPtr{g_key_file_get_string_list(kf, program, "mime_types", nullptr, nullptr)};
+                    archiver->program_ = CStrPtr{g_strdup(program)};
+
+                    // if default archiver is not set, find the first program existing in the current system.
+                    if(!defaultArchiver_) {
+                        CStrPtr fullPath{g_find_program_in_path(program)};
+                        if(fullPath) {
+                            defaultArchiver_ = archiver.get();
+                        }
+                    }
+
+                    allArchivers_.emplace_back(std::move(archiver));
+                }
+            }
+        }
+        g_key_file_free(kf);
+    }
+    return allArchivers_;
+}
+
+} // namespace Fm

--- a/libfm-qt/core/archiver.h
+++ b/libfm-qt/core/archiver.h
@@ -1,0 +1,69 @@
+#ifndef ARCHIVER_H
+#define ARCHIVER_H
+
+#include "../libfmqtglobals.h"
+#include "filepath.h"
+#include "gioptrs.h"
+
+#include <vector>
+#include <memory>
+
+namespace Fm {
+
+class LIBFM_QT_API Archiver {
+public:
+    Archiver();
+
+    bool isMimeTypeSupported(const char* type);
+
+    bool canCreateArchive() const {
+        return createCmd_ != nullptr;
+    }
+
+    bool createArchive(GAppLaunchContext* ctx, const FilePathList& files);
+
+    bool canExtractArchives() const {
+        return extractCmd_ != nullptr;
+    }
+
+    bool extractArchives(GAppLaunchContext* ctx, const FilePathList& files);
+
+    bool canExtractArchivesTo() const {
+        return extractToCmd_ != nullptr;
+    }
+
+    bool extractArchivesTo(GAppLaunchContext* ctx, const FilePathList& files, const FilePath& dest_dir);
+
+    /* get default GUI archivers used by libfm */
+    static Archiver* defaultArchiver();
+
+    /* set default GUI archivers used by libfm */
+    static void setDefaultArchiverByName(const char* name);
+
+    /* set default GUI archivers used by libfm */
+    static void setDefaultArchiver(Archiver* archiver);
+
+    /* get a list of FmArchiver* of all GUI archivers known to libfm */
+    static const std::vector<std::unique_ptr<Archiver>>& allArchivers();
+
+    const char* program() const {
+        return program_.get();
+    }
+
+private:
+    bool launchProgram(GAppLaunchContext* ctx, const char* cmd, const FilePathList& files, const FilePath &dir);
+
+private:
+    CStrPtr program_;
+    CStrPtr createCmd_;
+    CStrPtr extractCmd_;
+    CStrPtr extractToCmd_;
+    CStrArrayPtr mimeTypes_;
+
+    static Archiver* defaultArchiver_;
+    static std::vector<std::unique_ptr<Archiver>> allArchivers_;
+};
+
+} // namespace Fm
+
+#endif // ARCHIVER_H

--- a/libfm-qt/core/basicfilelauncher.cpp
+++ b/libfm-qt/core/basicfilelauncher.cpp
@@ -1,0 +1,453 @@
+#include "basicfilelauncher.h"
+#include "fileinfojob.h"
+#include "mountoperation.h"
+
+#include <gio/gdesktopappinfo.h>
+#include <glib/gi18n.h>
+
+#include <unordered_map>
+#include <string>
+
+#include <QObject>
+#include <QEventLoop>
+#include <QDebug>
+
+#include "legacy/fm-app-info.h"
+
+namespace Fm {
+
+BasicFileLauncher::BasicFileLauncher():
+    quickExec_{false} {
+}
+
+BasicFileLauncher::~BasicFileLauncher() {
+}
+
+bool BasicFileLauncher::launchFiles(const FileInfoList& fileInfos, GAppLaunchContext* ctx) {
+    FileInfoList mimeTypeInfos;
+    FileInfoList folderInfos;
+    FilePathList pathsToLaunch;
+    // classify files according to different mimetypes
+    for(auto& fileInfo : fileInfos) {
+        /*
+        qDebug("path: %s, type: %s, target: %s, isDir: %i, isShortcut: %i, isMountable: %i, isDesktopEntry: %i",
+               fileInfo->path().toString().get(), fileInfo->mimeType()->name(), fileInfo->target().c_str(),
+               fileInfo->isDir(), fileInfo->isShortcut(), fileInfo->isMountable(), fileInfo->isDesktopEntry());
+        */
+        if(fileInfo->isMountable()) {
+            if(fileInfo->target().empty()) {
+                // the mountable is not yet mounted so we have no target URI.
+                GErrorPtr err{G_IO_ERROR, G_IO_ERROR_NOT_MOUNTED,
+                            QObject::tr("The path is not mounted.")};
+                if(!showError(ctx, err, fileInfo->path(), fileInfo)) {
+                    // the user fail to handle the error, skip this file.
+                    continue;
+                }
+
+                // we do not have the target path in the FileInfo object.
+                // try to launch our path again to query the new file info later so we can get the mounted target URI.
+                pathsToLaunch.emplace_back(fileInfo->path());
+            }
+            else {
+                // we have the target path, launch it later
+                pathsToLaunch.emplace_back(FilePath::fromPathStr(fileInfo->target().c_str()));
+            }
+        }
+        else if(fileInfo->isDesktopEntry()) {
+            // launch the desktop entry
+            launchDesktopEntry(fileInfo, FilePathList{}, ctx);
+        }
+        else if(fileInfo->isExecutableType()) {
+            // directly execute the file
+            launchExecutable(fileInfo, ctx);
+        }
+        else if(fileInfo->isShortcut()) {
+            // for shortcuts, launch their targets instead
+            auto path = handleShortcut(fileInfo, ctx);
+            if(path.isValid()) {
+                pathsToLaunch.emplace_back(path);
+            }
+        }
+        else if(fileInfo->isDir()) {
+            folderInfos.emplace_back(fileInfo);
+        }
+        else {
+            mimeTypeInfos.emplace_back(fileInfo);
+        }
+    }
+
+    // open folders
+    if(!folderInfos.empty()) {
+        GErrorPtr err;
+        openFolder(ctx, folderInfos, err);
+    }
+
+    // Open files of different mime-types with their default apps,
+    // grouping them together appropriately and respecting their order.
+    std::vector<std::pair<GAppInfoPtr, FileInfoList>> launches;
+    std::unordered_map<std::string, GAppInfoPtr> defaultApps;
+    for(const auto& file : mimeTypeInfos) {
+        const char* mimeTypeName = file->mimeType()->name();
+        auto it = defaultApps.find(mimeTypeName);
+        if(it == defaultApps.end()) {
+            GErrorPtr err;
+            GAppInfoPtr app{g_app_info_get_default_for_type(mimeTypeName, false), false};
+            if(!app) {
+                app = chooseApp(FileInfoList(), mimeTypeName, err);
+            }
+            if(app) {
+                // check whether this app is already found for another mimetype
+                bool alreadyFound = false;
+                for(auto& launch : launches) {
+                    if(g_app_info_equal(app.get(), launch.first.get())) {
+                        alreadyFound = true;
+                        // remember it as the default app for this mimetype
+                        defaultApps[mimeTypeName] = launch.first;
+                        // update this launch (add the file to it)
+                        auto tmp = launch.second;
+                        tmp.push_back(file);
+                        launch.second = tmp;
+                        break;
+                    }
+                }
+                if(!alreadyFound) {
+                    defaultApps[mimeTypeName] = app;
+                    // remember this launch
+                    FileInfoList files;
+                    files.push_back(file);
+                    launches.push_back(std::make_pair(app, files));
+                }
+            }
+            else {
+                // remember that this mimetype has no default app (don't ask again)
+                defaultApps[mimeTypeName] = nullptr;
+            }
+        }
+        else if(auto app = it->second) { // a default app was found/chosen before
+            for(auto& launch : launches) {
+                if(launch.first == app) {
+                    auto tmp = launch.second;
+                    tmp.push_back(file);
+                    launch.second = tmp;
+                    break;
+                }
+            }
+        }
+    }
+    // perform the launches
+    for(const auto& launch : launches) {
+        launchWithApp(launch.first.get(), launch.second.paths(), ctx);
+    }
+
+    if(!pathsToLaunch.empty()) {
+        launchPaths(pathsToLaunch, ctx);
+    }
+
+    return true;
+}
+
+bool BasicFileLauncher::launchPaths(FilePathList paths, GAppLaunchContext* ctx) {
+    // FIXME: blocking with an event loop is not a good design :-(
+    QEventLoop eventLoop;
+    auto job = new FileInfoJob{paths};
+    job->setAutoDelete(false);  // do not automatically delete the job since we want its results later.
+
+    GObjectPtr<GAppLaunchContext> ctxPtr{ctx};
+
+    // error handling (for example: handle path not mounted error)
+    QObject::connect(job, &FileInfoJob::error,
+            &eventLoop, [this, job, ctx](const GErrorPtr & err, Job::ErrorSeverity /* severity */ , Job::ErrorAction &act) {
+        auto path = job->currentPath();
+        if(showError(ctx, err, path, nullptr)) {
+            // the user handled the error and ask for retry
+            act = Job::ErrorAction::RETRY;
+        }
+    }, Qt::BlockingQueuedConnection);  // BlockingQueuedConnection is required here to pause the job and wait for user response
+
+    QObject::connect(job, &FileInfoJob::finished,
+            [&eventLoop]() {
+        // exit the event loop when the job is done
+        eventLoop.exit();
+    });
+
+    // run the job in another thread to not block the UI
+    job->runAsync();
+
+    // blocking until the job is done with a event loop
+    eventLoop.exec();
+
+    // launch the file info
+    launchFiles(job->files(), ctx);
+
+    delete job;
+    return false;
+}
+
+GAppInfoPtr BasicFileLauncher::chooseApp(const FileInfoList& /* fileInfos */, const char* /*mimeType*/, GErrorPtr& /* err */) {
+    return GAppInfoPtr{};
+}
+
+bool BasicFileLauncher::openFolder(GAppLaunchContext* ctx, const FileInfoList& folderInfos, GErrorPtr& err) {
+    auto app = chooseApp(folderInfos, "inode/directory", err);
+    if(app) {
+        launchWithApp(app.get(), folderInfos.paths(), ctx);
+    }
+    else {
+        showError(ctx, err);
+    }
+    return false;
+}
+
+BasicFileLauncher::ExecAction BasicFileLauncher::askExecFile(const FileInfoPtr & /* file */) {
+    return ExecAction::DIRECT_EXEC;
+}
+
+bool BasicFileLauncher::showError(GAppLaunchContext* /* ctx */, const GErrorPtr & /* err */, const FilePath& /* path */, const FileInfoPtr& /* info */) {
+    return false;
+}
+
+int BasicFileLauncher::ask(const char* /* msg */, char* const* /* btn_labels */, int default_btn) {
+    return default_btn;
+}
+
+bool BasicFileLauncher::launchWithApp(GAppInfo* app, const FilePathList& paths, GAppLaunchContext* ctx) {
+    GList* uris = nullptr;
+    for(auto& path : paths) {
+        auto uri = path.uri();
+        uris = g_list_prepend(uris, uri.release());
+    }
+    uris = g_list_reverse(uris);
+    GErrorPtr err;
+    bool ret = bool(g_app_info_launch_uris(app, uris, ctx, &err));
+    g_list_free_full(uris, g_free);
+    if(!ret) {
+        // FIXME: show error for all files
+        showError(ctx, err, paths.empty() ? FilePath{} : paths[0]);
+    }
+    return ret;
+}
+
+
+bool BasicFileLauncher::launchDesktopEntry(const FileInfoPtr &fileInfo, const FilePathList &paths, GAppLaunchContext* ctx) {
+    /* treat desktop entries as executables */
+    auto target = fileInfo->target();
+    CStrPtr filename;
+    const char* desktopEntryName = nullptr;
+    FilePathList shortcutTargetPaths;
+    if(fileInfo->isExecutableType()) {
+        auto act = (quickExec_ || fileInfo->isTrustable()) ? ExecAction::DIRECT_EXEC : askExecFile(fileInfo);
+        switch(act) {
+        case ExecAction::EXEC_IN_TERMINAL:
+        case ExecAction::DIRECT_EXEC: {
+            if(fileInfo->isShortcut()) {
+                auto path = handleShortcut(fileInfo, ctx);
+                if(path.isValid()) {
+                    shortcutTargetPaths.emplace_back(path);
+                }
+            }
+            else {
+                if(target.empty()) {
+                    filename = fileInfo->path().localPath();
+                    desktopEntryName = filename.get();
+                }
+                else {
+                    desktopEntryName = target.c_str();
+                }
+            }
+            break;
+        }
+        case ExecAction::OPEN_WITH_DEFAULT_APP:
+            return launchWithDefaultApp(fileInfo, ctx);
+        case ExecAction::CANCEL:
+            return false;
+        default:
+            return false;
+        }
+    }
+    /* make exception for desktop entries under menu */
+    else if(fileInfo->isNative() /* an exception */ ||
+            fileInfo->path().hasUriScheme("menu")) {
+        if(target.empty()) {
+            filename = fileInfo->path().localPath();
+            desktopEntryName = filename.get();
+        }
+        else {
+            desktopEntryName = target.c_str();
+        }
+    }
+
+    if(desktopEntryName) {
+        return launchDesktopEntry(desktopEntryName, paths, ctx);
+    }
+    if(!shortcutTargetPaths.empty()) {
+        launchPaths(shortcutTargetPaths, ctx);
+    }
+    return false;
+}
+
+bool BasicFileLauncher::launchDesktopEntry(const char *desktopEntryName, const FilePathList &paths, GAppLaunchContext *ctx) {
+    bool ret = false;
+    GAppInfo* app;
+
+    /* Let GDesktopAppInfo try first. */
+    if(g_path_is_absolute(desktopEntryName)) {
+        app = G_APP_INFO(g_desktop_app_info_new_from_filename(desktopEntryName));
+    }
+    else {
+        app = G_APP_INFO(g_desktop_app_info_new(desktopEntryName));
+    }
+    /* we handle Type=Link in FmFileInfo so if GIO failed then
+       it cannot be launched in fact */
+
+    if(app) {
+        // don't call launchWithApp() because it calls g_app_info_launch_uris(),
+        // which uses the hard-coded terminal list of GLib -> gdesktopappinfo.c
+        GList* uris = nullptr;
+        for(auto& path : paths) {
+            auto uri = path.uri();
+            uris = g_list_prepend(uris, uri.release());
+        }
+        uris = g_list_reverse(uris);
+        GErrorPtr err;
+        ret = bool(fm_app_info_launch_uris(app, uris, ctx, &err));
+        g_list_free_full(uris, g_free);
+        if(!ret) {
+            // FIXME: show error for all files
+            showError(ctx, err, paths.empty() ? FilePath{} : paths[0]);
+        }
+        g_object_unref(app);
+    }
+    else {
+        // if no desktop app is found but we have a uri scheme, try to launch it directly
+        auto scheme = CStrPtr{g_uri_parse_scheme(desktopEntryName)};
+        if (scheme) {
+            if(GAppInfoPtr app{g_app_info_get_default_for_uri_scheme(scheme.get()), false}) {
+                FilePathList uris{FilePath::fromUri(desktopEntryName)};
+                launchWithApp(app.get(), uris, ctx);
+                ret = true;
+            }
+        }
+        if (!ret) {
+            QString msg = QObject::tr("Invalid desktop entry file: '%1'").arg(QString::fromUtf8(desktopEntryName));
+            GErrorPtr err{G_IO_ERROR, G_IO_ERROR_FAILED, msg};
+            showError(ctx, err);
+        }
+    }
+    return ret;
+}
+
+FilePath BasicFileLauncher::handleShortcut(const FileInfoPtr& fileInfo, GAppLaunchContext* ctx) {
+    auto target = fileInfo->target();
+
+    // if we know the target is a dir, we are not going to open it using other apps
+    // for example: `network:///smb-root' is a shortcut targeting `smb:///' and it's also a dir
+    if(fileInfo->isDir()) {
+        qDebug("shortcut is dir: %s", target.c_str());
+        return FilePath::fromPathStr(target.c_str());
+    }
+
+    auto scheme = CStrPtr{g_uri_parse_scheme(target.c_str())};
+    if(scheme) {
+        // collect the uri schemes we support
+        if(strcmp(scheme.get(), "file") == 0
+                || strcmp(scheme.get(), "trash") == 0
+                || strcmp(scheme.get(), "network") == 0
+                || strcmp(scheme.get(), "computer") == 0
+                || strcmp(scheme.get(), "menu") == 0) {
+            return FilePath::fromUri(target.c_str());
+        }
+        else {
+            // ask gio to launch the default handler for the uri scheme
+            if(GAppInfoPtr app{g_app_info_get_default_for_uri_scheme(scheme.get()), false}) {
+                FilePathList uris{FilePath::fromUri(target.c_str())};
+                launchWithApp(app.get(), uris, ctx);
+            }
+            else {
+                GErrorPtr err{G_IO_ERROR, G_IO_ERROR_FAILED,
+                              QObject::tr("No default application is set to launch '%1'")
+                              .arg(QString::fromUtf8(target.c_str()))};
+                showError(nullptr, err);
+            }
+        }
+    }
+    else {
+        // see it as a local path
+        return FilePath::fromLocalPath(target.c_str());
+    }
+    return FilePath();
+}
+
+bool BasicFileLauncher::launchExecutable(const FileInfoPtr &fileInfo, GAppLaunchContext* ctx) {
+    /* if it's an executable file, directly execute it. */
+    auto filename = fileInfo->path().localPath();
+    /* FIXME: we need to use eaccess/euidaccess here. */
+    if(g_file_test(filename.get(), G_FILE_TEST_IS_EXECUTABLE)) {
+        auto act = (quickExec_ || fileInfo->isTrustable()) ? ExecAction::DIRECT_EXEC : askExecFile(fileInfo);
+        int flags = G_APP_INFO_CREATE_NONE;
+        switch(act) {
+        case ExecAction::EXEC_IN_TERMINAL:
+            flags |= G_APP_INFO_CREATE_NEEDS_TERMINAL;
+        /* Falls through. */
+        case ExecAction::DIRECT_EXEC: {
+            /* filename may contain spaces. Fix #3143296 */
+            CStrPtr quoted{g_shell_quote(filename.get())};
+            // FIXME: remove libfm dependency
+            GAppInfoPtr app{fm_app_info_create_from_commandline(quoted.get(), nullptr, GAppInfoCreateFlags(flags), nullptr)};
+            if(app) {
+                CStrPtr run_path{g_path_get_dirname(filename.get())};
+                CStrPtr cwd;
+                /* bug #3589641: scripts are ran from $HOME.
+                   since GIO launcher is kinda ugly - it has
+                   no means to set running directory so we
+                   do workaround - change directory to it */
+                if(run_path && strcmp(run_path.get(), ".")) {
+                    cwd = CStrPtr{g_get_current_dir()};
+                    if(chdir(run_path.get()) != 0) {
+                        cwd.reset();
+                        // show errors
+                        QString msg = QObject::tr("Cannot set working directory to '%1': %2").arg(QString::fromUtf8(run_path.get()),
+                                                                                                  QString::fromUtf8(g_strerror(errno)));
+                        GErrorPtr err{G_IO_ERROR, g_io_error_from_errno(errno), msg};
+                        showError(ctx, err);
+                    }
+                }
+
+                // FIXME: remove libfm dependency
+                GErrorPtr err;
+                if(!fm_app_info_launch(app.get(), nullptr, ctx, &err)) {
+                    showError(ctx, err);
+                }
+                if(cwd) { /* return back */
+                    if(chdir(cwd.get()) != 0) {
+                        g_warning("fm_launch_files(): chdir() failed");
+                    }
+                }
+                return true;
+            }
+            break;
+        }
+        case ExecAction::OPEN_WITH_DEFAULT_APP:
+            return launchWithDefaultApp(fileInfo, ctx);
+        case ExecAction::CANCEL:
+        default:
+            break;
+        }
+    }
+    return false;
+}
+
+bool BasicFileLauncher::launchWithDefaultApp(const FileInfoPtr &fileInfo, GAppLaunchContext* ctx) {
+    FileInfoList files;
+    files.emplace_back(fileInfo);
+    GErrorPtr err;
+    GAppInfoPtr app{g_app_info_get_default_for_type(fileInfo->mimeType()->name(), false), false};
+    if(app) {
+        return launchWithApp(app.get(), files.paths(), ctx);
+    }
+    else {
+        showError(ctx, err, fileInfo->path());
+    }
+    return false;
+}
+
+} // namespace Fm

--- a/libfm-qt/core/basicfilelauncher.h
+++ b/libfm-qt/core/basicfilelauncher.h
@@ -1,0 +1,72 @@
+#ifndef BASICFILELAUNCHER_H
+#define BASICFILELAUNCHER_H
+
+#include "../libfmqtglobals.h"
+
+#include "fileinfo.h"
+#include "filepath.h"
+#include "mimetype.h"
+
+#include <gio/gio.h>
+
+namespace Fm {
+
+class LIBFM_QT_API BasicFileLauncher {
+public:
+
+    enum class ExecAction {
+        NONE,
+        DIRECT_EXEC,
+        EXEC_IN_TERMINAL,
+        OPEN_WITH_DEFAULT_APP,
+        CANCEL
+    };
+
+    explicit BasicFileLauncher();
+    virtual ~BasicFileLauncher();
+
+    bool launchFiles(const FileInfoList &fileInfos, GAppLaunchContext* ctx = nullptr);
+
+    bool launchPaths(FilePathList paths, GAppLaunchContext* ctx = nullptr);
+
+    bool launchDesktopEntry(const FileInfoPtr &fileInfo, const FilePathList& paths = FilePathList{}, GAppLaunchContext* ctx = nullptr);
+
+    bool launchDesktopEntry(const char* desktopEntryName, const FilePathList& paths = FilePathList{}, GAppLaunchContext* ctx = nullptr);
+
+    bool launchWithDefaultApp(const FileInfoPtr& fileInfo, GAppLaunchContext* ctx = nullptr);
+
+    bool launchWithApp(GAppInfo* app, const FilePathList& paths, GAppLaunchContext* ctx = nullptr);
+
+    bool launchExecutable(const FileInfoPtr &fileInfo, GAppLaunchContext* ctx = nullptr);
+
+    bool quickExec() const {
+        return quickExec_;
+    }
+
+    void setQuickExec(bool value) {
+        quickExec_ = value;
+    }
+
+protected:
+
+    virtual GAppInfoPtr chooseApp(const FileInfoList& fileInfos, const char* mimeType, GErrorPtr& err);
+
+    virtual bool openFolder(GAppLaunchContext* ctx, const FileInfoList& folderInfos, GErrorPtr& err);
+
+    virtual bool showError(GAppLaunchContext* ctx, const GErrorPtr& err, const FilePath& path = FilePath{}, const FileInfoPtr& info = FileInfoPtr{});
+
+    virtual ExecAction askExecFile(const FileInfoPtr& file);
+
+    virtual int ask(const char* msg, char* const* btn_labels, int default_btn);
+
+private:
+
+    FilePath handleShortcut(const FileInfoPtr &fileInfo, GAppLaunchContext* ctx = nullptr);
+
+private:
+    bool quickExec_; // Don't ask options on launch executable file
+};
+
+} // namespace Fm
+
+#endif // BASICFILELAUNCHER_H

--- a/libfm-qt/core/bookmarks.cpp
+++ b/libfm-qt/core/bookmarks.cpp
@@ -1,0 +1,221 @@
+#include "bookmarks.h"
+#include "cstrptr.h"
+#include <algorithm>
+#include <QTimer>
+#include <QStandardPaths>
+
+namespace Fm {
+
+std::weak_ptr<Bookmarks> Bookmarks::globalInstance_;
+
+static inline CStrPtr get_legacy_bookmarks_file(void) {
+    return CStrPtr{g_build_filename(g_get_home_dir(), ".gtk-bookmarks", nullptr)};
+}
+
+static inline CStrPtr get_new_bookmarks_file(void) {
+    return CStrPtr{g_build_filename(g_get_user_config_dir(), "gtk-3.0", "bookmarks", nullptr)};
+}
+
+BookmarkItem::BookmarkItem(const FilePath& path, const QString name):
+    path_{path},
+    name_{name} {
+    if(name_.isEmpty()) { // if the name is not specified, use basename of the path
+        name_ = QString::fromUtf8(path_.baseName().get());
+    }
+    // We cannot rely on FileInfos to set bookmark icons because there is no guarantee
+    // that FileInfos already exist, while their creation is costly. Therefore, we have
+    // to get folder icons directly, as is done at `FileInfo::setFromGFileInfo` and more.
+    auto local_path = path.localPath();
+    auto dot_dir = CStrPtr{g_build_filename(local_path.get(), ".directory", nullptr)};
+    if(g_file_test(dot_dir.get(), G_FILE_TEST_IS_REGULAR)) {
+        GKeyFile* kf = g_key_file_new();
+        if(g_key_file_load_from_file(kf, dot_dir.get(), G_KEY_FILE_NONE, nullptr)) {
+            CStrPtr icon_name{g_key_file_get_string(kf, "Desktop Entry", "Icon", nullptr)};
+            if(icon_name) {
+                icon_ = IconInfo::fromName(icon_name.get());
+            }
+        }
+        g_key_file_free(kf);
+    }
+    if(!icon_ || !icon_->isValid()) {
+        // first check some standard folders that are shared by Qt and GLib
+        if(path_ == FilePath::homeDir()) {
+            icon_ = IconInfo::fromName("user-home");
+        }
+        else if (path_.parent() == FilePath::homeDir()) {
+            QString folderPath = QString::fromUtf8(path_.toString().get());
+            if(folderPath == QStandardPaths::writableLocation(QStandardPaths::DesktopLocation)) {
+                icon_ = IconInfo::fromName("user-desktop");
+            }
+            else if(folderPath == QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation)) {
+                icon_ = IconInfo::fromName("folder-documents");
+            }
+            else if(folderPath == QStandardPaths::writableLocation(QStandardPaths::DownloadLocation)) {
+                icon_ = IconInfo::fromName("folder-download");
+            }
+            else if(folderPath == QStandardPaths::writableLocation(QStandardPaths::MusicLocation)) {
+                icon_ = IconInfo::fromName("folder-music");
+            }
+            else if(folderPath == QStandardPaths::writableLocation(QStandardPaths::PicturesLocation)) {
+                icon_ = IconInfo::fromName("folder-pictures");
+            }
+            else if(folderPath ==  QStandardPaths::writableLocation(QStandardPaths::MoviesLocation)) {
+                icon_ = IconInfo::fromName("folder-videos");
+            }
+        }
+        // fall back to the default folder icon
+        if(!icon_ || !icon_->isValid()) {
+            icon_ = IconInfo::fromName("folder");
+        }
+    }
+}
+
+Bookmarks::Bookmarks(QObject* parent):
+    QObject(parent),
+    idle_handler{false} {
+
+    /* trying the gtk-3.0 first and use it if it exists */
+    auto fpath = get_new_bookmarks_file();
+    file_ = FilePath::fromLocalPath(fpath.get());
+    load();
+    if(items_.empty()) { /* not found, use legacy file */
+        fpath = get_legacy_bookmarks_file();
+        file_ = FilePath::fromLocalPath(fpath.get());
+        load();
+    }
+    mon = GObjectPtr<GFileMonitor>{g_file_monitor_file(file_.gfile().get(), G_FILE_MONITOR_NONE, nullptr, nullptr), false};
+    if(mon) {
+        g_signal_connect(mon.get(), "changed", G_CALLBACK(_onFileChanged), this);
+    }
+}
+
+Bookmarks::~Bookmarks() {
+    if(mon) {
+        g_signal_handlers_disconnect_by_data(mon.get(), this);
+    }
+}
+
+const FilePath& Bookmarks::bookmarksFile() const {
+    return file_;
+}
+
+const std::shared_ptr<const BookmarkItem>& Bookmarks::insert(const FilePath& path, const QString& name, int pos) {
+    const auto insert_pos = (pos < 0 || static_cast<size_t>(pos) > items_.size()) ? items_.cend() : items_.cbegin() + pos;
+    auto it = items_.insert(insert_pos, std::make_shared<const BookmarkItem>(path, name));
+    queueSave();
+    return *it;
+}
+
+void Bookmarks::remove(const std::shared_ptr<const BookmarkItem>& item) {
+    items_.erase(std::remove(items_.begin(), items_.end(), item), items_.end());
+    queueSave();
+}
+
+void Bookmarks::reorder(const std::shared_ptr<const BookmarkItem>& item, int pos) {
+    auto old_it = std::find(items_.cbegin(), items_.cend(), item);
+    if(old_it == items_.cend())
+        return;
+    std::shared_ptr<const BookmarkItem> newItem = item;
+    auto old_pos = old_it - items_.cbegin();
+    items_.erase(old_it);
+    if(old_pos < pos)
+        --pos;
+    auto new_it = items_.cbegin() + pos;
+    if(new_it > items_.cend())
+        new_it = items_.cend();
+    items_.insert(new_it, std::move(newItem));
+    queueSave();
+}
+
+void Bookmarks::rename(const std::shared_ptr<const BookmarkItem>& item, QString new_name) {
+    auto it = std::find_if(items_.cbegin(), items_.cend(), [item](const std::shared_ptr<const BookmarkItem>& elem) {
+        return elem->path() == item->path();
+    });
+    if(it != items_.cend()) {
+        // create a new item to replace the old one
+        // we do not modify the old item directly since this data structure is shared with others
+        it = items_.insert(it, std::make_shared<const BookmarkItem>(item->path(), new_name));
+        items_.erase(it + 1); // remove the old item
+        queueSave();
+    }
+}
+
+std::shared_ptr<Bookmarks> Bookmarks::globalInstance() {
+    auto bookmarks = globalInstance_.lock();
+    if(!bookmarks) {
+        bookmarks = std::make_shared<Bookmarks>();
+        globalInstance_ = bookmarks;
+    }
+    return bookmarks;
+}
+
+void Bookmarks::save() {
+    std::string buf;
+    // G_LOCK(bookmarks);
+    for(auto& item: items_) {
+        auto uri = item->path().uri();
+        buf += uri.get();
+        buf += ' ';
+        buf += item->name().toUtf8().constData();
+        buf += '\n';
+    }
+    idle_handler = false;
+    // G_UNLOCK(bookmarks);
+    GError* err = nullptr;
+    if(!g_file_replace_contents(file_.gfile().get(), buf.c_str(), buf.length(), nullptr,
+                                FALSE, G_FILE_CREATE_NONE, nullptr, nullptr, &err)) {
+        g_critical("%s", err->message);
+        g_error_free(err);
+    }
+    /* we changed bookmarks list, let inform who interested in that */
+    Q_EMIT changed();
+}
+
+void Bookmarks::load() {
+    auto fpath = file_.localPath();
+    FILE* f;
+    char buf[1024];
+    /* load the file */
+    f = fopen(fpath.get(), "r");
+    if(f) {
+        while(fgets(buf, 1024, f)) {
+            // format of each line in the bookmark file:
+            // <URI> <name>\n
+            char* sep;
+            sep = strchr(buf, '\n');
+            if(sep) {
+                *sep = '\0';
+            }
+
+            QString name;
+            sep = strchr(buf, ' ');  // find the separator between URI and name
+            if(sep) {
+                *sep = '\0';
+                name = QString::fromUtf8(sep + 1);
+            }
+            auto uri = buf;
+            if(uri[0] != '\0') {
+                items_.push_back(std::make_shared<BookmarkItem>(FilePath::fromUri(uri), name));
+            }
+        }
+        fclose(f);
+    }
+}
+
+void Bookmarks::onFileChanged(GFileMonitor* /*mon*/, GFile* /*gf*/, GFile* /*other*/, GFileMonitorEvent /*evt*/) {
+    // reload the bookmarks
+    items_.clear();
+    load();
+    Q_EMIT changed();
+}
+
+
+void Bookmarks::queueSave() {
+    if(!idle_handler) {
+        QTimer::singleShot(0, this, &Bookmarks::save);
+        idle_handler = true;
+    }
+}
+
+
+} // namespace Fm

--- a/libfm-qt/core/bookmarks.h
+++ b/libfm-qt/core/bookmarks.h
@@ -1,0 +1,89 @@
+#ifndef FM2_BOOKMARKS_H
+#define FM2_BOOKMARKS_H
+
+#include <QObject>
+#include "gobjectptr.h"
+#include "filepath.h"
+#include "iconinfo.h"
+
+namespace Fm {
+
+class LIBFM_QT_API BookmarkItem {
+public:
+    friend class Bookmarks;
+
+    explicit BookmarkItem(const FilePath& path, const QString name);
+
+    const QString& name() const {
+        return name_;
+    }
+
+    const FilePath& path() const {
+        return path_;
+    }
+
+    const std::shared_ptr<const IconInfo>& icon() const {
+        return icon_;
+    }
+
+private:
+    void setName(const QString& name) {
+        name_ = name;
+    }
+
+private:
+    FilePath path_;
+    QString name_;
+    std::shared_ptr<const IconInfo> icon_;
+};
+
+
+class LIBFM_QT_API Bookmarks : public QObject {
+    Q_OBJECT
+public:
+    explicit Bookmarks(QObject* parent = nullptr);
+
+    ~Bookmarks() override;
+
+    const FilePath& bookmarksFile() const;
+
+    const std::shared_ptr<const BookmarkItem> &insert(const FilePath& path, const QString& name, int pos);
+
+    void remove(const std::shared_ptr<const BookmarkItem>& item);
+
+    void reorder(const std::shared_ptr<const BookmarkItem> &item, int pos);
+
+    void rename(const std::shared_ptr<const BookmarkItem>& item, QString new_name);
+
+    const std::vector<std::shared_ptr<const BookmarkItem>>& items() const {
+        return items_;
+    }
+
+    static std::shared_ptr<Bookmarks> globalInstance();
+
+Q_SIGNALS:
+    void changed();
+
+private Q_SLOTS:
+    void save();
+
+private:
+    void load();
+    void queueSave();
+
+    static void _onFileChanged(GFileMonitor* mon, GFile* gf, GFile* other, GFileMonitorEvent evt, Bookmarks* _this) {
+        _this->onFileChanged(mon, gf, other, evt);
+    }
+    void onFileChanged(GFileMonitor* mon, GFile* gf, GFile* other, GFileMonitorEvent evt);
+
+private:
+    FilePath file_;
+    GObjectPtr<GFileMonitor> mon;
+    std::vector<std::shared_ptr<const BookmarkItem>> items_;
+    static std::weak_ptr<Bookmarks> globalInstance_;
+    bool idle_handler;
+};
+
+} // namespace Fm
+
+#endif // FM2_BOOKMARKS_H

--- a/libfm-qt/core/cstrptr.h
+++ b/libfm-qt/core/cstrptr.h
@@ -1,0 +1,42 @@
+#ifndef FM2_CSTRPTR_H
+#define FM2_CSTRPTR_H
+
+#include <memory>
+#include <glib.h>
+
+namespace Fm {
+
+struct CStrDeleter {
+    void operator()(char* ptr) const {
+        g_free(ptr);
+    }
+};
+
+// smart pointer for C string (char*) which should be freed by free()
+typedef std::unique_ptr<char[], CStrDeleter> CStrPtr;
+
+struct CStrHash {
+    std::size_t operator()(const char* str) const {
+        return g_str_hash(str);
+    }
+};
+
+struct CStrEqual {
+    bool operator()(const char* str1, const char* str2) const {
+        return g_str_equal(str1, str2);
+    }
+};
+
+struct CStrVDeleter {
+    void operator()(char** ptr) const {
+        g_strfreev(ptr);
+    }
+};
+
+// smart pointer for C string array (char**) which should be freed by g_strfreev() of glib
+typedef std::unique_ptr<char*[], CStrVDeleter> CStrArrayPtr;
+
+
+} // namespace Fm
+
+#endif // FM2_CSTRPTR_H

--- a/libfm-qt/core/deletejob.cpp
+++ b/libfm-qt/core/deletejob.cpp
@@ -1,0 +1,158 @@
+#include "deletejob.h"
+#include "totalsizejob.h"
+#include "fileinfo_p.h"
+
+namespace Fm {
+
+bool DeleteJob::deleteFile(const FilePath& path, GFileInfoPtr inf) {
+    ErrorAction act = ErrorAction::CONTINUE;
+    while(!inf) {
+        GErrorPtr err;
+        inf = GFileInfoPtr{
+            g_file_query_info(path.gfile().get(), "standard::*",
+            G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+            cancellable().get(), &err),
+            false
+        };
+        if(err) {
+            act = emitError(err, ErrorSeverity::SEVERE);
+            if(act == ErrorAction::ABORT) {
+                return false;
+            }
+            if(act != ErrorAction::RETRY) {
+                break;
+            }
+        }
+    }
+
+    // TODO: get parent dir of the current path.
+    //       if there is a Fm::Folder object created for it, block the update for the folder temporarily.
+
+    /* currently processed file. */
+    setCurrentFile(path);
+
+    if(g_file_info_get_file_type(inf.get()) == G_FILE_TYPE_DIRECTORY) {
+        // delete the content of the dir prior to deleting itself
+        deleteDirContent(path, inf);
+    }
+
+    bool isTrashRoot = false;
+    // special handling for trash:///
+    if(!path.isNative() && g_strcmp0(path.uriScheme().get(), "trash") == 0) {
+        // little trick: basename of trash root is /
+        auto basename = path.baseName();
+        if(basename && basename[0] == G_DIR_SEPARATOR) {
+            isTrashRoot = true;
+        }
+    }
+
+    bool hasError = false;
+    while(!isCancelled()) {
+        GErrorPtr err;
+        // try to delete the path directly (but don't delete if it's trash:///)
+        if(isTrashRoot || g_file_delete(path.gfile().get(), cancellable().get(), &err)) {
+            break;
+        }
+        if(err) {
+            // FIXME: error handling
+            /* if it's non-empty dir then descent into it then try again */
+            /* trash root gives G_IO_ERROR_PERMISSION_DENIED */
+            if(err.domain() == G_IO_ERROR && err.code() == G_IO_ERROR_NOT_EMPTY) {
+                deleteDirContent(path, inf);
+            }
+            else if(err.domain() == G_IO_ERROR && err.code() == G_IO_ERROR_PERMISSION_DENIED) {
+                /* special case for trash:/// */
+                /* FIXME: is there any better way to handle this? */
+                auto scheme = path.uriScheme();
+                if(g_strcmp0(scheme.get(), "trash") == 0) {
+                    break;
+                }
+            }
+            act = emitError(err, ErrorSeverity::MODERATE);
+            if(act != ErrorAction::RETRY) {
+                hasError = true;
+                break;
+            }
+        }
+    }
+
+    addFinishedAmount(g_file_info_get_size(inf.get()), 1);
+
+    return !hasError;
+}
+
+bool DeleteJob::deleteDirContent(const FilePath& path, GFileInfoPtr inf) {
+    GErrorPtr err;
+    GFileEnumeratorPtr enu {
+        g_file_enumerate_children(path.gfile().get(), defaultGFileInfoQueryAttribs,
+        G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+        cancellable().get(), &err),
+        false
+    };
+    if(!enu) {
+        emitError(err, ErrorSeverity::MODERATE);
+        return false;
+    }
+
+    bool hasError = false;
+    while(!isCancelled()) {
+        inf = GFileInfoPtr{
+            g_file_enumerator_next_file(enu.get(), cancellable().get(), &err),
+            false
+        };
+        if(inf) {
+            auto subPath = path.child(g_file_info_get_name(inf.get()));
+            if(!deleteFile(subPath, inf)) {
+                continue;
+            }
+        }
+        else {
+            if(err) {
+                emitError(err, ErrorSeverity::MODERATE);
+                /* ErrorAction::RETRY is not supported here */
+                hasError = true;
+            }
+            else { /* EOF */
+            }
+            break;
+        }
+    }
+    g_file_enumerator_close(enu.get(), nullptr, nullptr);
+    return !hasError;
+}
+
+
+DeleteJob::DeleteJob(const FilePathList &paths): paths_{paths} {
+    setCalcProgressUsingSize(false);
+}
+
+DeleteJob::DeleteJob(FilePathList &&paths): paths_{paths} {
+    setCalcProgressUsingSize(false);
+}
+
+DeleteJob::~DeleteJob() {
+}
+
+void DeleteJob::exec() {
+    /* prepare the job, count total work needed with FmDeepCountJob */
+    TotalSizeJob totalSizeJob{paths_, TotalSizeJob::Flags::PREPARE_DELETE};
+    connect(&totalSizeJob, &TotalSizeJob::error, this, &DeleteJob::error);
+    connect(this, &DeleteJob::cancelled, &totalSizeJob, &TotalSizeJob::cancel);
+    totalSizeJob.run();
+
+    if(isCancelled()) {
+        return;
+    }
+
+    setTotalAmount(totalSizeJob.totalSize(), totalSizeJob.fileCount());
+    Q_EMIT preparedToRun();
+
+    for(auto& path : paths_) {
+        if(isCancelled()) {
+            break;
+        }
+        deleteFile(path, GFileInfoPtr{nullptr});
+    }
+}
+
+} // namespace Fm

--- a/libfm-qt/core/deletejob.h
+++ b/libfm-qt/core/deletejob.h
@@ -1,0 +1,33 @@
+#ifndef FM2_DELETEJOB_H
+#define FM2_DELETEJOB_H
+
+#include "../libfmqtglobals.h"
+#include "fileoperationjob.h"
+#include "filepath.h"
+#include "gioptrs.h"
+
+namespace Fm {
+
+class LIBFM_QT_API DeleteJob : public Fm::FileOperationJob {
+    Q_OBJECT
+public:
+    explicit DeleteJob(const FilePathList& paths);
+
+    explicit DeleteJob(FilePathList&& paths);
+
+    ~DeleteJob() override;
+
+protected:
+    void exec() override;
+
+private:
+    bool deleteFile(const FilePath& path, GFileInfoPtr inf);
+    bool deleteDirContent(const FilePath& path, GFileInfoPtr inf);
+
+private:
+    FilePathList paths_;
+};
+
+} // namespace Fm
+
+#endif // FM2_DELETEJOB_H

--- a/libfm-qt/core/dirlistjob.cpp
+++ b/libfm-qt/core/dirlistjob.cpp
@@ -1,0 +1,177 @@
+#include "dirlistjob.h"
+#include <gio/gio.h>
+#include "fileinfo_p.h"
+#include "gioptrs.h"
+#include <QDebug>
+
+namespace Fm {
+
+DirListJob::DirListJob(const FilePath& path, Flags _flags):
+    dir_path{path}, flags{_flags} {
+}
+
+void DirListJob::exec() {
+    GErrorPtr err;
+    GFileInfoPtr dir_inf;
+    GFilePtr dir_gfile = dir_path.gfile();
+    // FIXME: these are hacks for search:/// URI implemented by libfm which contains some bugs
+    bool isFileSearch = dir_path.hasUriScheme("search");
+    if(isFileSearch) {
+        // NOTE: The GFile instance changes its URI during file enumeration (bad design).
+        // So we create a copy here to avoid channging the gfile stored in dir_path.
+        // FIXME: later we should refactor file search and remove this dirty hack.
+        dir_gfile = GFilePtr{g_file_dup(dir_gfile.get())};
+    }
+_retry:
+    err.reset();
+    dir_inf = GFileInfoPtr{
+        g_file_query_info(dir_gfile.get(), defaultGFileInfoQueryAttribs,
+                          G_FILE_QUERY_INFO_NONE, cancellable().get(), &err),
+        false
+    };
+    if(!dir_inf) {
+        ErrorAction act = emitError(err, err.domain() == G_IO_ERROR && err.code() == G_IO_ERROR_CANCELLED
+                                         ? ErrorSeverity::MILD // may happen with MTP
+                                         : ErrorSeverity::MODERATE);
+        if(act == ErrorAction::RETRY) {
+            err.reset();
+            goto _retry;
+        }
+        return;
+    }
+
+    if(g_file_info_get_file_type(dir_inf.get()) != G_FILE_TYPE_DIRECTORY) {
+        auto path_str = dir_path.toString();
+        err = GErrorPtr{
+                G_IO_ERROR,
+                G_IO_ERROR_NOT_DIRECTORY,
+                tr("The specified directory '%1' is not valid").arg(QString::fromUtf8(path_str.get()))
+        };
+        emitError(err, ErrorSeverity::CRITICAL);
+        return;
+    }
+    else {
+        std::lock_guard<std::mutex> lock{mutex_};
+        dir_fi = std::make_shared<FileInfo>(dir_inf, dir_path);
+    }
+
+    FileInfoList foundFiles;
+    /* check if FS is R/O and set attr. into inf */
+    // FIXME:  _fm_file_info_job_update_fs_readonly(gf, inf, nullptr, nullptr);
+    err.reset();
+    GFileEnumeratorPtr enu = GFileEnumeratorPtr{
+            g_file_enumerate_children(dir_gfile.get(), defaultGFileInfoQueryAttribs,
+                                      G_FILE_QUERY_INFO_NONE, cancellable().get(), &err),
+            false
+    };
+    if(enu) {
+        // qDebug() << "START LISTING:" << dir_path.toString().get();
+        while(!isCancelled()) {
+            err.reset();
+            GFileInfoPtr inf{g_file_enumerator_next_file(enu.get(), cancellable().get(), &err), false};
+            if(inf) {
+#if 0
+                FmPath* dir, *sub;
+                GFile* child;
+                if(G_UNLIKELY(job->flags & FM_DIR_LIST_JOB_DIR_ONLY)) {
+                    /* FIXME: handle symlinks */
+                    if(g_file_info_get_file_type(inf) != G_FILE_TYPE_DIRECTORY) {
+                        g_object_unref(inf);
+                        continue;
+                    }
+                }
+#endif
+                // virtual folders may return children not within them
+                // For example: the search:/// URI implemented by libfm might return files from different folders during enumeration.
+                // So here we call g_file_enumerator_get_container() to get the real parent path rather than simply using dir_path.
+                // This is not the behaviour of gio, but the extensions by libfm might do this.
+                // FIXME: after we port these vfs implementation from libfm, we can redesign this.
+                FilePath realParentPath = FilePath{g_file_enumerator_get_container(enu.get()), true};
+                if(isFileSearch) { // this is a file sarch job (search:/// URI)
+                    // FIXME: redesign file search and remove this dirty hack
+                    // the libfm implementation of search:/// URI returns a customized GFile implementation that does not behave normally.
+                    // let's get its actual URI and re-create a normal gio GFile instance from it.
+                    realParentPath = FilePath::fromUri(realParentPath.uri().get());
+                }
+#if 0
+                if(g_file_info_get_file_type(inf) == G_FILE_TYPE_DIRECTORY)
+                    /* for dir: check if its FS is R/O and set attr. into inf */
+                {
+                    _fm_file_info_job_update_fs_readonly(child, inf, nullptr, nullptr);
+                }
+                fi = fm_file_info_new_from_g_file_data(child, inf, sub);
+#endif
+                auto fileInfo = std::make_shared<FileInfo>(inf, FilePath(), realParentPath);
+                if(emit_files_found) {
+                    // Q_EMIT filesFound();
+                }
+
+                foundFiles.push_back(std::move(fileInfo));
+            }
+            else {
+                if(err) {
+                    ErrorAction act = emitError(err, ErrorSeverity::MILD);
+                    /* ErrorAction::RETRY is not supported. */
+                    if(act == ErrorAction::ABORT) {
+                        cancel();
+                    }
+                }
+                /* otherwise it's EOL */
+                break;
+            }
+        }
+        err.reset();
+        g_file_enumerator_close(enu.get(), cancellable().get(), &err);
+    }
+    else {
+        emitError(err, err.domain() == G_IO_ERROR && err.code() == G_IO_ERROR_CANCELLED
+                       ? ErrorSeverity::MILD // may happen at Folder::reload()
+                       : ErrorSeverity::CRITICAL);
+    }
+
+    // qDebug() << "END LISTING:" << dir_path.toString().get();
+    if(!foundFiles.empty()) {
+        std::lock_guard<std::mutex> lock{mutex_};
+        files_.swap(foundFiles);
+    }
+}
+
+#if 0
+//FIXME: incremental..
+
+static gboolean emit_found_files(gpointer user_data) {
+    /* this callback is called from the main thread */
+    FmDirListJob* job = FM_DIR_LIST_JOB(user_data);
+    /* g_print("emit_found_files: %d\n", g_slist_length(job->files_to_add)); */
+
+    if(g_source_is_destroyed(g_main_current_source())) {
+        return FALSE;
+    }
+    g_signal_emit(job, signals[FILES_FOUND], 0, job->files_to_add);
+    g_slist_free_full(job->files_to_add, (GDestroyNotify)fm_file_info_unref);
+    job->files_to_add = nullptr;
+    job->delay_add_files_handler = 0;
+    return FALSE;
+}
+
+static gpointer queue_add_file(FmJob* fmjob, gpointer user_data) {
+    FmDirListJob* job = FM_DIR_LIST_JOB(fmjob);
+    FmFileInfo* file = FM_FILE_INFO(user_data);
+    /* this callback is called from the main thread */
+    /* g_print("queue_add_file: %s\n", fm_file_info_get_disp_name(file)); */
+    job->files_to_add = g_slist_prepend(job->files_to_add, fm_file_info_ref(file));
+    if(job->delay_add_files_handler == 0)
+        job->delay_add_files_handler = g_timeout_add_seconds_full(G_PRIORITY_LOW,
+                                       1, emit_found_files, g_object_ref(job), g_object_unref);
+    return nullptr;
+}
+
+void fm_dir_list_job_add_found_file(FmDirListJob* job, FmFileInfo* file) {
+    fm_file_info_list_push_tail(job->files, file);
+    if(G_UNLIKELY(job->emit_files_found)) {
+        fm_job_call_main_thread(FM_JOB(job), queue_add_file, file);
+    }
+}
+#endif
+
+} // namespace Fm

--- a/libfm-qt/core/dirlistjob.h
+++ b/libfm-qt/core/dirlistjob.h
@@ -1,0 +1,64 @@
+#ifndef FM2_DIRLISTJOB_H
+#define FM2_DIRLISTJOB_H
+
+#include "../libfmqtglobals.h"
+#include <mutex>
+#include "job.h"
+#include "filepath.h"
+#include "gobjectptr.h"
+#include "fileinfo.h"
+
+namespace Fm {
+
+class LIBFM_QT_API DirListJob : public Job {
+    Q_OBJECT
+public:
+    enum Flags {
+        FAST = 0,
+        DIR_ONLY = 1 << 0,
+        DETAILED = 1 << 1
+    };
+
+    explicit DirListJob(const FilePath& path, Flags flags);
+
+    FileInfoList& files() {
+        return files_;
+    }
+
+    void setIncremental(bool set);
+
+    bool incremental() const {
+        return emit_files_found;
+    }
+
+    FilePath dirPath() const {
+        std::lock_guard<std::mutex> lock{mutex_};
+        return dir_path;
+    }
+
+    std::shared_ptr<const FileInfo> dirInfo() const {
+        std::lock_guard<std::mutex> lock{mutex_};
+        return dir_fi;
+    }
+
+Q_SIGNALS:
+    void filesFound(FileInfoList& foundFiles);
+
+protected:
+
+    void exec() override;
+
+private:
+    mutable std::mutex mutex_;
+    FilePath dir_path;
+    Flags flags;
+    std::shared_ptr<const FileInfo> dir_fi;
+    FileInfoList files_;
+    bool emit_files_found;
+    // guint delay_add_files_handler;
+    // GSList* files_to_add;
+};
+
+} // namespace Fm
+
+#endif // FM2_DIRLISTJOB_H

--- a/libfm-qt/core/filechangeattrjob.cpp
+++ b/libfm-qt/core/filechangeattrjob.cpp
@@ -1,0 +1,324 @@
+#include "filechangeattrjob.h"
+#include "totalsizejob.h"
+
+#include <sys/stat.h>
+
+namespace Fm {
+
+static const char query[] =  G_FILE_ATTRIBUTE_STANDARD_TYPE","
+                             G_FILE_ATTRIBUTE_STANDARD_NAME","
+                             G_FILE_ATTRIBUTE_UNIX_GID","
+                             G_FILE_ATTRIBUTE_UNIX_UID","
+                             G_FILE_ATTRIBUTE_UNIX_MODE","
+                             G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME;
+
+FileChangeAttrJob::FileChangeAttrJob(FilePathList paths):
+    paths_{std::move(paths)},
+    recursive_{false},
+    // chmod
+    fileModeEnabled_{false},
+    newMode_{0},
+    newModeMask_{0},
+    // chown
+    ownerEnabled_{false},
+    uid_{0},
+    groupEnabled_{false},
+    gid_{0},
+    // Display name
+    displayNameEnabled_{false},
+    // icon
+    iconEnabled_{false},
+    // hidden
+    hiddenEnabled_{false},
+    hidden_{false},
+    // target uri
+    targetUriEnabled_{false} {
+
+    // the progress of chmod/chown is not related to file size
+    setCalcProgressUsingSize(false);
+}
+
+void FileChangeAttrJob::exec() {
+    // count total amount of the work
+    if(recursive_) {
+        TotalSizeJob totalSizeJob{paths_};
+        connect(&totalSizeJob, &TotalSizeJob::error, this, &FileChangeAttrJob::error);
+        connect(this, &FileChangeAttrJob::cancelled, &totalSizeJob, &TotalSizeJob::cancel);
+        totalSizeJob.run();
+        std::uint64_t totalSize, totalCount;
+        totalSizeJob.totalAmount(totalSize, totalCount);
+        setTotalAmount(totalSize, totalCount);
+    }
+    else {
+        setTotalAmount(paths_.size(), paths_.size());
+    }
+
+    // ready to start
+    Q_EMIT preparedToRun();
+
+    // do the actual change attrs job
+    for(auto& path : paths_) {
+        if(isCancelled()) {
+            break;
+        }
+        GErrorPtr err;
+        GFileInfoPtr info{
+            g_file_query_info(path.gfile().get(), query,
+                              G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+                              cancellable().get(), &err),
+            false
+        };
+        if(info) {
+            processFile(path, info);
+        }
+        else {
+            handleError(err, path, info);
+        }
+    }
+}
+
+bool FileChangeAttrJob::processFile(const FilePath& path, const GFileInfoPtr& info) {
+    setCurrentFile(path);
+    bool ret = true;
+
+    if(ownerEnabled_) {
+        changeFileOwner(path, info, uid_);
+    }
+    if(groupEnabled_) {
+        changeFileGroup(path, info, gid_);
+    }
+    if(fileModeEnabled_) {
+        changeFileMode(path, info, newMode_, newModeMask_);
+    }
+    /* change display name, icon, hidden, target */
+    if(displayNameEnabled_ && !displayName().empty()) {
+        changeFileDisplayName(path, info, displayName_.c_str());
+    }
+    if(iconEnabled_ && icon_) {
+        changeFileIcon(path, info, icon_);
+    }
+    if(hiddenEnabled_) {
+        changeFileHidden(path, info, hidden_);
+    }
+    if(targetUriEnabled_ && !targetUri_.empty()) {
+        changeFileTargetUri(path, info, targetUri_.c_str());
+    }
+
+    // FIXME: do not use size 1 here.
+    addFinishedAmount(1, 1);
+
+    // recursively apply to subfolders
+    auto type = g_file_info_get_file_type(info.get());
+    if(!isCancelled() && recursive_ && type == G_FILE_TYPE_DIRECTORY) {
+        bool retry;
+        do {
+            retry = false;
+            GErrorPtr err;
+            GFileEnumeratorPtr enu{
+                g_file_enumerate_children(path.gfile().get(), query,
+                                            G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+                                            cancellable().get(), &err),
+                false
+            };
+            if(enu) {
+                while(!isCancelled()) {
+                    err.reset();
+                    GFileInfoPtr childInfo{g_file_enumerator_next_file(enu.get(), cancellable().get(), &err), false};
+                    if(childInfo) {
+                        auto childPath = path.child(g_file_info_get_name(childInfo.get()));
+                        ret = processFile(childPath, childInfo);
+                        if(!ret) { /* _fm_file_ops_job_change_attr_file() failed */
+                            break;
+                        }
+                    }
+                    else {
+                        if(err) {
+                            handleError(err, path, info, ErrorSeverity::MILD);
+                            retry = false;
+                            /* FM_JOB_RETRY is not supported here */
+                        }
+                        else { /* EOF */
+                            break;
+                        }
+                    }
+                }
+                g_file_enumerator_close(enu.get(), cancellable().get(), nullptr);
+            }
+            else {
+                retry = handleError(err, path, info);
+            }
+        } while(!isCancelled() && retry);
+    }
+    return ret;
+}
+
+bool FileChangeAttrJob::handleError(GErrorPtr &err, const FilePath & /*path*/, const GFileInfoPtr & /*info*/, ErrorSeverity severity) {
+    auto act = emitError(err, severity);
+    if (act == ErrorAction::RETRY) {
+        err.reset();
+        return true;
+    }
+    return false;
+}
+
+bool FileChangeAttrJob::changeFileOwner(const FilePath& path, const GFileInfoPtr& info, uid_t uid) {
+    /* change owner */
+    bool ret = false;
+    bool retry;
+    do {
+        GErrorPtr err;
+        if(!g_file_set_attribute_uint32(path.gfile().get(), G_FILE_ATTRIBUTE_UNIX_UID,
+                                        uid, G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+                                        cancellable().get(), &err)) {
+            retry = handleError(err, path, info, ErrorSeverity::MILD);
+            err.reset();
+        }
+        else {
+            ret = true;
+            retry = false;
+        }
+    } while(retry && !isCancelled());
+    return ret;
+}
+
+bool FileChangeAttrJob::changeFileGroup(const FilePath& path, const GFileInfoPtr& info, gid_t gid) {
+    /* change group */
+    bool ret = false;
+    bool retry;
+    do {
+        GErrorPtr err;
+        if(!g_file_set_attribute_uint32(path.gfile().get(), G_FILE_ATTRIBUTE_UNIX_GID,
+                                        gid, G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+                                        cancellable().get(), &err)) {
+            retry = handleError(err, path, info, ErrorSeverity::MILD);
+            err.reset();
+        }
+        else {
+            ret = true;
+            retry = false;
+        }
+    } while(retry && !isCancelled());
+    return ret;
+}
+
+bool FileChangeAttrJob::changeFileMode(const FilePath& path, const GFileInfoPtr& info, mode_t newMode, mode_t newModeMask) {
+    bool ret = false;
+    /* change mode */
+    if(newModeMask) {
+        guint32 mode = g_file_info_get_attribute_uint32(info.get(), G_FILE_ATTRIBUTE_UNIX_MODE);
+        mode &= ~newModeMask;
+        mode |= (newMode & newModeMask);
+
+        auto type = g_file_info_get_file_type(info.get());
+        /* FIXME: this behavior should be optional. */
+        /* treat dirs with 'r' as 'rx' */
+        if(type == G_FILE_TYPE_DIRECTORY) {
+            if((newModeMask & S_IRUSR) && (mode & S_IRUSR)) {
+                mode |= S_IXUSR;
+            }
+            if((newModeMask & S_IRGRP) && (mode & S_IRGRP)) {
+                mode |= S_IXGRP;
+            }
+            if((newModeMask & S_IROTH) && (mode & S_IROTH)) {
+                mode |= S_IXOTH;
+            }
+        }
+
+        /* new mode */
+        bool retry;
+        do {
+            GErrorPtr err;
+            if(!g_file_set_attribute_uint32(path.gfile().get(), G_FILE_ATTRIBUTE_UNIX_MODE,
+                                            mode, G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+                                            cancellable().get(), &err)) {
+                retry = handleError(err, path, info, ErrorSeverity::MILD);
+                err.reset();
+            }
+            else {
+                ret = true;
+                retry = false;
+            }
+        } while(retry && !isCancelled());
+    }
+    return ret;
+
+}
+
+bool FileChangeAttrJob::changeFileDisplayName(const FilePath& path, const GFileInfoPtr& info, const char* displayName) {
+    bool ret = false;
+    bool retry;
+    do {
+        GErrorPtr err;
+        if(!g_file_set_display_name(path.gfile().get(), displayName, cancellable().get(), &err)) {
+            retry = handleError(err, path, info, ErrorSeverity::MILD);
+            err.reset();
+        }
+        else {
+            ret = true;
+            retry = false;
+        }
+    } while(retry && !isCancelled());
+    return ret;
+}
+
+bool FileChangeAttrJob::changeFileIcon(const FilePath& path, const GFileInfoPtr& info, GIconPtr& icon) {
+    bool ret = false;
+    bool retry;
+    do {
+        GErrorPtr err;
+        if(!g_file_set_attribute(path.gfile().get(), G_FILE_ATTRIBUTE_STANDARD_ICON,
+                                 G_FILE_ATTRIBUTE_TYPE_OBJECT, icon.get(),
+                                 G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+                                 cancellable().get(), &err)) {
+            retry = handleError(err, path, info, ErrorSeverity::MILD);
+            err.reset();
+        }
+        else {
+            ret = true;
+            retry = false;
+        }
+    } while(retry && !isCancelled());
+    return ret;
+}
+
+bool FileChangeAttrJob::changeFileHidden(const FilePath& path, const GFileInfoPtr& info, bool hidden) {
+    bool ret = false;
+    bool retry;
+    do {
+        GErrorPtr err;
+        gboolean g_hidden = hidden;
+        if(!g_file_set_attribute(path.gfile().get(), G_FILE_ATTRIBUTE_STANDARD_IS_HIDDEN,
+                                 G_FILE_ATTRIBUTE_TYPE_BOOLEAN, &g_hidden,
+                                 G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+                                 cancellable().get(), &err)) {
+            retry = handleError(err, path, info, ErrorSeverity::MILD);
+            err.reset();
+        }
+        else {
+            ret = true;
+            retry = false;
+        }
+    } while(retry && !isCancelled());
+    return ret;
+}
+
+bool FileChangeAttrJob::changeFileTargetUri(const FilePath& path, const GFileInfoPtr& info, const char* targetUri) {
+    bool ret = false;
+    bool retry;
+    do {
+        GErrorPtr err;
+        if(!g_file_set_attribute_string(path.gfile().get(), G_FILE_ATTRIBUTE_STANDARD_TARGET_URI,
+                                        targetUri, G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+                                        cancellable().get(), &err)) {
+            retry = handleError(err, path, info, ErrorSeverity::MILD);
+            err.reset();
+        }
+        else {
+            ret = true;
+            retry = false;
+        }
+    } while(retry && !isCancelled());
+    return ret;
+}
+
+} // namespace Fm

--- a/libfm-qt/core/filechangeattrjob.h
+++ b/libfm-qt/core/filechangeattrjob.h
@@ -1,0 +1,145 @@
+#ifndef FM2_FILECHANGEATTRJOB_H
+#define FM2_FILECHANGEATTRJOB_H
+
+#include "../libfmqtglobals.h"
+#include "fileoperationjob.h"
+#include "gioptrs.h"
+
+#include <string>
+
+#include <sys/types.h>
+
+namespace Fm {
+
+class LIBFM_QT_API FileChangeAttrJob : public Fm::FileOperationJob {
+    Q_OBJECT
+public:
+    explicit FileChangeAttrJob(FilePathList paths);
+
+    void setFileModeEnabled(bool enabled) {
+        fileModeEnabled_ = enabled;
+    }
+    void setFileMode(mode_t newMode, mode_t newModeMask) {
+        newMode_ = newMode;
+        newModeMask_ = newModeMask;
+    }
+
+    bool ownerEnabled() const {
+        return ownerEnabled_;
+    }
+    void setOwnerEnabled(bool enabled) {
+        ownerEnabled_ = enabled;
+    }
+    void setOwner(uid_t uid) {
+        uid_ = uid;
+    }
+
+    bool groupEnabled() const {
+        return groupEnabled_;
+    }
+    void setGroupEnabled(bool groupEnabled) {
+        groupEnabled_ = groupEnabled;
+    }
+    void setGroup(gid_t gid) {
+        gid_ = gid;
+    }
+
+    // This only work for change attr jobs.
+    void setRecursive(bool recursive) {
+        recursive_ = recursive;
+    }
+
+    void setHiddenEnabled(bool enabled) {
+        hiddenEnabled_ = enabled;
+    }
+    void setHidden(bool hidden) {
+        hidden_ = hidden;
+    }
+
+    bool iconEnabled() const {
+        return iconEnabled_;
+    }
+    void setIconEnabled(bool iconEnabled) {
+        iconEnabled_ = iconEnabled;
+    }
+
+    bool displayNameEnabled() const {
+        return displayNameEnabled_;
+    }
+    void setDisplayNameEnabled(bool displayNameEnabled) {
+        displayNameEnabled_ = displayNameEnabled;
+    }
+
+    const std::string& displayName() const {
+        return displayName_;
+    }
+    void setDisplayName(const std::string& displayName) {
+        displayName_ = displayName;
+    }
+
+    bool targetUriEnabled() const {
+        return targetUriEnabled_;
+    }
+    void setTargetUriEnabled(bool targetUriEnabled) {
+        targetUriEnabled_ = targetUriEnabled;
+    }
+
+    const std::string& targetUri() const {
+        return targetUri_;
+    }
+    void setTargetUri(const std::string& value) {
+        targetUri_ = value;
+    }
+
+
+protected:
+    void exec() override;
+
+private:
+    bool processFile(const FilePath& path, const GFileInfoPtr& info);
+    bool handleError(GErrorPtr& err, const FilePath& path, const GFileInfoPtr& info, ErrorSeverity severity = ErrorSeverity::MODERATE);
+
+    bool changeFileOwner(const FilePath& path, const GFileInfoPtr& info, uid_t uid);
+    bool changeFileGroup(const FilePath& path, const GFileInfoPtr& info, gid_t gid);
+    bool changeFileMode(const FilePath& path, const GFileInfoPtr& info, mode_t newMode, mode_t newModeMask);
+    bool changeFileDisplayName(const FilePath& path, const GFileInfoPtr& info, const char* displayName);
+    bool changeFileIcon(const FilePath& path, const GFileInfoPtr& info, GIconPtr& icon);
+    bool changeFileHidden(const FilePath& path, const GFileInfoPtr& info, bool hidden);
+    bool changeFileTargetUri(const FilePath& path, const GFileInfoPtr& info, const char* targetUri_);
+
+private:
+    FilePathList paths_;
+    bool recursive_;
+
+    // chmod
+    bool fileModeEnabled_;
+    mode_t newMode_;
+    mode_t newModeMask_;
+
+    // chown
+    bool ownerEnabled_;
+    uid_t uid_;
+
+    bool groupEnabled_;
+    gid_t gid_;
+
+    // Display name
+    bool displayNameEnabled_;
+    std::string displayName_;
+
+    // icon
+    bool iconEnabled_;
+    GIconPtr icon_;
+
+    // hidden
+    bool hiddenEnabled_;
+    bool hidden_;
+
+    // target uri
+    bool targetUriEnabled_;
+    std::string targetUri_;
+};
+
+} // namespace Fm
+
+#endif // FM2_FILECHANGEATTRJOB_H

--- a/libfm-qt/core/fileinfo.cpp
+++ b/libfm-qt/core/fileinfo.cpp
@@ -1,0 +1,476 @@
+#include "fileinfo.h"
+#include "fileinfo_p.h"
+#include <gio/gio.h>
+
+#define METADATA_TRUST "metadata::trust"
+
+namespace Fm {
+
+const char defaultGFileInfoQueryAttribs[] = "standard::*,"
+                                            "unix::*,"
+                                            "time::*,"
+                                            "access::*,"
+                                            "trash::deletion-date,"
+                                            "id::filesystem,"
+                                            "metadata::emblems,"
+                                            "mountable::can-mount,"
+                                            "mountable::can-unmount,"
+                                            "mountable::can-eject,"
+                                            METADATA_TRUST;
+
+FileInfo::FileInfo() {
+    // FIXME: initialize numeric data members
+}
+
+FileInfo::FileInfo(const GFileInfoPtr& inf, const FilePath& filePath, const FilePath& parentDirPath) {
+    setFromGFileInfo(inf, filePath, parentDirPath);
+}
+
+FileInfo::~FileInfo() {
+}
+
+void FileInfo::setFromGFileInfo(const GObjectPtr<GFileInfo>& inf, const FilePath& filePath, const FilePath& parentDirPath) {
+    inf_ = inf;
+    filePath_ = filePath;
+    if (filePath_ && filePath_.hasParent()) {
+        dirPath_ = filePath_.parent();
+    }
+    else {
+        dirPath_ = parentDirPath;
+    }
+    const char* tmp, *uri;
+    GIcon* gicon;
+    GFileType type;
+
+    if (const char * name = g_file_info_get_name(inf.get()))
+        name_ = name;
+
+    dispName_ = QString::fromUtf8(g_file_info_get_display_name(inf.get()));
+
+    size_ = g_file_info_get_size(inf.get());
+
+    tmp = g_file_info_get_content_type(inf.get());
+    if(tmp) {
+        mimeType_ = MimeType::fromName(tmp);
+    }
+
+    mode_ = g_file_info_get_attribute_uint32(inf.get(), G_FILE_ATTRIBUTE_UNIX_MODE);
+
+    uid_ = gid_ = -1;
+    if(g_file_info_has_attribute(inf.get(), G_FILE_ATTRIBUTE_UNIX_UID)) {
+        uid_ = g_file_info_get_attribute_uint32(inf.get(), G_FILE_ATTRIBUTE_UNIX_UID);
+    }
+    if(g_file_info_has_attribute(inf.get(), G_FILE_ATTRIBUTE_UNIX_GID)) {
+        gid_ = g_file_info_get_attribute_uint32(inf.get(), G_FILE_ATTRIBUTE_UNIX_GID);
+    }
+
+    type = g_file_info_get_file_type(inf.get());
+    if(0 == mode_) { /* if UNIX file mode is not available, compose a fake one. */
+        switch(type) {
+        case G_FILE_TYPE_REGULAR:
+            mode_ |= S_IFREG;
+            break;
+        case G_FILE_TYPE_DIRECTORY:
+            mode_ |= S_IFDIR;
+            break;
+        case G_FILE_TYPE_SYMBOLIC_LINK:
+            mode_ |= S_IFLNK;
+            break;
+        case G_FILE_TYPE_SHORTCUT:
+            break;
+        case G_FILE_TYPE_MOUNTABLE:
+            break;
+        case G_FILE_TYPE_SPECIAL:
+            if(mode_) {
+                break;
+            }
+            /* if it's a special file but it doesn't have UNIX mode, compose a fake one. */
+            if(strcmp(tmp, "inode/chardevice") == 0) {
+                mode_ |= S_IFCHR;
+            }
+            else if(strcmp(tmp, "inode/blockdevice") == 0) {
+                mode_ |= S_IFBLK;
+            }
+            else if(strcmp(tmp, "inode/fifo") == 0) {
+                mode_ |= S_IFIFO;
+            }
+#ifdef S_IFSOCK
+            else if(strcmp(tmp, "inode/socket") == 0) {
+                mode_ |= S_IFSOCK;
+            }
+#endif
+            break;
+        case G_FILE_TYPE_UNKNOWN:
+            ;
+        }
+    }
+
+    if(g_file_info_has_attribute(inf.get(), G_FILE_ATTRIBUTE_ACCESS_CAN_READ)) {
+        isAccessible_ = g_file_info_get_attribute_boolean(inf.get(), G_FILE_ATTRIBUTE_ACCESS_CAN_READ);
+    }
+    else
+        /* assume it's accessible */
+    {
+        isAccessible_ = true;
+    }
+
+    if(g_file_info_has_attribute(inf.get(), G_FILE_ATTRIBUTE_ACCESS_CAN_WRITE)) {
+        isWritable_ = g_file_info_get_attribute_boolean(inf.get(), G_FILE_ATTRIBUTE_ACCESS_CAN_WRITE);
+    }
+    else
+        /* assume it's writable */
+    {
+        isWritable_ = true;
+    }
+
+    if(g_file_info_has_attribute(inf.get(), G_FILE_ATTRIBUTE_ACCESS_CAN_DELETE)) {
+        isDeletable_ = g_file_info_get_attribute_boolean(inf.get(), G_FILE_ATTRIBUTE_ACCESS_CAN_DELETE);
+    }
+    else
+        /* assume it's deletable */
+    {
+        isDeletable_ = true;
+    }
+
+    isShortcut_ = (type == G_FILE_TYPE_SHORTCUT);
+    isMountable_ = (type == G_FILE_TYPE_MOUNTABLE);
+
+    canMount_ = canUnmount_ = canEject_ = false;
+    if(isMountable_) {
+        if(g_file_info_has_attribute(inf.get(), G_FILE_ATTRIBUTE_MOUNTABLE_CAN_MOUNT)) {
+            canMount_ = g_file_info_get_attribute_boolean(inf.get(), G_FILE_ATTRIBUTE_MOUNTABLE_CAN_MOUNT);
+        }
+
+        if(g_file_info_has_attribute(inf.get(), G_FILE_ATTRIBUTE_MOUNTABLE_CAN_UNMOUNT)) {
+            canUnmount_ = g_file_info_get_attribute_boolean(inf.get(), G_FILE_ATTRIBUTE_MOUNTABLE_CAN_UNMOUNT);
+        }
+
+        if(g_file_info_has_attribute(inf.get(), G_FILE_ATTRIBUTE_MOUNTABLE_CAN_EJECT)) {
+            canEject_ = g_file_info_get_attribute_boolean(inf.get(), G_FILE_ATTRIBUTE_MOUNTABLE_CAN_EJECT);
+        }
+    }
+
+    /* special handling for symlinks */
+    if(g_file_info_get_is_symlink(inf.get())) {
+        mode_ &= ~S_IFMT; /* reset type */
+        mode_ |= S_IFLNK; /* set type to symlink */
+        goto _file_is_symlink;
+    }
+
+    switch(type) {
+    case G_FILE_TYPE_SHORTCUT:
+    /* Falls through. */
+    case G_FILE_TYPE_MOUNTABLE:
+        uri = g_file_info_get_attribute_string(inf.get(), G_FILE_ATTRIBUTE_STANDARD_TARGET_URI);
+        if(uri) {
+            if(g_str_has_prefix(uri, "file:///")) {
+                auto filename = CStrPtr{g_filename_from_uri(uri, nullptr, nullptr)};
+                target_ = filename.get();
+            }
+            else {
+                target_ = uri;
+            }
+            if(!mimeType_) {
+                mimeType_ = MimeType::guessFromFileName(target_.c_str());
+            }
+        }
+
+        /* if the mime-type is not determined or is unknown */
+        if(G_UNLIKELY(!mimeType_ || mimeType_->isUnknownType())) {
+            /* FIXME: is this appropriate? */
+            if(type == G_FILE_TYPE_SHORTCUT) {
+                mimeType_ = MimeType::inodeShortcut();
+            }
+            else {
+                mimeType_ = MimeType::inodeMountPoint();
+            }
+        }
+        break;
+    case G_FILE_TYPE_DIRECTORY:
+        if(!mimeType_) {
+            mimeType_ = MimeType::inodeDirectory();
+        }
+        isReadOnly_ = false; /* default is R/W */
+        if(g_file_info_has_attribute(inf.get(), G_FILE_ATTRIBUTE_FILESYSTEM_READONLY)) {
+            isReadOnly_ = g_file_info_get_attribute_boolean(inf.get(), G_FILE_ATTRIBUTE_FILESYSTEM_READONLY);
+        }
+        /* directories should be writable to be deleted by user */
+        if(isReadOnly_ || !isWritable_) {
+            isDeletable_ = false;
+        }
+        break;
+    case G_FILE_TYPE_SYMBOLIC_LINK:
+_file_is_symlink:
+        uri = g_file_info_get_symlink_target(inf.get());
+        if(uri) {
+            if(g_str_has_prefix(uri, "file:///")) {
+                auto filename = CStrPtr{g_filename_from_uri(uri, nullptr, nullptr)};
+                target_ = filename.get();
+            }
+            else {
+                target_ = uri;
+            }
+            if(!mimeType_) {
+                mimeType_ = MimeType::guessFromFileName(target_.c_str());
+            }
+        }
+    /* Falls through. */
+    /* continue with absent mime type */
+    default: /* G_FILE_TYPE_UNKNOWN G_FILE_TYPE_REGULAR G_FILE_TYPE_SPECIAL */
+        if(G_UNLIKELY(!mimeType_)) {
+            if(!mimeType_) {
+                mimeType_ = MimeType::guessFromFileName(name_.c_str());
+            }
+        }
+    }
+
+    if(!mimeType_) {
+        mimeType_ = MimeType::fromName("application/octet-stream");
+    }
+
+    /* if there is a custom folder icon, use it */
+    if(isNative() && type == G_FILE_TYPE_DIRECTORY) {
+        auto local_path = path().localPath();
+        auto dot_dir = CStrPtr{g_build_filename(local_path.get(), ".directory", nullptr)};
+        if(g_file_test(dot_dir.get(), G_FILE_TEST_IS_REGULAR)) {
+            GKeyFile* kf = g_key_file_new();
+            if(g_key_file_load_from_file(kf, dot_dir.get(), G_KEY_FILE_NONE, nullptr)) {
+                CStrPtr icon_name{g_key_file_get_string(kf, "Desktop Entry", "Icon", nullptr)};
+                if(icon_name) {
+                    auto dot_icon = IconInfo::fromName(icon_name.get());
+                    if(dot_icon && dot_icon->isValid()) {
+                        icon_ = dot_icon;
+                    }
+                }
+            }
+            g_key_file_free(kf);
+        }
+     }
+
+    if(!icon_) {
+        /* try file-specific icon first */
+        gicon = g_file_info_get_icon(inf.get());
+        if(gicon) {
+            icon_ = IconInfo::fromGIcon(gicon);
+        }
+    }
+
+#if 0
+    /* set "locked" icon on unaccesible folder */
+    else if(!accessible && type == G_FILE_TYPE_DIRECTORY) {
+        icon = g_object_ref(icon_locked_folder);
+    }
+    else {
+        icon = g_object_ref(fm_mime_type_get_icon(mime_type));
+    }
+#endif
+
+    /* if the file has emblems, add them to the icon */
+    auto emblem_names = g_file_info_get_attribute_stringv(inf.get(), "metadata::emblems");
+    if(emblem_names) {
+        auto n_emblems = g_strv_length(emblem_names);
+        for(int i = n_emblems - 1; i >= 0; --i) {
+            emblems_.emplace_front(Fm::IconInfo::fromName(emblem_names[i]));
+        }
+    }
+
+    tmp = g_file_info_get_attribute_string(inf.get(), G_FILE_ATTRIBUTE_ID_FILESYSTEM);
+    filesystemId_ = g_intern_string(tmp);
+
+    mtime_ = g_file_info_get_attribute_uint64(inf.get(), G_FILE_ATTRIBUTE_TIME_MODIFIED);
+    atime_ = g_file_info_get_attribute_uint64(inf.get(), G_FILE_ATTRIBUTE_TIME_ACCESS);
+    ctime_ = g_file_info_get_attribute_uint64(inf.get(), G_FILE_ATTRIBUTE_TIME_CHANGED);
+    crtime_ = g_file_info_get_attribute_uint64(inf.get(), G_FILE_ATTRIBUTE_TIME_CREATED);
+    if(auto dt = g_file_info_get_deletion_date(inf.get())){
+        dtime_ = g_date_time_to_unix(dt);
+    }
+    else {
+        dtime_ = 0;
+    }
+    isHidden_ = g_file_info_get_is_hidden(inf.get());
+    // g_file_info_get_is_backup() does not cover ".bak" and ".old".
+    // NOTE: Here, dispName_ is not modified for desktop entries yet.
+    isBackup_ = g_file_info_get_is_backup(inf.get())
+                || dispName_.endsWith(QLatin1String(".bak"))
+                || dispName_.endsWith(QLatin1String(".old"));
+    isNameChangeable_ = true; /* GVFS tends to ignore this attribute */
+    isIconChangeable_ = isHiddenChangeable_ = false;
+    if(g_file_info_has_attribute(inf.get(), G_FILE_ATTRIBUTE_ACCESS_CAN_RENAME)) {
+        isNameChangeable_ = g_file_info_get_attribute_boolean(inf.get(), G_FILE_ATTRIBUTE_ACCESS_CAN_RENAME);
+    }
+
+    // special handling for desktop entry files (show the name and icon defined in the desktop entry instead)
+    if(isNative() && G_UNLIKELY(isDesktopEntry())) {
+        auto local_path = path().localPath();
+        GKeyFile* kf = g_key_file_new();
+        if(g_key_file_load_from_file(kf, local_path.get(), G_KEY_FILE_NONE, nullptr)) {
+            /* check if type is correct and supported */
+            CStrPtr type{g_key_file_get_string(kf, "Desktop Entry", "Type", nullptr)};
+            if(type) {
+                // Type == "Link"
+                if(strcmp(type.get(), G_KEY_FILE_DESKTOP_TYPE_LINK) == 0) {
+                    CStrPtr uri{g_key_file_get_string(kf, G_KEY_FILE_DESKTOP_GROUP, G_KEY_FILE_DESKTOP_KEY_URL, nullptr)};
+                    if(uri) {
+                        isShortcut_ = true;
+                        target_ = uri.get();
+                    }
+                }
+            }
+            CStrPtr icon_name{g_key_file_get_string(kf, "Desktop Entry", "Icon", nullptr)};
+            if(icon_name) {
+                icon_ = IconInfo::fromName(icon_name.get());
+            }
+            /* Use title of the desktop entry for display */
+            CStrPtr displayName{g_key_file_get_locale_string(kf, "Desktop Entry", "Name", nullptr, nullptr)};
+            if(displayName) {
+                dispName_ = QString::fromUtf8(displayName.get());
+            }
+            /* handle 'Hidden' key to set hidden attribute */
+            if(!isHidden_) {
+                isHidden_ = g_key_file_get_boolean(kf, "Desktop Entry", "Hidden", nullptr);
+            }
+        }
+        g_key_file_free(kf);
+    }
+
+    if(!icon_ && mimeType_)
+        icon_ = mimeType_->icon();
+
+#if 0
+    GFile* _gf = nullptr;
+    GFileAttributeInfoList* list;
+    auto list = g_file_query_settable_attributes(gf, nullptr, nullptr);
+    if(G_LIKELY(list)) {
+        if(g_file_attribute_info_list_lookup(list, G_FILE_ATTRIBUTE_STANDARD_ICON)) {
+            icon_is_changeable = true;
+        }
+        if(g_file_attribute_info_list_lookup(list, G_FILE_ATTRIBUTE_STANDARD_IS_HIDDEN)) {
+            hidden_is_changeable = true;
+        }
+        g_file_attribute_info_list_unref(list);
+    }
+    if(G_UNLIKELY(_gf)) {
+        g_object_unref(_gf);
+    }
+#endif
+}
+
+bool FileInfo::canThumbnail() const {
+    /* We cannot use S_ISREG here as this exclude all symlinks */
+    if(size_ == 0 ||  /* don't generate thumbnails for empty files */
+            !(mode_ & S_IFREG) ||
+            isDesktopEntry() ||
+            isUnknownType()) {
+        return false;
+    }
+    return true;
+}
+
+/* full path of the file is required by this function */
+bool FileInfo::isExecutableType() const {
+    if(isDesktopEntry()) {
+        /* treat desktop entries as executables if
+         they are native and have read permission */
+        if(isNative() && (mode_ & (S_IRUSR|S_IRGRP|S_IROTH))) {
+            if(isShortcut() && !target_.empty()) {
+                /* handle shortcuts from desktop to menu entries:
+                   first check for entries in /usr/share/applications and such
+                   which may be considered as a safe desktop entry path
+                   then check if that is a shortcut to a native file
+                   otherwise it is a link to a file under menu:// */
+                if (!g_str_has_prefix(target_.c_str(), "/usr/share/")) {
+                    auto target = FilePath::fromPathStr(target_.c_str());
+                    bool is_native = target.isNative();
+                    if (is_native) {
+                        return true;
+                    }
+                }
+            }
+            else {
+                return true;
+            }
+        }
+        return false;
+    }
+    else if(isText()) { /* g_content_type_can_be_executable reports text files as executables too */
+        /* We don't execute remote files nor files in trash */
+        if(isNative() && (mode_ & (S_IXOTH | S_IXGRP | S_IXUSR))) {
+            /* it has executable bits so lets check shell-bang */
+            auto pathStr = path().toString();
+            int fd = open(pathStr.get(), O_RDONLY);
+            if(fd >= 0) {
+                char buf[2];
+                ssize_t rdlen = read(fd, &buf, 2);
+                close(fd);
+                if(rdlen == 2 && buf[0] == '#' && buf[1] == '!') {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+    return mimeType_->canBeExecutable();
+}
+
+bool FileInfo::isTrustable() const {
+    if(isExecutableType()) {
+        /* to avoid GIO assertion warning: */
+        if(g_file_info_get_attribute_type(inf_.get(), METADATA_TRUST) == G_FILE_ATTRIBUTE_TYPE_STRING) {
+            if(const auto data = g_file_info_get_attribute_string(inf_.get(), METADATA_TRUST)) {
+                return (strcmp(data, "true") == 0);
+            }
+        }
+        return false;
+    }
+    return true;
+}
+
+void FileInfo::setTrustable(bool trust) const {
+    if(!isExecutableType()) {
+        return; // METADATA_TRUST is only for executables
+    }
+    GObjectPtr<GFileInfo> info {g_file_info_new()}; // used to set only this attribute
+    if(trust) {
+        g_file_info_set_attribute_string(info.get(), METADATA_TRUST, "true");
+        g_file_info_set_attribute_string(inf_.get(), METADATA_TRUST, "true");
+    }
+    else {
+        g_file_info_set_attribute(info.get(), METADATA_TRUST, G_FILE_ATTRIBUTE_TYPE_INVALID, nullptr);
+        g_file_info_set_attribute(inf_.get(), METADATA_TRUST, G_FILE_ATTRIBUTE_TYPE_INVALID, nullptr);
+    }
+    g_file_set_attributes_from_info(path().gfile().get(),
+                                    info.get(),
+                                    G_FILE_QUERY_INFO_NONE,
+                                    nullptr, nullptr);
+}
+
+
+bool FileInfoList::isSameType() const {
+    if(!empty()) {
+        auto& item = front();
+        for(auto it = cbegin() + 1; it != cend(); ++it) {
+            auto& item2 = *it;
+            if(item->mimeType() != item2->mimeType()) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool FileInfoList::isSameFilesystem() const {
+    if(!empty()) {
+        auto& item = front();
+        for(auto it = cbegin() + 1; it != cend(); ++it) {
+            auto& item2 = *it;
+            if(item->filesystemId() != item2->filesystemId()) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+
+
+} // namespace Fm

--- a/libfm-qt/core/fileinfo.h
+++ b/libfm-qt/core/fileinfo.h
@@ -1,0 +1,308 @@
+/*
+ * Copyright (C) 2016 Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef __LIBFM_QT_FM2_FILE_INFO_H__
+#define __LIBFM_QT_FM2_FILE_INFO_H__
+
+#include <QObject>
+#include <QtGlobal>
+#include "../libfmqtglobals.h"
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include <vector>
+#include <set>
+#include <utility>
+#include <string>
+#include <forward_list>
+
+#include "gioptrs.h"
+#include "filepath.h"
+#include "iconinfo.h"
+#include "mimetype.h"
+
+
+namespace Fm {
+
+class FileInfoList;
+typedef std::set<unsigned int> HashSet;
+
+class LIBFM_QT_API FileInfo {
+public:
+
+    explicit FileInfo();
+
+    explicit FileInfo(const GFileInfoPtr& inf, const FilePath& filePath, const FilePath& parentDirPath = FilePath());
+
+    virtual ~FileInfo();
+
+    bool canSetHidden() const {
+        return isHiddenChangeable_;
+    }
+
+    bool canSetIcon() const {
+        return isIconChangeable_;
+    }
+
+    bool canSetName() const {
+        return isNameChangeable_;
+    }
+
+    bool canThumbnail() const;
+
+    gid_t gid() const {
+        return gid_;
+    }
+
+    uid_t uid() const {
+        return uid_;
+    }
+
+    const char* filesystemId() const {
+        return filesystemId_;
+    }
+
+    const std::shared_ptr<const IconInfo>& icon() const {
+        return icon_;
+    }
+
+    const std::shared_ptr<const MimeType>& mimeType() const {
+        return mimeType_;
+    }
+
+    quint64 ctime() const {
+        return ctime_;
+    }
+
+    quint64 crtime() const {
+        return crtime_;
+    }
+
+    quint64 atime() const {
+        return atime_;
+    }
+
+    quint64 mtime() const {
+        return mtime_;
+    }
+
+    quint64 dtime() const {
+        return dtime_;
+    }
+    const std::string& target() const {
+        return target_;
+    }
+
+    bool isWritableDirectory() const {
+        return (!isReadOnly_ && isDir());
+    }
+
+    bool isAccessible() const {
+        return isAccessible_;
+    }
+
+    bool isWritable() const {
+        return isWritable_;
+    }
+
+    bool isDeletable() const {
+        return isDeletable_;
+    }
+
+    bool isExecutableType() const;
+
+    bool isBackup() const {
+        return isBackup_;
+    }
+
+    bool isHidden() const {
+        // FIXME: we might treat backup files as hidden
+        return isHidden_;
+    }
+
+    bool isUnknownType() const {
+        return mimeType_->isUnknownType();
+    }
+
+    bool isDesktopEntry() const {
+        return mimeType_->isDesktopEntry();
+    }
+
+    bool isText() const {
+        return mimeType_->isText();
+    }
+
+    bool isImage() const {
+        return mimeType_->isImage();
+    }
+
+    bool isMountable() const {
+        return isMountable_;
+    }
+
+    bool isShortcut() const {
+        return isShortcut_;
+    }
+
+    bool isSymlink() const {
+        return S_ISLNK(mode_) ? true : false;
+    }
+
+    bool isDir() const {
+        return S_ISDIR(mode_) || mimeType_->isDir();
+    }
+
+    bool isNative() const {
+        return dirPath_ ? dirPath_.isNative() : path().isNative();
+    }
+
+    bool canMount() const {
+        return canMount_;
+    }
+
+    bool canUnmount() const {
+        return canUnmount_;
+    }
+
+    bool canEject() const {
+        return canEject_;
+    }
+
+
+    mode_t mode() const {
+        return mode_;
+    }
+
+    uint64_t realSize() const {
+        return blksize_ *blocks_;
+    }
+
+    uint64_t size() const {
+        return size_;
+    }
+
+    const std::string& name() const {
+        return name_;
+    }
+
+    const QString& displayName() const {
+        return dispName_;
+    }
+
+    QString description() const {
+        return QString::fromUtf8(mimeType_ ? mimeType_->desc() : "");
+    }
+
+    FilePath path() const {
+        return filePath_ ? filePath_ : dirPath_ ? dirPath_.child(name_.c_str()) : FilePath::fromPathStr(name_.c_str());
+    }
+
+    const FilePath& dirPath() const {
+        return dirPath_;
+    }
+
+    void setFromGFileInfo(const GFileInfoPtr& inf, const FilePath& filePath, const FilePath& parentDirPath);
+
+    const std::forward_list<std::shared_ptr<const IconInfo>>& emblems() const {
+        return emblems_;
+    }
+
+    bool isTrustable() const;
+
+    void setTrustable(bool trust) const;
+
+    GObjectPtr<GFileInfo> gFileInfo() const {
+        return inf_;
+    }
+
+private:
+    GObjectPtr<GFileInfo> inf_;
+    std::string name_;
+    QString dispName_;
+
+    FilePath filePath_;
+    FilePath dirPath_;
+
+    mode_t mode_;
+    const char* filesystemId_;
+    uid_t uid_;
+    gid_t gid_;
+    uint64_t size_;
+    quint64 mtime_;
+    quint64 atime_;
+    quint64 ctime_;
+    quint64 crtime_;
+    quint64 dtime_;
+
+    uint64_t blksize_;
+    uint64_t blocks_;
+
+    std::shared_ptr<const MimeType> mimeType_;
+    std::shared_ptr<const IconInfo> icon_;
+    std::forward_list<std::shared_ptr<const IconInfo>> emblems_;
+
+    std::string target_; /* target of shortcut or mountable. */
+
+    bool isShortcut_ : 1; /* TRUE if file is shortcut type */
+    bool isMountable_ : 1; /* TRUE if file is mountable type */
+    bool isAccessible_ : 1; /* TRUE if can be read by user */
+    bool isWritable_ : 1; /* TRUE if can be written to by user */
+    bool isDeletable_ : 1; /* TRUE if can be deleted by user */
+    bool isHidden_ : 1; /* TRUE if file is hidden */
+    bool isBackup_ : 1; /* TRUE if file is backup */
+    bool isNameChangeable_ : 1; /* TRUE if name can be changed */
+    bool isIconChangeable_ : 1; /* TRUE if icon can be changed */
+    bool isHiddenChangeable_ : 1; /* TRUE if hidden can be changed */
+    bool isReadOnly_ : 1; /* TRUE if host FS is R/O */
+    bool canMount_ : 1;  /* TRUE if can be mounted */
+    bool canUnmount_ : 1; /* TRUE if can be unmounted */
+    bool canEject_ : 1; /* TRUE if can be ejected */
+};
+
+
+class LIBFM_QT_API FileInfoList: public std::vector<std::shared_ptr<const FileInfo>> {
+public:
+
+    bool isSameType() const;
+
+    bool isSameFilesystem() const;
+
+    FilePathList paths() const {
+        FilePathList ret;
+        for(auto& file: *this) {
+            ret.push_back(file->path());
+        }
+        return ret;
+    }
+};
+
+// smart pointer to FileInfo objects (once created, FileInfo objects should stay immutable so const is needed here)
+typedef std::shared_ptr<const FileInfo> FileInfoPtr;
+
+typedef std::pair<FileInfoPtr, FileInfoPtr> FileInfoPair;
+
+}
+
+Q_DECLARE_METATYPE(std::shared_ptr<const Fm::FileInfo>)
+
+
+#endif // __LIBFM_QT_FM2_FILE_INFO_H__

--- a/libfm-qt/core/fileinfo_p.h
+++ b/libfm-qt/core/fileinfo_p.h
@@ -1,0 +1,10 @@
+#ifndef FILEINFO_P_H
+#define FILEINFO_P_H
+
+namespace Fm {
+
+    extern const char defaultGFileInfoQueryAttribs[];
+
+} // namespace Fm
+
+#endif // FILEINFO_P_H

--- a/libfm-qt/core/fileinfojob.cpp
+++ b/libfm-qt/core/fileinfojob.cpp
@@ -1,0 +1,42 @@
+#include "fileinfojob.h"
+#include "fileinfo_p.h"
+
+namespace Fm {
+
+FileInfoJob::FileInfoJob(FilePathList paths):
+    Job(),
+    paths_{std::move(paths)} {
+}
+
+void FileInfoJob::exec() {
+    for(const auto& path: paths_) {
+        if(isCancelled()) {
+            break;
+        }
+        currentPath_ = path;
+
+        bool retry;
+        do {
+            retry = false;
+            GErrorPtr err;
+            GFileInfoPtr inf{
+                g_file_query_info(path.gfile().get(), defaultGFileInfoQueryAttribs,
+                                  G_FILE_QUERY_INFO_NONE, cancellable().get(), &err),
+                false
+            };
+            if(inf) {
+                auto fileInfoPtr = std::make_shared<FileInfo>(inf, path);
+                results_.push_back(fileInfoPtr);
+                Q_EMIT gotInfo(path, results_.back());
+            }
+            else {
+                auto act = emitError(err);
+                if(act == Job::ErrorAction::RETRY) {
+                    retry = true;
+                }
+            }
+        } while(retry && !isCancelled());
+    }
+}
+
+} // namespace Fm

--- a/libfm-qt/core/fileinfojob.h
+++ b/libfm-qt/core/fileinfojob.h
@@ -1,0 +1,44 @@
+#ifndef FM2_FILEINFOJOB_H
+#define FM2_FILEINFOJOB_H
+
+#include "../libfmqtglobals.h"
+#include "job.h"
+#include "filepath.h"
+#include "fileinfo.h"
+
+namespace Fm {
+
+
+class LIBFM_QT_API FileInfoJob : public Job {
+    Q_OBJECT
+public:
+
+    explicit FileInfoJob(FilePathList paths);
+
+    const FilePathList& paths() const {
+        return paths_;
+    }
+
+    const FileInfoList& files() const {
+        return results_;
+    }
+
+    const FilePath& currentPath() const {
+        return currentPath_;
+    }
+
+Q_SIGNALS:
+    void gotInfo(const FilePath& path, std::shared_ptr<const FileInfo>& info);
+
+protected:
+    void exec() override;
+
+private:
+    FilePathList paths_;
+    FileInfoList results_;
+    FilePath currentPath_;
+};
+
+} // namespace Fm
+
+#endif // FM2_FILEINFOJOB_H

--- a/libfm-qt/core/filelinkjob.cpp
+++ b/libfm-qt/core/filelinkjob.cpp
@@ -1,0 +1,9 @@
+#include "filelinkjob.h"
+
+namespace Fm {
+
+FileLinkJob::FileLinkJob() {
+
+}
+
+} // namespace Fm

--- a/libfm-qt/core/filelinkjob.h
+++ b/libfm-qt/core/filelinkjob.h
@@ -1,0 +1,16 @@
+#ifndef FM2_FILELINKJOB_H
+#define FM2_FILELINKJOB_H
+
+#include "../libfmqtglobals.h"
+#include "fileoperationjob.h"
+
+namespace Fm {
+
+class LIBFM_QT_API FileLinkJob : public Fm::FileOperationJob {
+public:
+    explicit FileLinkJob();
+};
+
+} // namespace Fm
+
+#endif // FM2_FILELINKJOB_H

--- a/libfm-qt/core/filemonitor.cpp
+++ b/libfm-qt/core/filemonitor.cpp
@@ -1,0 +1,9 @@
+#include "filemonitor.h"
+
+namespace Fm {
+
+FileMonitor::FileMonitor() {
+
+}
+
+} // namespace Fm

--- a/libfm-qt/core/filemonitor.h
+++ b/libfm-qt/core/filemonitor.h
@@ -1,0 +1,26 @@
+#ifndef FM2_FILEMONITOR_H
+#define FM2_FILEMONITOR_H
+
+#include "../libfmqtglobals.h"
+#include <QObject>
+#include "gioptrs.h"
+#include "filepath.h"
+
+namespace Fm {
+
+class LIBFM_QT_API FileMonitor: public QObject {
+    Q_OBJECT
+public:
+
+    explicit FileMonitor();
+
+Q_SIGNALS:
+
+
+private:
+    GFileMonitorPtr monitor_;
+};
+
+} // namespace Fm
+
+#endif // FM2_FILEMONITOR_H

--- a/libfm-qt/core/fileoperationjob.cpp
+++ b/libfm-qt/core/fileoperationjob.cpp
@@ -1,0 +1,102 @@
+#include "fileoperationjob.h"
+
+namespace Fm {
+
+FileOperationJob::FileOperationJob():
+    hasTotalAmount_{false},
+    calcProgressUsingSize_{true},
+    totalSize_{0},
+    totalCount_{0},
+    finishedSize_{0},
+    finishedCount_{0},
+    currentFileSize_{0},
+    currentFileFinished_{0} {
+}
+
+bool FileOperationJob::totalAmount(uint64_t& fileSize, uint64_t& fileCount) const {
+    std::lock_guard<std::mutex> lock{mutex_};
+    if(hasTotalAmount_) {
+        fileSize = totalSize_;
+        fileCount = totalCount_;
+    }
+    return hasTotalAmount_;
+}
+
+bool FileOperationJob::currentFileProgress(FilePath& path, uint64_t& totalSize, uint64_t& finishedSize) const {
+    std::lock_guard<std::mutex> lock{mutex_};
+    if(currentFile_.isValid()) {
+        path = currentFile_;
+        totalSize = currentFileSize_;
+        finishedSize = currentFileFinished_;
+    }
+    return currentFile_.isValid();
+}
+
+double FileOperationJob::progress() const {
+    std::lock_guard<std::mutex> lock{mutex_};
+    double finishedRatio;
+    if(calcProgressUsingSize_) {
+        finishedRatio = totalSize_ > 0 ? double(finishedSize_ + currentFileFinished_) / totalSize_ : 0.0;
+    }
+    else {
+        finishedRatio = totalCount_ > 0 ? double(finishedCount_) / totalCount_ : 0.0;
+    }
+
+    if(finishedRatio > 1.0) {
+        finishedRatio = 1.0;
+    }
+    return finishedRatio;
+}
+
+FileOperationJob::FileExistsAction FileOperationJob::askRename(const FileInfo &src, const FileInfo &dest, FilePath &newDest) {
+    FileExistsAction action = SKIP;
+    Q_EMIT fileExists(src, dest, action, newDest);
+    return action;
+}
+
+bool FileOperationJob::finishedAmount(uint64_t& finishedSize, uint64_t& finishedCount) const {
+    std::lock_guard<std::mutex> lock{mutex_};
+    if(hasTotalAmount_) {
+        finishedSize = finishedSize_;
+        finishedCount = finishedCount_;
+    }
+    return hasTotalAmount_;
+}
+
+void FileOperationJob::setTotalAmount(uint64_t fileSize, uint64_t fileCount) {
+    std::lock_guard<std::mutex> lock{mutex_};
+    hasTotalAmount_ = true;
+    totalSize_ = fileSize;
+    totalCount_ = fileCount;
+}
+
+void FileOperationJob::setFinishedAmount(uint64_t finishedSize, uint64_t finishedCount) {
+    std::lock_guard<std::mutex> lock{mutex_};
+    finishedSize_ = finishedSize;
+    finishedCount_ = finishedCount;
+}
+
+void FileOperationJob::addFinishedAmount(uint64_t finishedSize, uint64_t finishedCount) {
+    std::lock_guard<std::mutex> lock{mutex_};
+    finishedSize_ += finishedSize;
+    finishedCount_ += finishedCount;
+}
+
+FilePath FileOperationJob::currentFile() const {
+    std::lock_guard<std::mutex> lock{mutex_};
+    auto ret = currentFile_;
+    return ret;
+}
+
+void FileOperationJob::setCurrentFile(const FilePath& path) {
+    std::lock_guard<std::mutex> lock{mutex_};
+    currentFile_ = path;
+}
+
+void FileOperationJob::setCurrentFileProgress(uint64_t totalSize, uint64_t finishedSize) {
+    std::lock_guard<std::mutex> lock{mutex_};
+    currentFileSize_ = totalSize;
+    currentFileFinished_ = finishedSize;
+}
+
+} // namespace Fm

--- a/libfm-qt/core/fileoperationjob.h
+++ b/libfm-qt/core/fileoperationjob.h
@@ -1,0 +1,96 @@
+#ifndef FM2_FILEOPERATIONJOB_H
+#define FM2_FILEOPERATIONJOB_H
+
+#include "../libfmqtglobals.h"
+#include "job.h"
+#include <string>
+#include <mutex>
+#include <cstdint>
+#include "fileinfo.h"
+#include "filepath.h"
+
+namespace Fm {
+
+class LIBFM_QT_API FileOperationJob : public Fm::Job {
+    Q_OBJECT
+public:
+    enum FileExistsAction {
+        CANCEL = 0,
+        OVERWRITE = 1<<0,
+        RENAME = 1<<1,
+        SKIP = 1<<2,
+        SKIP_ERROR = 1<<3
+    };
+
+    explicit FileOperationJob();
+
+    // get total amount of work to do
+    bool totalAmount(std::uint64_t& fileSize, std::uint64_t& fileCount) const;
+
+    // get currently finished job amount
+    bool finishedAmount(std::uint64_t& finishedSize, std::uint64_t& finishedCount) const;
+
+    // get the current file
+    FilePath currentFile() const;
+
+    // get progress of the current file
+    bool currentFileProgress(FilePath& path, std::uint64_t& totalSize, std::uint64_t& finishedSize) const;
+
+    // is the job calculate progress based on file size or file counts
+    bool calcProgressUsingSize() const {
+        return calcProgressUsingSize_;
+    }
+
+    // get currently finished amount (0.0 to 1.0)
+    virtual double progress() const;
+
+Q_SIGNALS:
+
+    void preparedToRun();
+
+    // void currentFile(const char* file);
+
+    // void progress(uint32_t percent);
+
+    // to correctly handle the signal, connect with Qt::BlockingQueuedConnection so it's a sync call.
+    void fileExists(const FileInfo& src, const FileInfo& dest, FileExistsAction& response, FilePath& newDest);
+
+protected:
+
+    FileExistsAction askRename(const FileInfo& src, const FileInfo& dest, FilePath& newDest);
+
+    void setTotalAmount(std::uint64_t fileSize, std::uint64_t fileCount);
+
+    void setFinishedAmount(std::uint64_t finishedSize, std::uint64_t finishedCount);
+
+    void addFinishedAmount(std::uint64_t finishedSize, std::uint64_t finishedCount);
+
+    void setCurrentFile(const FilePath &path);
+
+    void setCurrentFileProgress(uint64_t totalSize, uint64_t finishedSize);
+
+    void setCalcProgressUsingSize(bool value) {
+        calcProgressUsingSize_ = value;
+    }
+
+    std::mutex& mutex() {
+        return mutex_;
+    }
+
+private:
+    bool hasTotalAmount_;
+    bool calcProgressUsingSize_;
+    std::uint64_t totalSize_;
+    std::uint64_t totalCount_;
+    std::uint64_t finishedSize_;
+    std::uint64_t finishedCount_;
+
+    FilePath currentFile_;
+    std::uint64_t currentFileSize_;
+    std::uint64_t currentFileFinished_;
+    mutable std::mutex mutex_;
+};
+
+} // namespace Fm
+
+#endif // FM2_FILEOPERATIONJOB_H

--- a/libfm-qt/core/filepath.cpp
+++ b/libfm-qt/core/filepath.cpp
@@ -1,0 +1,21 @@
+#include "filepath.h"
+#include <cstdlib>
+#include <utility>
+#include <glib.h>
+
+namespace Fm {
+
+FilePath FilePath::homeDir_;
+
+const FilePath &FilePath::homeDir() {
+    if(!homeDir_) {
+        const char* home = getenv("HOME");
+        if(!home) {
+            home = g_get_home_dir();
+        }
+        homeDir_ = FilePath::fromLocalPath(home);
+    }
+    return homeDir_;
+}
+
+} // namespace Fm

--- a/libfm-qt/core/filepath.h
+++ b/libfm-qt/core/filepath.h
@@ -1,0 +1,177 @@
+#ifndef FM2_FILEPATH_H
+#define FM2_FILEPATH_H
+
+#include "../libfmqtglobals.h"
+#include "gobjectptr.h"
+#include "cstrptr.h"
+#include <gio/gio.h>
+#include <vector>
+#include <QMetaType>
+
+namespace Fm {
+
+class LIBFM_QT_API FilePath {
+public:
+
+    explicit FilePath() {
+    }
+
+    explicit FilePath(GFile* gfile, bool add_ref): gfile_{gfile, add_ref} {
+    }
+
+    FilePath(const FilePath& other): FilePath{} {
+        *this = other;
+    }
+
+    FilePath(FilePath&& other) noexcept: FilePath{} {
+        *this = other;
+    }
+
+    static FilePath fromUri(const char* uri) {
+        return FilePath{g_file_new_for_uri(uri), false};
+    }
+
+    static FilePath fromLocalPath(const char* path) {
+        return FilePath{g_file_new_for_path(path), false};
+    }
+
+    static FilePath fromDisplayName(const char* path) {
+        return FilePath{g_file_parse_name(path), false};
+    }
+
+    static FilePath fromPathStr(const char* path_str) {
+        return FilePath{g_file_new_for_commandline_arg(path_str), false};
+    }
+
+    bool isValid() const {
+        return gfile_ != nullptr;
+    }
+
+    unsigned int hash() const {
+        return g_file_hash(gfile_.get());
+    }
+
+    CStrPtr baseName() const {
+        return CStrPtr{g_file_get_basename(gfile_.get())};
+    }
+
+    CStrPtr localPath() const {
+        return CStrPtr{g_file_get_path(gfile_.get())};
+    }
+
+    CStrPtr uri() const {
+        return CStrPtr{g_file_get_uri(gfile_.get())};
+    }
+
+    CStrPtr toString() const {
+        if(isNative()) {
+            return localPath();
+        }
+        return uri();
+    }
+
+    // a human readable UTF-8 display name for the path
+    CStrPtr displayName() const {
+        return CStrPtr{g_file_get_parse_name(gfile_.get())};
+    }
+
+    FilePath parent() const {
+        return FilePath{g_file_get_parent(gfile_.get()), false};
+    }
+
+    bool hasParent() const {
+        return g_file_has_parent(gfile_.get(), nullptr);
+    }
+
+    bool isParentOf(const FilePath& other) const {
+        return g_file_has_parent(other.gfile_.get(), gfile_.get());
+    }
+
+    bool isPrefixOf(const FilePath& other) const {
+        return g_file_has_prefix(other.gfile_.get(), gfile_.get());
+    }
+
+    FilePath child(const char* name) const {
+        return FilePath{g_file_get_child(gfile_.get(), name), false};
+    }
+
+    CStrPtr relativePathStr(const FilePath& descendant) const {
+        return CStrPtr{g_file_get_relative_path(gfile_.get(), descendant.gfile_.get())};
+    }
+
+    FilePath relativePath(const char* relPath) const {
+        return FilePath{g_file_resolve_relative_path(gfile_.get(), relPath), false};
+    }
+
+    bool isNative() const {
+        return g_file_is_native(gfile_.get());
+    }
+
+    bool hasUriScheme(const char* scheme) const {
+        return g_file_has_uri_scheme(gfile_.get(), scheme);
+    }
+
+    CStrPtr uriScheme() const {
+        return CStrPtr{g_file_get_uri_scheme(gfile_.get())};
+    }
+
+    const GObjectPtr<GFile>& gfile() const {
+        return gfile_;
+    }
+
+    FilePath& operator = (const FilePath& other) {
+        gfile_ = other.gfile_;
+        return *this;
+    }
+
+    FilePath& operator = (const FilePath&& other) noexcept {
+        gfile_ = std::move(other.gfile_);
+        return *this;
+    }
+
+    bool operator == (const FilePath& other) const {
+        return operator==(other.gfile_.get());
+    }
+
+    bool operator == (GFile* other_gfile) const {
+        if(gfile_ == other_gfile) {
+            return true;
+        }
+        if(gfile_ && other_gfile) {
+            return g_file_equal(gfile_.get(), other_gfile);
+        }
+        return false;
+    }
+
+    bool operator != (const FilePath& other) const {
+        return !operator==(other);
+    }
+
+    bool operator != (std::nullptr_t) const {
+        return gfile_ != nullptr;
+    }
+
+    operator bool() const {
+        return gfile_ != nullptr;
+    }
+
+    static const FilePath& homeDir();
+
+private:
+    GObjectPtr<GFile> gfile_;
+    static FilePath homeDir_;
+};
+
+struct FilePathHash {
+    std::size_t operator() (const FilePath& path) const {
+        return path.hash();
+    }
+};
+
+typedef std::vector<FilePath> FilePathList;
+
+} // namespace Fm
+
+Q_DECLARE_METATYPE(Fm::FilePath)
+
+#endif // FM2_FILEPATH_H

--- a/libfm-qt/core/filesysteminfojob.cpp
+++ b/libfm-qt/core/filesysteminfojob.cpp
@@ -1,0 +1,24 @@
+#include "filesysteminfojob.h"
+#include "gobjectptr.h"
+
+namespace Fm {
+
+void FileSystemInfoJob::exec() {
+    GObjectPtr<GFileInfo> inf = GObjectPtr<GFileInfo>{
+            g_file_query_filesystem_info(
+                path_.gfile().get(),
+                G_FILE_ATTRIBUTE_FILESYSTEM_SIZE","
+                G_FILE_ATTRIBUTE_FILESYSTEM_FREE,
+                cancellable().get(), nullptr),
+            false
+    };
+    if(!inf)
+        return;
+    if(g_file_info_has_attribute(inf.get(), G_FILE_ATTRIBUTE_FILESYSTEM_SIZE)) {
+        size_ = g_file_info_get_attribute_uint64(inf.get(), G_FILE_ATTRIBUTE_FILESYSTEM_SIZE);
+        freeSize_ = g_file_info_get_attribute_uint64(inf.get(), G_FILE_ATTRIBUTE_FILESYSTEM_FREE);
+        isAvailable_ = true;
+    }
+}
+
+} // namespace Fm

--- a/libfm-qt/core/filesysteminfojob.h
+++ b/libfm-qt/core/filesysteminfojob.h
@@ -1,0 +1,45 @@
+#ifndef FM2_FILESYSTEMINFOJOB_H
+#define FM2_FILESYSTEMINFOJOB_H
+
+#include "../libfmqtglobals.h"
+#include "job.h"
+#include "filepath.h"
+
+namespace Fm {
+
+class LIBFM_QT_API FileSystemInfoJob : public Job {
+    Q_OBJECT
+public:
+    explicit FileSystemInfoJob(const FilePath& path):
+        path_{path},
+        isAvailable_{false},
+        size_{0},
+        freeSize_{0} {
+    }
+
+    bool isAvailable() const {
+        return isAvailable_;
+    }
+
+    uint64_t size() const {
+        return size_;
+    }
+
+    uint64_t freeSize() const {
+        return freeSize_;
+    }
+
+protected:
+
+    void exec() override;
+
+private:
+    FilePath path_;
+    bool isAvailable_;
+    uint64_t size_;
+    uint64_t freeSize_;
+};
+
+} // namespace Fm
+
+#endif // FM2_FILESYSTEMINFOJOB_H

--- a/libfm-qt/core/filetransferjob.cpp
+++ b/libfm-qt/core/filetransferjob.cpp
@@ -1,0 +1,672 @@
+#include "filetransferjob.h"
+#include "totalsizejob.h"
+#include "fileinfo_p.h"
+
+namespace Fm {
+
+FileTransferJob::FileTransferJob(FilePathList srcPaths, Mode mode):
+    FileOperationJob{},
+    srcPaths_{std::move(srcPaths)},
+    mode_{mode},
+    hasDestDirPath_{false} {
+}
+
+FileTransferJob::FileTransferJob(FilePathList srcPaths, FilePathList destPaths, Mode mode):
+    FileTransferJob{std::move(srcPaths), mode} {
+    destPaths_ = std::move(destPaths);
+}
+
+FileTransferJob::FileTransferJob(FilePathList srcPaths, const FilePath& destDirPath, Mode mode):
+    FileTransferJob{std::move(srcPaths), mode} {
+    hasDestDirPath_ = true;
+    setDestDirPath(destDirPath);
+}
+
+void FileTransferJob::setSrcPaths(FilePathList srcPaths) {
+    srcPaths_ = std::move(srcPaths);
+}
+
+void FileTransferJob::setDestPaths(FilePathList destPaths) {
+    hasDestDirPath_ = false;
+    destPaths_ = std::move(destPaths);
+}
+
+void FileTransferJob::setDestDirPath(const FilePath& destDirPath) {
+    hasDestDirPath_ = true;
+    destPaths_.clear();
+    destPaths_.reserve(srcPaths_.size());
+    for(const auto& srcPath: srcPaths_) {
+        FilePath destPath;
+        if(mode_ == Mode::LINK && !srcPath.isNative()) {
+            // special handling for URLs
+            auto fullBasename = srcPath.baseName();
+            char* basename = fullBasename.get();
+            char* dname = nullptr;
+            // if we drop URI query onto native filesystem, omit query part
+            if(!srcPath.isNative()) {
+                dname = strchr(basename, '?');
+            }
+            // if basename consist only from query then use first part of it
+            if(dname == basename) {
+                basename++;
+                dname = strchr(basename, '&');
+            }
+
+            CStrPtr _basename;
+            if(dname) {
+                _basename = CStrPtr{g_strndup(basename, dname - basename)};
+                dname = strrchr(_basename.get(), G_DIR_SEPARATOR);
+                g_debug("cutting '%s' to '%s'", basename, dname ? &dname[1] : _basename.get());
+                if(dname) {
+                    basename = &dname[1];
+                }
+                else {
+                    basename = _basename.get();
+                }
+            }
+            destPath = destDirPath.child(basename);
+        }
+        else {
+            destPath = destDirPath.child(srcPath.baseName().get());
+        }
+        destPaths_.emplace_back(std::move(destPath));
+    }
+}
+
+void FileTransferJob::gfileCopyProgressCallback(goffset current_num_bytes, goffset total_num_bytes, FileTransferJob* _this) {
+    _this->setCurrentFileProgress(total_num_bytes, current_num_bytes);
+}
+
+bool FileTransferJob::moveFileSameFs(const FilePath& srcPath, const GFileInfoPtr& srcInfo, FilePath& destPath) {
+    int flags = G_FILE_COPY_ALL_METADATA | G_FILE_COPY_NOFOLLOW_SYMLINKS;
+    GErrorPtr err;
+    bool retry;
+    do {
+        retry = false;
+        err.reset();
+        // do the file operation
+        if(!g_file_move(srcPath.gfile().get(), destPath.gfile().get(), GFileCopyFlags(flags), cancellable().get(),
+                       nullptr, this, &err)) {
+            // Specially with mounts bound to /mnt, g_file_move() may give the recursive error
+            // and fail, in which case, we ignore the error and try copying and deleting.
+            if(err.code() == G_IO_ERROR_WOULD_RECURSE) {
+              if(auto parent = destPath.parent()) {
+                  return copyFile(srcPath, srcInfo, parent, destPath.baseName().get());
+              }
+            }
+            retry = handleError(err, srcPath, srcInfo, destPath, flags);
+        }
+        else {
+            return true;
+        }
+    } while(retry && !isCancelled());
+    return false;
+}
+
+bool FileTransferJob::copyRegularFile(const FilePath& srcPath, const GFileInfoPtr& srcInfo, FilePath& destPath) {
+    int flags = G_FILE_COPY_ALL_METADATA | G_FILE_COPY_NOFOLLOW_SYMLINKS;
+    GErrorPtr err;
+    bool retry;
+    do {
+        retry = false;
+        err.reset();
+
+        // reset progress of the current file (only for copy)
+        auto size = g_file_info_get_size(srcInfo.get());
+        setCurrentFileProgress(size, 0);
+
+        // do the file operation
+        if(!g_file_copy(srcPath.gfile().get(), destPath.gfile().get(), GFileCopyFlags(flags), cancellable().get(),
+                       (GFileProgressCallback)&gfileCopyProgressCallback, this, &err)) {
+            retry = handleError(err, srcPath, srcInfo, destPath, flags);
+        }
+        else {
+            return true;
+        }
+    } while(retry && !isCancelled());
+    return false;
+}
+
+bool FileTransferJob::copySpecialFile(const FilePath& srcPath, const GFileInfoPtr& srcInfo, FilePath &destPath) {
+    bool ret = false;
+    // only handle FIFO for local files
+    if(srcPath.isNative() && destPath.isNative()) {
+        auto src_path = srcPath.localPath();
+        struct stat src_st;
+        int r;
+        r = lstat(src_path.get(), &src_st);
+        if(r == 0) {
+            // Handle FIFO on native file systems.
+            if(S_ISFIFO(src_st.st_mode)) {
+                auto dest_path = destPath.localPath();
+                if(mkfifo(dest_path.get(), src_st.st_mode) == 0) {
+                    ret = true;
+                }
+            }
+            // FIXME: how about block device, char device, and socket?
+        }
+    }
+    if(!ret) {
+        GErrorPtr err;
+        g_set_error(&err, G_IO_ERROR, G_IO_ERROR_FAILED,
+                    ("Cannot copy file '%s': not supported"),
+                    g_file_info_get_display_name(srcInfo.get()));
+        emitError(err, ErrorSeverity::MODERATE);
+    }
+    return ret;
+}
+
+bool FileTransferJob::copyDirContent(const FilePath& srcPath, GFileInfoPtr /*srcInfo*/, FilePath& destPath, bool skip) {
+    bool ret = false;
+    // copy dir content
+    GErrorPtr err;
+    auto enu = GFileEnumeratorPtr{
+            g_file_enumerate_children(srcPath.gfile().get(),
+                                      defaultGFileInfoQueryAttribs,
+                                      G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+                                      cancellable().get(), &err),
+            false};
+    if(enu) {
+        int n_children = 0;
+        int n_copied = 0;
+        ret = true;
+        while(!isCancelled()) {
+            err.reset();
+            GFileInfoPtr inf{g_file_enumerator_next_file(enu.get(), cancellable().get(), &err), false};
+            if(inf) {
+                ++n_children;
+                const char* name = g_file_info_get_name(inf.get());
+                FilePath childPath = srcPath.child(name);
+                bool child_ret = copyFile(childPath, inf, destPath, name, skip);
+                if(child_ret) {
+                    ++n_copied;
+                }
+                else {
+                    ret = false;
+                }
+            }
+            else {
+                if(err) {
+                    // fail to read directory content
+                    // NOTE: since we cannot read the source dir, we cannot calculate the progress correctly, either.
+                    emitError(err, ErrorSeverity::MODERATE);
+                    err.reset();
+                    /* ErrorAction::RETRY is not supported here */
+                    ret = false;
+                }
+                else { /* EOF is reached */
+                    /* all files are successfully copied. */
+                    if(isCancelled()) {
+                        ret = false;
+                    }
+                    else {
+                        /* some files are not copied */
+                        if(n_children != n_copied) {
+                            /* if the copy actions are skipped deliberately, it's ok */
+                            if(!skip) {
+                                ret = false;
+                            }
+                        }
+                        /* else job->skip_dir_content is true */
+                    }
+                    break;
+                }
+            }
+        }
+        g_file_enumerator_close(enu.get(), nullptr, &err);
+    }
+    else {
+        if(err) {
+            emitError(err, ErrorSeverity::MODERATE);
+        }
+    }
+    return ret;
+}
+
+bool FileTransferJob::makeDir(const FilePath& srcPath, GFileInfoPtr srcInfo, FilePath& destPath) {
+    if(isCancelled()) {
+        return false;
+    }
+
+    bool mkdir_done = false;
+    do {
+        GErrorPtr err;
+        mkdir_done = g_file_make_directory_with_parents(destPath.gfile().get(), cancellable().get(), &err);
+        if(!mkdir_done) {
+            if(err->domain == G_IO_ERROR && (err->code == G_IO_ERROR_EXISTS ||
+                                             err->code == G_IO_ERROR_INVALID_FILENAME ||
+                                             err->code == G_IO_ERROR_FILENAME_TOO_LONG)) {
+                GFileInfoPtr destInfo = GFileInfoPtr {
+                    g_file_query_info(destPath.gfile().get(),
+                    defaultGFileInfoQueryAttribs,
+                    G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+                    cancellable().get(), nullptr),
+                    false
+                };
+                if(!destInfo) {
+                    // FIXME: error handling
+                    break;
+                }
+
+                FilePath newDestPath;
+                FileExistsAction opt = askRename(FileInfo{srcInfo, srcPath}, FileInfo{destInfo, destPath}, newDestPath);
+                switch(opt) {
+                case FileOperationJob::RENAME:
+                    destPath = std::move(newDestPath);
+                    break;
+                case FileOperationJob::SKIP:
+                    /* when a dir is skipped, we need to know its total size to calculate correct progress */
+                    mkdir_done = true; /* pretend that dir creation succeeded */
+                    break;
+                case FileOperationJob::OVERWRITE:
+                    mkdir_done = true; /* pretend that dir creation succeeded */
+                    break;
+                case FileOperationJob::CANCEL:
+                    cancel();
+                    return false;
+                case FileOperationJob::SKIP_ERROR: ; /* FIXME */
+                }
+            }
+            else {
+                ErrorAction act = emitError(err, ErrorSeverity::MODERATE);
+                if(act != ErrorAction::RETRY) {
+                    break;
+                }
+            }
+        }
+    } while(!mkdir_done && !isCancelled());
+
+    bool chmod_done = false;
+    if(mkdir_done && !isCancelled()) {
+        mode_t mode = g_file_info_get_attribute_uint32(srcInfo.get(), G_FILE_ATTRIBUTE_UNIX_MODE);
+        if(mode) {
+            mode |= (S_IRUSR | S_IWUSR); /* ensure we have rw permission to this file. */
+            do {
+                GErrorPtr err;
+                // chmod the newly created dir properly
+                // if(!fm_job_is_cancelled(fmjob) && !job->skip_dir_content)
+                chmod_done = g_file_set_attribute_uint32(destPath.gfile().get(),
+                                                         G_FILE_ATTRIBUTE_UNIX_MODE,
+                                                         mode, G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+                                                         cancellable().get(), &err);
+                if(!chmod_done) {
+                    /* NOTE: Some filesystems may not support this. So, ignore errors for now. */
+                    break;
+                    /*ErrorAction act = emitError(err, ErrorSeverity::MODERATE);
+                    if(act != ErrorAction::RETRY) {
+                        break;
+                    }*/
+                }
+            } while(!chmod_done && !isCancelled());
+        }
+    }
+    return mkdir_done/* && chmod_done*/;
+}
+
+bool FileTransferJob::handleError(GErrorPtr &err, const FilePath &srcPath, const GFileInfoPtr &srcInfo, FilePath &destPath, int& flags) {
+    bool retry = false;
+    /* handle existing files or file name conflict */
+    if(err.domain() == G_IO_ERROR && (err.code() == G_IO_ERROR_EXISTS ||
+                                     err.code() == G_IO_ERROR_INVALID_FILENAME ||
+                                     err.code() == G_IO_ERROR_FILENAME_TOO_LONG)) {
+        flags &= ~G_FILE_COPY_OVERWRITE;
+
+        // get info of the existing file
+        GFileInfoPtr destInfo = GFileInfoPtr {
+            g_file_query_info(destPath.gfile().get(),
+            defaultGFileInfoQueryAttribs,
+            G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+            cancellable().get(), nullptr),
+            false
+        };
+
+        // ask the user to rename or overwrite the existing file
+        if(!isCancelled() && destInfo) {
+            FilePath newDestPath;
+            FileExistsAction opt = askRename(FileInfo{srcInfo, srcPath},
+                                             FileInfo{destInfo, destPath},
+                                             newDestPath);
+            switch(opt) {
+            case FileOperationJob::RENAME:
+                // try a new file name
+                if(newDestPath.isValid()) {
+                    destPath = std::move(newDestPath);
+                    // FIXME: handle the error when newDestPath is invalid.
+                }
+                retry = true;
+                break;
+            case FileOperationJob::OVERWRITE:
+                // overwrite existing file
+                flags |= G_FILE_COPY_OVERWRITE;
+                retry = true;
+                err.reset();
+                break;
+            case FileOperationJob::CANCEL:
+                // cancel the whole job.
+                cancel();
+                break;
+            case FileOperationJob::SKIP:
+                // skip current file and don't copy it
+            case FileOperationJob::SKIP_ERROR: ; /* FIXME */
+                retry = false;
+                break;
+            }
+            err.reset();
+        }
+    }
+
+    // show error message
+    if(!isCancelled() && err) {
+        ErrorAction act = emitError(err, ErrorSeverity::MODERATE);
+        err.reset();
+        if(act == ErrorAction::RETRY) {
+            // the user wants retry the operation again
+            retry = true;
+        }
+        const bool is_no_space = (err.domain() == G_IO_ERROR && err.code() == G_IO_ERROR_NO_SPACE);
+        /* FIXME: ask to leave partial content? */
+        if(is_no_space) {
+            // run out of disk space. delete the partial content we copied.
+            g_file_delete(destPath.gfile().get(), cancellable().get(), nullptr);
+        }
+    }
+    return retry;
+}
+
+bool FileTransferJob::processPath(const FilePath& srcPath, const FilePath& destDirPath, const char* destFileName) {
+    GErrorPtr err;
+    GFileInfoPtr srcInfo = GFileInfoPtr {
+        g_file_query_info(srcPath.gfile().get(),
+        defaultGFileInfoQueryAttribs,
+        G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+        cancellable().get(), &err),
+        false
+    };
+    if(!srcInfo || isCancelled()) {
+        // FIXME: report error
+        return false;
+    }
+
+    // Use GIO's copy name for destination if existing. This is especially good for copying
+    // from another file system or from places like recent:/// and also handles encoding.
+    const char* destCopyName = g_file_info_get_attribute_string(srcInfo.get(), "standard::copy-name");
+
+    bool ret;
+    switch(mode_) {
+    case Mode::MOVE:
+        ret = moveFile(srcPath, srcInfo, destDirPath,
+                       hasDestDirPath_ && destCopyName ? destCopyName : destFileName);
+        break;
+    case Mode::COPY: {
+        bool deleteSrc = false;
+        ret = copyFile(srcPath, srcInfo, destDirPath,
+                       hasDestDirPath_ && destCopyName ? destCopyName : destFileName, deleteSrc);
+        break;
+    }
+    case Mode::LINK:
+        ret = linkFile(srcPath, srcInfo, destDirPath,
+                        // see setDestDirPath()
+                        srcPath.isNative() && hasDestDirPath_ &&  destCopyName ? destCopyName : destFileName);
+        break;
+    default:
+        ret = false;
+        break;
+    }
+    return ret;
+}
+
+bool FileTransferJob::moveFile(const FilePath &srcPath, const GFileInfoPtr &srcInfo, const FilePath &destDirPath, const char *destFileName) {
+    setCurrentFile(srcPath);
+
+    GErrorPtr err;
+    GFileInfoPtr destDirInfo = GFileInfoPtr {
+        g_file_query_info(destDirPath.gfile().get(),
+        "id::filesystem",
+        G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+        cancellable().get(), &err),
+        false
+    };
+
+    if(!destDirInfo || isCancelled()) {
+        // FIXME: report errors
+        return false;
+    }
+
+    // If src and dest are on the same filesystem, do move.
+    // Exception: if src FS is trash:///, we always do move
+    // Otherwise, do copy & delete src files.
+    auto src_fs = g_file_info_get_attribute_string(srcInfo.get(), "id::filesystem");
+    auto dest_fs = g_file_info_get_attribute_string(destDirInfo.get(), "id::filesystem");
+    bool ret;
+    if(src_fs && dest_fs && (strcmp(src_fs, dest_fs) == 0 || g_str_has_prefix(src_fs, "trash"))) {
+        // src and dest are on the same filesystem
+        auto destPath = destDirPath.child(destFileName);
+        ret = moveFileSameFs(srcPath, srcInfo, destPath);
+
+        // increase current progress
+        // FIXME: it's not appropriate to calculate the progress of move operations using file size
+        // since the time required to move a file is not related to it's file size.
+        auto size = g_file_info_get_size(srcInfo.get());
+        addFinishedAmount(size, 1);
+    }
+    else {
+        // cross device/filesystem move: copy & delete
+        ret = copyFile(srcPath, srcInfo, destDirPath, destFileName);
+        // NOTE: do not need to increase progress here since it's done by copyPath().
+    }
+    return ret;
+}
+
+bool FileTransferJob::copyFile(const FilePath& srcPath, const GFileInfoPtr& srcInfo, const FilePath& destDirPath, const char* destFileName, bool skip) {
+    setCurrentFile(srcPath);
+
+    auto size = g_file_info_get_size(srcInfo.get());
+    bool success = false;
+    setCurrentFileProgress(size, 0);
+
+    auto destPath = destDirPath.child(destFileName);
+    auto file_type = g_file_info_get_file_type(srcInfo.get());
+    if(!skip) {
+        switch(file_type) {
+        case G_FILE_TYPE_DIRECTORY:
+            // prevent a dir from being copied into itself
+            if(srcPath.isPrefixOf(destPath)) {
+                GErrorPtr err = GErrorPtr{
+                                G_IO_ERROR,
+                                G_IO_ERROR_NOT_SUPPORTED,
+                                tr("Cannot copy a directory into itself!")
+                };
+                emitError(err, ErrorSeverity::MODERATE);
+            }
+            else {
+                success = makeDir(srcPath, srcInfo, destPath);
+            }
+            break;
+        case G_FILE_TYPE_SPECIAL:
+            success = copySpecialFile(srcPath, srcInfo, destPath);
+            break;
+        default:
+            success = copyRegularFile(srcPath, srcInfo, destPath);
+            break;
+        }
+    }
+    else { // skip the file
+        success = true;
+    }
+
+    if(success) {
+        // finish copying the file
+        addFinishedAmount(size, 1);
+        setCurrentFileProgress(0, 0);
+
+        // recursively copy dir content
+        if(file_type == G_FILE_TYPE_DIRECTORY) {
+            success = copyDirContent(srcPath, srcInfo, destPath, skip);
+        }
+
+        if(!skip && success && mode_ == Mode::MOVE) {
+            // delete the source file for cross-filesystem move
+            GErrorPtr err;
+            if(g_file_delete(srcPath.gfile().get(), cancellable().get(), &err)) {
+                // FIXME: add some file size to represent the amount of work need to delete a file
+                addFinishedAmount(1, 1);
+            }
+            else {
+                success = false;
+            }
+        }
+    }
+    return success;
+}
+
+bool FileTransferJob::linkFile(const FilePath &srcPath, const GFileInfoPtr &srcInfo, const FilePath &destDirPath, const char *destFileName) {
+    setCurrentFile(srcPath);
+
+    bool ret = false;
+    // cannot create links on non-native filesystems
+    if(!destDirPath.isNative()) {
+        auto msg = tr("Cannot create a link on non-native filesystem");
+        GErrorPtr err{g_error_new_literal(G_IO_ERROR, G_IO_ERROR_FAILED, msg.toUtf8().constData())};
+        emitError(err, ErrorSeverity::CRITICAL);
+        return false;
+    }
+
+    if(srcPath.isNative()) {
+        // create symlinks for native files
+        auto destPath = destDirPath.child(destFileName);
+        ret = createSymlink(srcPath, srcInfo, destPath);
+    }
+    else {
+        // ensure that the dest file has *.desktop filename extension.
+        CStrPtr desktopEntryFileName{g_strconcat(destFileName, ".desktop", nullptr)};
+        auto destPath = destDirPath.child(desktopEntryFileName.get());
+        ret = createShortcut(srcPath, srcInfo, destPath);
+    }
+
+    // update progress
+    // FIXME: increase the progress by 1 byte is not appropriate
+    addFinishedAmount(1, 1);
+    return ret;
+}
+
+bool FileTransferJob::createSymlink(const FilePath &srcPath, const GFileInfoPtr &srcInfo, FilePath &destPath) {
+    bool ret = false;
+    auto src = srcPath.localPath();
+    int flags = 0;
+    GErrorPtr err;
+    bool retry;
+    do {
+        retry = false;
+        if(flags & G_FILE_COPY_OVERWRITE) {  // overwrite existing file
+            // creating symlink cannot overwrite existing files directly, so we delete the existing file first.
+            g_file_delete(destPath.gfile().get(), cancellable().get(), nullptr);
+        }
+        if(!g_file_make_symbolic_link(destPath.gfile().get(), src.get(), cancellable().get(), &err)) {
+            retry = handleError(err, srcPath, srcInfo, destPath, flags);
+        }
+        else {
+            ret = true;
+            break;
+        }
+    } while(!isCancelled() && retry);
+    return ret;
+}
+
+bool FileTransferJob::createShortcut(const FilePath &srcPath, const GFileInfoPtr &srcInfo, FilePath &destPath) {
+    bool ret = false;
+    const char* iconName = nullptr;
+    GIcon* icon = g_file_info_get_icon(srcInfo.get());
+    if(icon && G_IS_THEMED_ICON(icon)) {
+        auto iconNames = g_themed_icon_get_names(G_THEMED_ICON(icon));
+        if(iconNames && iconNames[0]) {
+            iconName = iconNames[0];
+        }
+    }
+
+    CStrPtr srcPathUri;
+    auto uri = g_file_info_get_attribute_string(srcInfo.get(), G_FILE_ATTRIBUTE_STANDARD_TARGET_URI);
+    if(!uri) {
+        srcPathUri = srcPath.uri();
+        uri = srcPathUri.get();
+    }
+
+    CStrPtr srcPathDispName;
+    auto name = g_file_info_get_display_name(srcInfo.get());
+    if(!name) {
+        srcPathDispName = srcPath.displayName();
+        name = srcPathDispName.get();
+    }
+
+    GKeyFile* kf = g_key_file_new();
+    if(kf) {
+        g_key_file_set_string(kf, G_KEY_FILE_DESKTOP_GROUP, G_KEY_FILE_DESKTOP_KEY_TYPE, "Link");
+        g_key_file_set_string(kf, G_KEY_FILE_DESKTOP_GROUP, G_KEY_FILE_DESKTOP_KEY_NAME, name);
+        if(iconName) {
+            g_key_file_set_string(kf, G_KEY_FILE_DESKTOP_GROUP, G_KEY_FILE_DESKTOP_KEY_ICON, iconName);
+        }
+        if(uri) {
+            g_key_file_set_string(kf, G_KEY_FILE_DESKTOP_GROUP, G_KEY_FILE_DESKTOP_KEY_URL, uri);
+        }
+        gsize contentLen;
+        CStrPtr content{g_key_file_to_data(kf, &contentLen, nullptr)};
+        g_key_file_free(kf);
+
+        int flags = 0;
+        if(content) {
+            bool retry;
+            GErrorPtr err;
+            do {
+                retry = false;
+                if(flags & G_FILE_COPY_OVERWRITE) {  // overwrite existing file
+                    g_file_delete(destPath.gfile().get(), cancellable().get(), nullptr);
+                }
+
+                if(!g_file_replace_contents(destPath.gfile().get(), content.get(), contentLen, nullptr, false, G_FILE_CREATE_NONE, nullptr, cancellable().get(), &err)) {
+                    retry = handleError(err, srcPath, srcInfo, destPath, flags);
+                    err.reset();
+                }
+                else {
+                    ret = true;
+                }
+            } while(!isCancelled() && retry);
+            ret = true;
+        }
+    }
+    return ret;
+}
+
+
+void FileTransferJob::exec() {
+    // calculate the total size of files to copy
+    auto totalSizeFlags = (mode_ == Mode::COPY ? TotalSizeJob::DEFAULT : TotalSizeJob::PREPARE_MOVE);
+    TotalSizeJob totalSizeJob{srcPaths_, totalSizeFlags};
+    connect(&totalSizeJob, &TotalSizeJob::error, this, &FileTransferJob::error);
+    connect(this, &FileTransferJob::cancelled, &totalSizeJob, &TotalSizeJob::cancel);
+    totalSizeJob.run();
+    if(isCancelled()) {
+        return;
+    }
+
+    // ready to start
+    setTotalAmount(totalSizeJob.totalSize(), totalSizeJob.fileCount());
+    Q_EMIT preparedToRun();
+
+    if(srcPaths_.size() != destPaths_.size()) {
+        qWarning("error: srcPaths.size() != destPaths.size() when copying files");
+        return;
+    }
+
+    // copy the files
+    for(size_t i = 0; i < srcPaths_.size(); ++i) {
+        if(isCancelled()) {
+            break;
+        }
+        const auto& srcPath = srcPaths_[i];
+        const auto& destPath = destPaths_[i];
+        auto destDirPath = destPath.parent();
+        processPath(srcPath, destDirPath, destPath.baseName().get());
+    }
+}
+
+
+} // namespace Fm

--- a/libfm-qt/core/filetransferjob.h
+++ b/libfm-qt/core/filetransferjob.h
@@ -1,0 +1,59 @@
+#ifndef FM2_COPYJOB_H
+#define FM2_COPYJOB_H
+
+#include "../libfmqtglobals.h"
+#include "fileoperationjob.h"
+#include "gioptrs.h"
+
+namespace Fm {
+
+class LIBFM_QT_API FileTransferJob : public Fm::FileOperationJob {
+    Q_OBJECT
+public:
+
+    enum class Mode {
+        COPY,
+        MOVE,
+        LINK
+    };
+
+    explicit FileTransferJob(FilePathList srcPaths, Mode mode = Mode::COPY);
+    explicit FileTransferJob(FilePathList srcPaths, FilePathList destPaths, Mode mode = Mode::COPY);
+    explicit FileTransferJob(FilePathList srcPaths, const FilePath &destDirPath, Mode mode = Mode::COPY);
+
+    void setSrcPaths(FilePathList srcPaths);
+    void setDestPaths(FilePathList destPaths);
+    void setDestDirPath(const FilePath &destDirPath);
+
+protected:
+    void exec() override;
+
+private:
+    bool processPath(const FilePath& srcPath, const FilePath& destPath, const char *destFileName);
+    bool moveFile(const FilePath &srcPath, const GFileInfoPtr &srcInfo, const FilePath &destDirPath, const char *destFileName);
+    bool copyFile(const FilePath &srcPath, const GFileInfoPtr &srcInfo, const FilePath &destDirPath, const char *destFileName, bool skip = false);
+    bool linkFile(const FilePath &srcPath, const GFileInfoPtr &srcInfo, const FilePath &destDirPath, const char *destFileName);
+
+    bool moveFileSameFs(const FilePath &srcPath, const GFileInfoPtr& srcInfo, FilePath &destPath);
+    bool copyRegularFile(const FilePath &srcPath, const GFileInfoPtr& srcInfo, FilePath &destPath);
+    bool copySpecialFile(const FilePath &srcPath, const GFileInfoPtr& srcInfo, FilePath& destPath);
+    bool copyDirContent(const FilePath &srcPath, GFileInfoPtr srcInfo, FilePath &destPath, bool skip = false);
+    bool makeDir(const FilePath &srcPath, GFileInfoPtr srcInfo, FilePath &destPath);
+    bool createSymlink(const FilePath &srcPath, const GFileInfoPtr& srcInfo, FilePath& destPath);
+    bool createShortcut(const FilePath &srcPath, const GFileInfoPtr& srcInfo, FilePath& destPath);
+
+    bool handleError(GErrorPtr& err, const FilePath &srcPath, const GFileInfoPtr &srcInfo, FilePath &destPath, int& flags);
+
+    static void gfileCopyProgressCallback(goffset current_num_bytes, goffset total_num_bytes, FileTransferJob* _this);
+
+private:
+    FilePathList srcPaths_;
+    FilePathList destPaths_;
+    Mode mode_;
+    bool hasDestDirPath_;
+};
+
+
+} // namespace Fm
+
+#endif // FM2_COPYJOB_H

--- a/libfm-qt/core/folder.cpp
+++ b/libfm-qt/core/folder.cpp
@@ -1,0 +1,930 @@
+/*
+ *      fm-folder.c
+ *
+ *      Copyright 2009 - 2012 Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *      Copyright 2012-2016 Andriy Grytsenko (LStranger) <andrej@rep.kiev.ua>
+ *
+ *      This file is a part of the Libfm library.
+ *
+ *      This library is free software; you can redistribute it and/or
+ *      modify it under the terms of the GNU Lesser General Public
+ *      License as published by the Free Software Foundation; either
+ *      version 2.1 of the License, or (at your option) any later version.
+ *
+ *      This library is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *      Lesser General Public License for more details.
+ *
+ *      You should have received a copy of the GNU Lesser General Public
+ *      License along with this library; if not, write to the Free Software
+ *      Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "folder.h"
+#include <cstring>
+#include <cassert>
+#include <QTimer>
+#include <QDebug>
+
+#include "dirlistjob.h"
+#include "filesysteminfojob.h"
+#include "fileinfojob.h"
+
+namespace Fm {
+
+std::unordered_map<FilePath, std::weak_ptr<Folder>, FilePathHash> Folder::cache_;
+std::mutex Folder::mutex_;
+
+Folder::Folder():
+    dirlist_job{nullptr},
+    fsInfoJob_{nullptr},
+    volumeManager_{VolumeManager::globalInstance()},
+    /* for file monitor */
+    has_idle_reload_handler{false},
+    has_idle_update_handler{false},
+    pending_change_notify{false},
+    filesystem_info_pending{false},
+    wants_incremental{false},
+    stop_emission{false}, /* don't set it 1 bit to not lock other bits */
+    /* filesystem info - set in query thread, read in main */
+    fs_total_size{0},
+    fs_free_size{0},
+    has_fs_info{false},
+    defer_content_test{false} {
+
+    connect(volumeManager_.get(), &VolumeManager::mountAdded, this, &Folder::onMountAdded);
+    connect(volumeManager_.get(), &VolumeManager::mountRemoved, this, &Folder::onMountRemoved);
+}
+
+Folder::Folder(const FilePath& path): Folder() {
+    dirPath_ = path;
+}
+
+Folder::~Folder() {
+    if(dirMonitor_) {
+        g_signal_handlers_disconnect_by_data(dirMonitor_.get(), this);
+        dirMonitor_.reset();
+    }
+
+    if(dirlist_job) {
+        dirlist_job->cancel();
+    }
+
+    // cancel any file info job in progress.
+    for(auto job: fileinfoJobs_) {
+        job->cancel();
+    }
+
+    if(fsInfoJob_) {
+        fsInfoJob_->cancel();
+    }
+
+    // We store a weak_ptr instead of shared_ptr in the hash table, so the hash table
+    // does not own a reference to the folder. When the last reference to Folder is
+    // freed, we need to remove its hash table entry.
+    std::lock_guard<std::mutex> lock{mutex_};
+    auto it = cache_.find(dirPath_);
+    if(it != cache_.end()) {
+        cache_.erase(it);
+    }
+}
+
+// static
+std::shared_ptr<Folder> Folder::fromPath(const FilePath& path) {
+    std::lock_guard<std::mutex> lock{mutex_};
+    auto it = cache_.find(path);
+    if(it != cache_.end()) {
+        auto folder = it->second.lock();
+        if(folder) {
+            return folder;
+        }
+        else { // FIXME: is this possible?
+            cache_.erase(it);
+        }
+    }
+    auto folder = std::make_shared<Folder>(path);
+    folder->reload();
+    cache_.emplace(path, folder);
+    return folder;
+}
+
+// static
+// Checks if this is the path of a folder in use.
+std::shared_ptr<Folder> Folder::findByPath(const FilePath& path) {
+    std::lock_guard<std::mutex> lock{mutex_};
+    auto it = cache_.find(path);
+    if(it != cache_.end()) {
+        auto folder = it->second.lock();
+        if(folder) {
+            return folder;
+        }
+    }
+    return nullptr;
+}
+
+bool Folder::makeDirectory(const char* /*name*/, GError** /*error*/) {
+    // TODO:
+    // FIXME: what the API is used for in the original libfm C API?
+    return false;
+}
+
+bool Folder::isIncremental() const {
+    return wants_incremental;
+}
+
+bool Folder::isValid() const {
+    return dirInfo_ != nullptr;
+}
+
+bool Folder::isLoaded() const {
+    return (dirlist_job == nullptr);
+}
+
+std::shared_ptr<const FileInfo> Folder::fileByName(const char* name) const {
+    auto it = files_.find(name);
+    if(it != files_.end()) {
+        return it->second;
+    }
+    return nullptr;
+}
+
+bool Folder::isEmpty() const {
+    return files_.empty();
+}
+
+bool Folder::hasFileMonitor() const {
+    return (dirMonitor_ != nullptr);
+}
+
+FileInfoList Folder::files() const {
+    FileInfoList ret;
+    ret.reserve(files_.size());
+    for(const auto& item : files_) {
+        ret.push_back(item.second);
+    }
+    return ret;
+}
+
+
+const FilePath& Folder::path() const {
+    auto pathStr = dirPath_.toString();
+    // qDebug() << this << "FOLDER_PATH:" << pathStr.get() << dirPath_.gfile().get();
+    //assert(!g_str_has_prefix(pathStr.get(), "file:"));
+    return dirPath_;
+}
+
+const std::shared_ptr<const FileInfo>& Folder::info() const {
+    return dirInfo_;
+}
+
+#if 0
+void Folder::init(FmFolder* folder) {
+    files = fm_file_info_list_new();
+    G_LOCK(hash);
+    if(G_UNLIKELY(hash_uses == 0)) {
+        hash = g_hash_table_new((GHashFunc)fm_path_hash, (GEqualFunc)fm_path_equal);
+        volume_monitor = g_volume_monitor_get();
+        if(G_LIKELY(volume_monitor)) {
+            g_signal_connect(volume_monitor, "mount-added", G_CALLBACK(on_mount_added), nullptr);
+            g_signal_connect(volume_monitor, "mount-removed", G_CALLBACK(on_mount_removed), nullptr);
+        }
+    }
+    hash_uses++;
+    G_UNLOCK(hash);
+}
+#endif
+
+void Folder::onIdleReload() {
+    /* check if folder still exists */
+    reload();
+    // G_LOCK(query);
+    has_idle_reload_handler = false;
+    // G_UNLOCK(query);
+}
+
+void Folder::queueReload() {
+    // G_LOCK(query);
+    if(!has_idle_reload_handler) {
+        has_idle_reload_handler = true;
+        QTimer::singleShot(0, this, &Folder::onIdleReload);
+    }
+    // G_UNLOCK(query);
+}
+
+void Folder::onFileInfoFinished() {
+    FileInfoJob* job = static_cast<FileInfoJob*>(sender());
+    fileinfoJobs_.erase(std::find(fileinfoJobs_.cbegin(), fileinfoJobs_.cend(), job));
+
+    /* NOTE: The pending changes should be processed in the order reported by GIO;
+       otherwise; the final file info might be wrong. Here, we ensure that the next
+       pending changes are processed only after the current info job is finished. */
+
+    if(job->isCancelled()) {
+        has_idle_update_handler = false; // allow future updates
+        return;
+    }
+
+    FileInfoList files_to_add;
+    FileInfoList files_to_delete;
+    std::vector<FileInfoPair> files_to_update;
+
+    const auto& paths = job->paths();
+    const auto& infos = job->files();
+    auto path_it = paths.cbegin();
+    auto info_it = infos.cbegin();
+    for(; path_it != paths.cend() && info_it != infos.cend(); ++path_it, ++info_it) {
+        const auto& path = *path_it;
+        const auto& info = *info_it;
+
+        if(path == dirPath_) { // got the info for the folder itself.
+            dirInfo_ = info;
+        }
+        else {
+            auto it = files_.find(info->path().baseName().get());
+            if(it != files_.end()) { // the file already exists, update
+                files_to_update.push_back(std::make_pair(it->second, info));
+            }
+            else { // newly added
+                files_to_add.push_back(info);
+            }
+            files_[info->path().baseName().get()] = info;
+        }
+    }
+    if(!files_to_add.empty()) {
+        Q_EMIT filesAdded(files_to_add);
+    }
+    if(!files_to_update.empty()) {
+        Q_EMIT filesChanged(files_to_update);
+    }
+    Q_EMIT contentChanged();
+
+    // process the changes accumulated during this info job
+    if(filesystem_info_pending // means a pending change; see "onFileSystemInfoFinished()"
+       || !paths_to_update.empty() || !paths_to_add.empty() || !paths_to_del.empty()) {
+        QTimer::singleShot(0, this, &Folder::processPendingChanges);
+    }
+    // there's no pending change at the moment; let the next one be processed
+    else {
+        has_idle_update_handler = false;
+    }
+}
+
+void Folder::processPendingChanges() {
+    // FmFileInfoJob* job = nullptr;
+    std::lock_guard<std::mutex> lock{mutex_};
+
+    // idle_handler = 0;
+    /* if we were asked to block updates let delay it for now */
+    if(stop_emission) {
+        has_idle_update_handler = false;
+        return;
+    }
+
+    FileInfoJob* info_job = nullptr;
+    if(!paths_to_update.empty() || !paths_to_add.empty()) {
+        FilePathList paths;
+        paths.insert(paths.end(), paths_to_add.cbegin(), paths_to_add.cend());
+        paths.insert(paths.end(), paths_to_update.cbegin(), paths_to_update.cend());
+        info_job = new FileInfoJob{paths};
+        paths_to_update.clear();
+        paths_to_add.clear();
+    }
+    else {
+        // let the next pending changes be processed; see "onFileInfoFinished()"
+        has_idle_update_handler = false;
+    }
+
+    if(info_job) {
+        fileinfoJobs_.push_back(info_job);
+        info_job->setAutoDelete(true);
+        connect(info_job, &FileInfoJob::finished, this, &Folder::onFileInfoFinished, Qt::BlockingQueuedConnection);
+        info_job->runAsync();
+#if 0
+        pending_jobs = g_slist_prepend(pending_jobs, job);
+        if(!fm_job_run_async(FM_JOB(job))) {
+            pending_jobs = g_slist_remove(pending_jobs, job);
+            g_object_unref(job);
+            g_critical("failed to start folder update job");
+        }
+#endif
+    }
+
+    // process deletion
+    FileInfoList deleted_files;
+    auto path_it = paths_to_del.begin();
+    while(path_it != paths_to_del.end()) {
+        const auto& path = *path_it;
+        auto name = path.baseName();
+        auto it = files_.find(name.get());
+        if(it != files_.end()) {
+            deleted_files.push_back(it->second);
+            files_.erase(it);
+            path_it = paths_to_del.erase(path_it);
+        }
+        else {
+            ++path_it;
+        }
+    }
+    if(!deleted_files.empty()) {
+        Q_EMIT filesRemoved(deleted_files);
+        Q_EMIT contentChanged();
+    }
+
+    if(pending_change_notify) {
+        Q_EMIT changed();
+        /* update volume info */
+        queryFilesystemInfo();
+        pending_change_notify = false;
+    }
+
+    if(filesystem_info_pending) {
+        Q_EMIT fileSystemChanged();
+        filesystem_info_pending = false;
+    }
+}
+
+/* should be called only with G_LOCK(lists) on! */
+void Folder::queueUpdate() {
+    // qDebug() << "queue_update:" << !has_idle_handler << paths_to_add.size() << paths_to_update.size() << paths_to_del.size();
+    if(!has_idle_update_handler) {
+        QTimer::singleShot(0, this, &Folder::processPendingChanges);
+        has_idle_update_handler = true;
+    }
+}
+
+
+/* NOTE: When queuing files for addition/update/deletion in the following functions,
+   the currently detected files (namely, "files_") should not be taken into account
+   because they might be changed soon due to a previous call to queueUpdate(). */
+
+/* returns true if reference was taken from path */
+bool Folder::eventFileAdded(const FilePath &path) {
+    bool added = true;
+    // G_LOCK(lists);
+    if(std::find(paths_to_del.cbegin(), paths_to_del.cend(), path) != paths_to_del.cend()) {
+        // if the file was going to be deleted, its addition means an update,
+        // so remove it from the deletion queue and add it to the update queue
+        paths_to_del.erase(std::remove(paths_to_del.begin(), paths_to_del.end(), path), paths_to_del.cend());
+        if(std::find(paths_to_update.cbegin(), paths_to_update.cend(), path) == paths_to_update.cend()) {
+            paths_to_update.push_back(path);
+        }
+    }
+    else if(std::find(paths_to_add.cbegin(), paths_to_add.cend(), path) == paths_to_add.cend()) {
+        paths_to_add.push_back(path);
+    }
+    else { // file already queued for adding, don't duplicate
+        added = false;
+    }
+
+    if(added) {
+        queueUpdate();
+    }
+    // G_UNLOCK(lists);
+    return added;
+}
+
+bool Folder::eventFileChanged(const FilePath &path) {
+    bool added;
+    // G_LOCK(lists);
+    if(std::find(paths_to_update.cbegin(), paths_to_update.cend(), path) == paths_to_update.cend()
+       && std::find(paths_to_add.cbegin(), paths_to_add.cend(), path) == paths_to_add.cend()) {
+        paths_to_update.push_back(path);
+        added = true;
+        queueUpdate();
+    }
+    else {
+        added = false;
+    }
+    // G_UNLOCK(lists);
+    return added;
+}
+
+void Folder::eventFileDeleted(const FilePath& path) {
+    bool deleted = true;
+    // qDebug() << "delete " << path.baseName().get();
+    // G_LOCK(lists);
+    /* WARNING: If the file is in the addition queue, we shouldn not remove it from that queue
+       and ignore its deletion because it may have been added by the directory list job, in
+       which case, ignoring an addition-deletion sequence would result in a nonexistent file. */
+    if(std::find(paths_to_del.cbegin(), paths_to_del.cend(), path) == paths_to_del.cend()) {
+        paths_to_del.push_back(path);
+        // the update queue can be cancelled for a file that is going to be deleted
+        paths_to_update.erase(std::remove(paths_to_update.begin(), paths_to_update.end(), path), paths_to_update.cend());
+    }
+    else {
+        deleted = false;
+    }
+
+    if(deleted) {
+        queueUpdate();
+    }
+    // G_UNLOCK(lists);
+}
+
+
+void Folder::onDirChanged(GFileMonitorEvent evt) {
+    switch(evt) {
+    case G_FILE_MONITOR_EVENT_PRE_UNMOUNT:
+        /* g_debug("folder is going to be unmounted"); */
+        break;
+    case G_FILE_MONITOR_EVENT_UNMOUNTED:
+        Q_EMIT unmount();
+        /* g_debug("folder is unmounted"); */
+        queueReload();
+        break;
+    case G_FILE_MONITOR_EVENT_DELETED:
+        Q_EMIT removed();
+        /* g_debug("folder is deleted"); */
+        break;
+    case G_FILE_MONITOR_EVENT_CREATED:
+        queueReload();
+        break;
+    case G_FILE_MONITOR_EVENT_ATTRIBUTE_CHANGED:
+    case G_FILE_MONITOR_EVENT_CHANGED: {
+        std::lock_guard<std::mutex> lock{mutex_};
+        pending_change_notify = true;
+        if(std::find(paths_to_update.cbegin(), paths_to_update.cend(), dirPath_) != paths_to_update.cend()) {
+            paths_to_update.push_back(dirPath_);
+            queueUpdate();
+        }
+        /* g_debug("folder is changed"); */
+        break;
+    }
+#if GLIB_CHECK_VERSION(2,24,0)
+    case G_FILE_MONITOR_EVENT_MOVED:
+#endif
+    case G_FILE_MONITOR_EVENT_CHANGES_DONE_HINT:
+        ;
+    default:
+        break;
+    }
+}
+
+void Folder::onFileChangeEvents(GFileMonitor* /*monitor*/, GFile* gf, GFile* /*other_file*/, GFileMonitorEvent evt) {
+    /* const char* names[]={
+        "G_FILE_MONITOR_EVENT_CHANGED",
+        "G_FILE_MONITOR_EVENT_CHANGES_DONE_HINT",
+        "G_FILE_MONITOR_EVENT_DELETED",
+        "G_FILE_MONITOR_EVENT_CREATED",
+        "G_FILE_MONITOR_EVENT_ATTRIBUTE_CHANGED",
+        "G_FILE_MONITOR_EVENT_PRE_UNMOUNT",
+        "G_FILE_MONITOR_EVENT_UNMOUNTED"
+    }; */
+    if(dirPath_ == gf) {
+        onDirChanged(evt);
+        return;
+    }
+    else {
+        std::lock_guard<std::mutex> lock{mutex_};
+        auto path = FilePath{gf, true};
+        /* NOTE: sometimes, for unknown reasons, GFileMonitor gives us the
+         * same event of the same file for multiple times. So we need to
+         * check for duplications ourselves here. */
+        switch(evt) {
+        case G_FILE_MONITOR_EVENT_CREATED:
+            eventFileAdded(path);
+            break;
+        case G_FILE_MONITOR_EVENT_ATTRIBUTE_CHANGED:
+        case G_FILE_MONITOR_EVENT_CHANGED:
+            eventFileChanged(path);
+            break;
+        case G_FILE_MONITOR_EVENT_DELETED:
+            eventFileDeleted(path);
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+void Folder::onDirListFinished() {
+    DirListJob* job = static_cast<DirListJob*>(sender());
+    if(job->isCancelled()) { // this is a cancelled job, ignore!
+        if(job == dirlist_job) {
+            dirlist_job = nullptr;
+            Q_EMIT finishLoading(); // this was the last job until now
+        }
+        return;
+    }
+    dirInfo_ = job->dirInfo();
+
+    FileInfoList files_to_add;
+    std::vector<FileInfoPair> files_to_update;
+    const auto& infos = job->files();
+
+    // with "search://", there is no update for infos and all of them should be added
+    if(strcmp(dirPath_.uriScheme().get(), "search") == 0) {
+        files_to_add = infos;
+        for(auto& file: files_to_add) {
+            files_[file->path().baseName().get()] = file;
+        }
+    }
+    else {
+        auto info_it = infos.cbegin();
+        for(; info_it != infos.cend(); ++info_it) {
+            const auto& info = *info_it;
+            auto it = files_.find(info->path().baseName().get());
+            if(it != files_.end()) {
+                files_to_update.push_back(std::make_pair(it->second, info));
+            }
+            else {
+                files_to_add.push_back(info);
+            }
+            files_[info->path().baseName().get()] = info;
+        }
+    }
+
+    if(!files_to_add.empty()) {
+        Q_EMIT filesAdded(files_to_add);
+    }
+    if(!files_to_update.empty()) {
+        Q_EMIT filesChanged(files_to_update);
+    }
+
+#if 0
+    if(dirlist_job->isCancelled() && !wants_incremental) {
+        GList* l;
+        for(l = fm_file_info_list_peek_head_link(job->files); l; l = l->next) {
+            FmFileInfo* inf = (FmFileInfo*)l->data;
+            files = g_slist_prepend(files, inf);
+            fm_file_info_list_push_tail(files, inf);
+        }
+        if(G_LIKELY(files)) {
+            GSList* l;
+
+            G_LOCK(lists);
+            if(defer_content_test && fm_path_is_native(dir_path))
+                /* we got only basic info on content, schedule update it now */
+                for(l = files; l; l = l->next)
+                    files_to_update = g_slist_prepend(files_to_update,
+                                              fm_path_ref(fm_file_info_get_path(l->data)));
+            G_UNLOCK(lists);
+            g_signal_emit(folder, signals[FILES_ADDED], 0, files);
+            g_slist_free(files);
+        }
+
+        if(job->dir_fi) {
+            dir_fi = fm_file_info_ref(job->dir_fi);
+        }
+
+        /* Some new files are created while FmDirListJob is loading the folder. */
+        G_LOCK(lists);
+        if(G_UNLIKELY(files_to_add)) {
+            /* This should be a very rare case. Could this happen? */
+            GSList* l;
+            for(l = files_to_add; l;) {
+                FmPath* path = l->data;
+                GSList* next = l->next;
+                if(_Folder::get_file_by_path(folder, path)) {
+                    /* we already have the file. remove it from files_to_add,
+                     * and put it in files_to_update instead.
+                     * No strdup for name is needed here. We steal
+                     * the string from files_to_add.*/
+                    files_to_update = g_slist_prepend(files_to_update, path);
+                    files_to_add = g_slist_delete_link(files_to_add, l);
+                }
+                l = next;
+            }
+        }
+        G_UNLOCK(lists);
+    }
+    else if(!dir_fi && job->dir_fi)
+        /* we may need dir_fi for incremental folders too */
+    {
+        dir_fi = fm_file_info_ref(job->dir_fi);
+    }
+    g_object_unref(dirlist_job);
+#endif
+
+    dirlist_job = nullptr;
+    Q_EMIT finishLoading();
+}
+
+#if 0
+
+
+void on_dirlist_job_files_found(FmDirListJob* job, GSList* files, gpointer user_data) {
+    FmFolder* folder = FM_FOLDER(user_data);
+    GSList* l;
+    for(l = files; l; l = l->next) {
+        FmFileInfo* file = FM_FILE_INFO(l->data);
+        fm_file_info_list_push_tail(files, file);
+    }
+    if(G_UNLIKELY(!dir_fi && job->dir_fi))
+        /* we may want info while folder is still loading */
+    {
+        dir_fi = fm_file_info_ref(job->dir_fi);
+    }
+    g_signal_emit(folder, signals[FILES_ADDED], 0, files);
+}
+
+ErrorAction on_dirlist_job_error(FmDirListJob* job, GError* err, FmJobErrorSeverity severity, FmFolder* folder) {
+    guint ret;
+    /* it's possible that some signal handlers tries to free the folder
+     * when errors occurs, so let's g_object_ref here. */
+    g_object_ref(folder);
+    g_signal_emit(folder, signals[ERROR], 0, err, (guint)severity, &ret);
+    g_object_unref(folder);
+    return ret;
+}
+
+void free_dirlist_job(FmFolder* folder) {
+    if(wants_incremental) {
+        g_signal_handlers_disconnect_by_func(dirlist_job, on_dirlist_job_files_found, folder);
+    }
+    g_signal_handlers_disconnect_by_func(dirlist_job, on_dirlist_job_finished, folder);
+    g_signal_handlers_disconnect_by_func(dirlist_job, on_dirlist_job_error, folder);
+    fm_job_cancel(FM_JOB(dirlist_job));
+    g_object_unref(dirlist_job);
+    dirlist_job = nullptr;
+}
+
+#endif
+
+
+void Folder::reload() {
+    // cancel in-progress jobs if there are any
+    if(dirlist_job) {
+        dirlist_job->cancel();
+    }
+    GError* err = nullptr;
+    // cancel directory monitoring
+    if(dirMonitor_) {
+        g_signal_handlers_disconnect_by_data(dirMonitor_.get(), this);
+        dirMonitor_.reset();
+    }
+
+    /* clear all update-lists now, see SF bug #919 - if update comes before
+       listing job is finished, a duplicate may be created in the folder */
+    if(has_idle_update_handler) {
+        // FIXME: cancel the idle handler
+        paths_to_add.clear();
+        paths_to_update.clear();
+        paths_to_del.clear();
+
+        // cancel any file info job in progress.
+        for(auto job: fileinfoJobs_) {
+            job->cancel();
+            disconnect(job, &FileInfoJob::finished, this, &Folder::onFileInfoFinished);
+        }
+        fileinfoJobs_.clear();
+
+        // ensure future changes will be processed
+        has_idle_update_handler = false;
+    }
+
+    /* remove all existing files */
+    if(!files_.empty()) {
+        // FIXME: this is not very efficient :(
+        auto tmp = files();
+        files_.clear();
+        Q_EMIT filesRemoved(tmp);
+    }
+
+    /* Tell the world that we're about to reload the folder.
+     * It might be a good idea for users of the folder to disconnect
+     * from the folder temporarily and reconnect to it again after
+     * the folder complete the loading. This might reduce some
+     * unnecessary signal handling and UI updates. */
+    Q_EMIT startLoading();
+
+    dirInfo_.reset(); // clear dir info
+
+    /* also re-create a new file monitor */
+    // mon = GFileMonitorPtr{fm_monitor_directory(dir_path.gfile().get(), &err), false};
+    // FIXME: should we make this cancellable?
+    dirMonitor_ = GFileMonitorPtr{
+            g_file_monitor_directory(dirPath_.gfile().get(), G_FILE_MONITOR_WATCH_MOUNTS, nullptr, &err),
+            false
+    };
+
+    if(dirMonitor_) {
+        g_signal_connect(dirMonitor_.get(), "changed", G_CALLBACK(_onFileChangeEvents), this);
+    }
+    else {
+        qDebug("file monitor cannot be created: %s", err->message);
+        g_error_free(err);
+    }
+
+    Q_EMIT contentChanged();
+
+    /* run a new dir listing job */
+    // FIXME:
+    // defer_content_test = fm_config->defer_content_test;
+    dirlist_job = new DirListJob(dirPath_, defer_content_test ? DirListJob::FAST : DirListJob::DETAILED);
+    dirlist_job->setAutoDelete(true);
+    connect(dirlist_job, &DirListJob::error, this, &Folder::error, Qt::BlockingQueuedConnection);
+    connect(dirlist_job, &DirListJob::finished, this, &Folder::onDirListFinished, Qt::BlockingQueuedConnection);
+
+#if 0
+    if(wants_incremental) {
+        g_signal_connect(dirlist_job, "files-found", G_CALLBACK(on_dirlist_job_files_found), folder);
+    }
+    fm_dir_list_job_set_incremental(dirlist_job, wants_incremental);
+#endif
+
+    dirlist_job->runAsync();
+
+    /* also reload filesystem info.
+     * FIXME: is this needed? */
+    queryFilesystemInfo();
+}
+
+#if 0
+
+/**
+ * Folder::is_incremental
+ * @folder: folder to test
+ *
+ * Checks if a folder is incrementally loaded.
+ * After an FmFolder object is obtained from calling Folder::from_path(),
+ * if it's not yet loaded, it begins loading the content of the folder
+ * and emits "start-loading" signal. Most of the time, the info of the
+ * files in the folder becomes available only after the folder is fully
+ * loaded. That means, after the "finish-loading" signal is emitted.
+ * Before the loading is finished, Folder::get_files() returns nothing.
+ * You can tell if a folder is still being loaded with Folder::is_loaded().
+ *
+ * However, for some special FmFolder types, such as the ones handling
+ * search:// URIs, we want to access the file infos while the folder is
+ * still being loaded (the search is still ongoing).
+ * The content of the folder grows incrementally and Folder::get_files()
+ * returns files currently being loaded even when the folder is not
+ * fully loaded. This is what we called incremental.
+ * Folder::is_incremental() tells you if the FmFolder has this feature.
+ *
+ * Returns: %true if @folder is incrementally loaded
+ *
+ * Since: 1.0.2
+ */
+bool Folder::is_incremental(FmFolder* folder) {
+    return wants_incremental;
+}
+
+#endif
+
+bool Folder::getFilesystemInfo(uint64_t* total_size, uint64_t* free_size) const {
+    if(has_fs_info) {
+        *total_size = fs_total_size;
+        *free_size = fs_free_size;
+        return true;
+    }
+    return false;
+}
+
+
+void Folder::onFileSystemInfoFinished() {
+    FileSystemInfoJob* job = static_cast<FileSystemInfoJob*>(sender());
+    if(job->isCancelled() || job != fsInfoJob_) { // this is a cancelled job, ignore!
+        fsInfoJob_ = nullptr;
+        has_fs_info = false;
+        return;
+    }
+    has_fs_info = job->isAvailable();
+    fs_total_size = job->size();
+    fs_free_size = job->freeSize();
+    filesystem_info_pending = true;
+    fsInfoJob_ = nullptr;
+    queueUpdate();
+}
+
+
+void Folder::queryFilesystemInfo() {
+    // G_LOCK(query);
+    if(fsInfoJob_)
+        return;
+    fsInfoJob_ = new FileSystemInfoJob{dirPath_};
+    fsInfoJob_->setAutoDelete(true);
+    connect(fsInfoJob_, &FileSystemInfoJob::finished, this, &Folder::onFileSystemInfoFinished, Qt::BlockingQueuedConnection);
+
+    fsInfoJob_->runAsync();
+    // G_UNLOCK(query);
+}
+
+
+#if 0
+/**
+ * Folder::block_updates
+ * @folder: folder to apply
+ *
+ * Blocks emitting signals for changes in folder, i.e. if some file was
+ * added, changed, or removed in folder after this API, no signal will be
+ * sent until next call to Folder::unblock_updates().
+ *
+ * Since: 1.2.0
+ */
+void Folder::block_updates(FmFolder* folder) {
+    /* g_debug("Folder::block_updates %p", folder); */
+    G_LOCK(lists);
+    /* just set the flag */
+    stop_emission = true;
+    G_UNLOCK(lists);
+}
+
+/**
+ * Folder::unblock_updates
+ * @folder: folder to apply
+ *
+ * Unblocks emitting signals for changes in folder. If some changes were
+ * in folder after previous call to Folder::block_updates() then these
+ * changes will be sent after this call.
+ *
+ * Since: 1.2.0
+ */
+void Folder::unblock_updates(FmFolder* folder) {
+    /* g_debug("Folder::unblock_updates %p", folder); */
+    G_LOCK(lists);
+    stop_emission = false;
+    /* query update now */
+    queue_update(folder);
+    G_UNLOCK(lists);
+    /* g_debug("Folder::unblock_updates OK"); */
+}
+
+/**
+ * Folder::make_directory
+ * @folder: folder to apply
+ * @name: display name for new directory
+ * @error: (allow-none) (out): location to save error
+ *
+ * Creates new directory in given @folder.
+ *
+ * Returns: %true in case of success.
+ *
+ * Since: 1.2.0
+ */
+bool Folder::make_directory(FmFolder* folder, const char* name, GError** error) {
+    GFile* dir, *gf;
+    FmPath* path;
+    bool ok;
+
+    dir = fm_path_to_gfile(dir_path);
+    gf = g_file_get_child_for_display_name(dir, name, error);
+    g_object_unref(dir);
+    if(gf == nullptr) {
+        return false;
+    }
+    ok = g_file_make_directory(gf, nullptr, error);
+    if(ok) {
+        path = fm_path_new_for_gfile(gf);
+        if(!_Folder::event_file_added(folder, path)) {
+            fm_path_unref(path);
+        }
+    }
+    g_object_unref(gf);
+    return ok;
+}
+
+void Folder::content_changed(FmFolder* folder) {
+    if(has_fs_info && !fs_info_not_avail) {
+        Folder::query_filesystem_info(folder);
+    }
+}
+
+#endif
+
+/* NOTE:
+ * GFileMonitor has some significant limitations:
+ * 1. Currently it can correctly emit unmounted event for a directory.
+ * 2. After a directory is unmounted, its content changes.
+ *    Inotify does not fire events for this so a forced reload is needed.
+ * 3. If a folder is empty, and later a filesystem is mounted to the
+ *    folder, its content should reflect the content of the newly mounted
+ *    filesystem. However, GFileMonitor and inotify do not emit events
+ *    for this case. A forced reload might be needed for this case as well.
+ * 4. Some limitations come from Linux/inotify. If FAM/gamin is used,
+ *    the condition may be different. More testing is needed.
+ */
+void Folder::onMountAdded(const Mount& mnt) {
+    /* If a filesystem is mounted over an existing folder,
+     * we need to refresh the content of the folder to reflect
+     * the changes. Besides, we need to create a new GFileMonitor
+     * for the newly-mounted filesystem as the inode already changed.
+     * GFileMonitor cannot detect this kind of changes caused by mounting.
+     * So let's do it ourselves. */
+    auto mountRoot = mnt.root();
+    if(mountRoot.isPrefixOf(dirPath_)) {
+        queueReload();
+    }
+    /* g_debug("FmFolder::mount_added"); */
+}
+
+void Folder::onMountRemoved(const Mount& mnt) {
+    /* g_debug("FmFolder::mount_removed"); */
+
+    /* NOTE: gvfs does not emit unmount signals for remote folders since
+     * GFileMonitor does not support remote filesystems at all.
+     * So here is the side effect, no unmount notifications.
+     * We need to generate the signal ourselves. */
+    if(!dirMonitor_) {
+        // this is only needed when we don't have a GFileMonitor
+        auto mountRoot = mnt.root();
+        if(mountRoot.isPrefixOf(dirPath_)) {
+            // if the current folder is under the unmounted path, generate the event ourselves
+            onDirChanged(G_FILE_MONITOR_EVENT_UNMOUNTED);
+        }
+    }
+}
+
+} // namespace Fm

--- a/libfm-qt/core/folder.h
+++ b/libfm-qt/core/folder.h
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2016 Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef __LIBFM2_QT_FM_FOLDER_H__
+#define __LIBFM2_QT_FM_FOLDER_H__
+
+#include <gio/gio.h>
+#include <cstdint>
+#include <memory>
+#include <vector>
+#include <unordered_map>
+#include <mutex>
+#include <functional>
+
+#include <QObject>
+#include <QtGlobal>
+#include "../libfmqtglobals.h"
+
+#include "gioptrs.h"
+#include "fileinfo.h"
+#include "job.h"
+#include "volumemanager.h"
+
+namespace Fm {
+
+class DirListJob;
+class FileSystemInfoJob;
+class FileInfoJob;
+
+
+class LIBFM_QT_API Folder: public QObject {
+    Q_OBJECT
+public:
+
+    explicit Folder();
+
+    explicit Folder(const FilePath& path);
+
+    ~Folder() override;
+
+    static std::shared_ptr<Folder> fromPath(const FilePath& path);
+
+    static std::shared_ptr<Folder> findByPath(const FilePath& path);
+
+    bool makeDirectory(const char* name, GError** error);
+
+    void queryFilesystemInfo();
+
+    bool getFilesystemInfo(uint64_t* total_size, uint64_t* free_size) const;
+
+    void reload();
+
+    bool isIncremental() const;
+
+    bool isValid() const;
+
+    bool isLoaded() const;
+
+    std::shared_ptr<const FileInfo> fileByName(const char* name) const;
+
+    bool isEmpty() const;
+
+    bool hasFileMonitor() const;
+
+    FileInfoList files() const;
+
+    const FilePath& path() const;
+
+    const std::shared_ptr<const FileInfo> &info() const;
+
+    void forEachFile(std::function<void (const std::shared_ptr<const FileInfo>&)> func) const {
+        std::lock_guard<std::mutex> lock{mutex_};
+        for(auto it = files_.begin(); it != files_.end(); ++it) {
+            func(it->second);
+        }
+    }
+
+Q_SIGNALS:
+    void startLoading();
+
+    void finishLoading();
+
+    void filesAdded(FileInfoList& addedFiles);
+
+    void filesChanged(std::vector<FileInfoPair>& changePairs);
+
+    void filesRemoved(FileInfoList& removedFiles);
+
+    void removed();
+
+    void changed();
+
+    void unmount();
+
+    void contentChanged();
+
+    void fileSystemChanged();
+
+    // FIXME: this API design is bad. We leave this here to be compatible with the old libfm C API.
+    // It might be better to remember the error state while loading the folder, and let the user of the
+    // API handle the error on finish.
+    void error(const GErrorPtr& err, Job::ErrorSeverity severity, Job::ErrorAction& response);
+
+private:
+
+    static void _onFileChangeEvents(GFileMonitor* monitor, GFile* file, GFile* other_file, GFileMonitorEvent event_type, Folder* _this) {
+        _this->onFileChangeEvents(monitor, file, other_file, event_type);
+    }
+    void onFileChangeEvents(GFileMonitor* monitor, GFile* file, GFile* other_file, GFileMonitorEvent event_type);
+    void onDirChanged(GFileMonitorEvent event_type);
+
+    void queueUpdate();
+    void queueReload();
+
+    bool eventFileAdded(const FilePath &path);
+    bool eventFileChanged(const FilePath &path);
+    void eventFileDeleted(const FilePath &path);
+
+private Q_SLOTS:
+
+    void processPendingChanges();
+
+    void onDirListFinished();
+
+    void onFileSystemInfoFinished();
+
+    void onFileInfoFinished();
+
+    void onIdleReload();
+
+    void onMountAdded(const Mount& mnt);
+
+    void onMountRemoved(const Mount& mnt);
+
+private:
+    FilePath dirPath_;
+    GFileMonitorPtr dirMonitor_;
+
+    std::shared_ptr<const FileInfo> dirInfo_;
+    DirListJob* dirlist_job;
+    std::vector<FileInfoJob*> fileinfoJobs_;
+    FileSystemInfoJob* fsInfoJob_;
+
+    std::shared_ptr<VolumeManager> volumeManager_;
+
+    /* for file monitor */
+    bool has_idle_reload_handler;
+    bool has_idle_update_handler;
+    FilePathList paths_to_add;
+    FilePathList paths_to_update;
+    FilePathList paths_to_del;
+    // GSList* pending_jobs;
+    bool pending_change_notify;
+    bool filesystem_info_pending;
+
+    bool wants_incremental;
+    bool stop_emission; /* don't set it 1 bit to not lock other bits */
+
+    // NOTE: Here, FileInfo::path().baseName().get() should be used as the key value, not FileInfo::name(),
+    // because the latter is not always the same as the former and the former will be used for comparison.
+    std::unordered_map<const std::string, std::shared_ptr<const FileInfo>, std::hash<std::string>> files_;
+
+    /* filesystem info - set in query thread, read in main */
+    uint64_t fs_total_size;
+    uint64_t fs_free_size;
+    GCancellablePtr fs_size_cancellable;
+
+    bool has_fs_info : 1;
+    bool defer_content_test : 1;
+
+    static std::unordered_map<FilePath, std::weak_ptr<Folder>, FilePathHash> cache_;
+    static std::mutex mutex_;
+};
+
+}
+
+#endif // __LIBFM_QT_FM2_FOLDER_H__

--- a/libfm-qt/core/folderconfig.cpp
+++ b/libfm-qt/core/folderconfig.cpp
@@ -1,0 +1,275 @@
+/**
+ * SECTION:fm-folder-config
+ * @short_description: Folder specific settings cache.
+ * @title: FmFolderConfig
+ *
+ * @include: libfm/fm.h
+ *
+ * This API represents access to folder-specific configuration settings.
+ * Each setting is a key/value pair. To use it the descriptor should be
+ * opened first, then required operations performed, then closed. Each
+ * opened descriptor holds a lock on the cache so it is not adviced to
+ * keep it somewhere.
+ */
+
+#include "folderconfig.h"
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <cerrno>
+
+namespace Fm {
+
+CStrPtr FolderConfig::globalConfigFile_;
+
+// FIXME: sharing the same keyfile object everywhere is problematic
+// FIXME: this is MT-unsafe
+static GKeyFile* fc_cache = nullptr;
+static bool fc_cache_changed = FALSE;
+
+FolderConfig::FolderConfig():
+    keyFile_{nullptr},
+    changed_{false} {
+}
+
+FolderConfig::FolderConfig(const Fm::FilePath& path): FolderConfig{} {
+    (void)open(path);
+}
+
+FolderConfig::~FolderConfig() {
+    if(isOpened()) {
+        GErrorPtr err;
+        close(err);
+    }
+}
+
+bool FolderConfig::open(const Fm::FilePath& path) {
+    if(isOpened()) {  // the config is already opened
+        return false;
+    }
+
+    changed_ = FALSE;
+    if(path.isNative()) {
+        /* clear .directory file first */
+        auto sub_path = path.child(".directory");
+        configFilePath_ = sub_path.toString();
+
+        // FIXME: this only works for local filesystem and it's a blocking call. :-(
+        if(g_file_test(configFilePath_.get(), G_FILE_TEST_EXISTS)) {
+            keyFile_ = g_key_file_new();
+            if(g_key_file_load_from_file(keyFile_, configFilePath_.get(),
+                                         GKeyFileFlags(G_KEY_FILE_KEEP_COMMENTS | G_KEY_FILE_KEEP_TRANSLATIONS),
+                                         nullptr) &&
+                    g_key_file_has_group(keyFile_, "File Manager")) {
+                group_ = CStrPtr{g_strdup("File Manager")};
+                return true;
+            }
+            g_key_file_free(keyFile_);
+        }
+    }
+
+    // No per-folder config file.
+    // use the global key file instead and use the folder path as group key
+    configFilePath_.reset();
+    group_ = path.toString();
+
+    // FIXME: we should use ref counting here. glib 2.36+ supports g_key_file_ref()
+    keyFile_ = fc_cache;
+    return true;
+}
+
+
+bool FolderConfig::close(GErrorPtr& err) {
+    bool ret = TRUE;
+    if(!isOpened()) {
+        return false;
+    }
+
+    if(configFilePath_) {
+        if(changed_) {
+            char* out;
+            gsize len;
+
+            out = g_key_file_to_data(keyFile_, &len, &err);
+            if(!out || !g_file_set_contents(configFilePath_.get(), out, len, &err)) {
+                ret = FALSE;
+            }
+            g_free(out);
+        }
+        configFilePath_.reset();
+        g_key_file_free(keyFile_);
+    }
+    else {
+        group_.reset();
+        if(changed_) {
+            fc_cache_changed = TRUE;
+        }
+    }
+    keyFile_ = nullptr;
+    return ret;
+}
+
+bool FolderConfig::isOpened() const {
+    return keyFile_ != nullptr;
+}
+
+bool FolderConfig::isEmpty() {
+    return !g_key_file_has_group(keyFile_, group_.get());
+}
+
+bool FolderConfig::getInteger(const char* key, int* val) {
+    GErrorPtr err;
+    auto ret = g_key_file_get_integer(keyFile_, group_.get(), key, &err);
+    if(err) {
+        return false;
+    }
+    *val = ret;
+    return true;
+}
+
+bool FolderConfig::getUint64(const char* key, uint64_t *val) {
+    GError* error = nullptr;
+#if GLIB_CHECK_VERSION(2, 26, 0)
+    guint64 ret = g_key_file_get_uint64(keyFile_, group_.get(), key, &error);
+#else
+    gchar* s, *end;
+    guint64 ret;
+
+    s = g_key_file_get_value(keyFile_, group_.get(), key, &error);
+#endif
+    if(error) {
+        g_error_free(error);
+        return FALSE;
+    }
+#if !GLIB_CHECK_VERSION(2, 26, 0)
+    ret = g_ascii_strtoull(s, &end, 10);
+    if(*s == '\0' || *end != '\0') {
+        g_free(s);
+        return FALSE;
+    }
+    g_free(s);
+#endif
+    *val = ret;
+    return TRUE;
+}
+
+bool FolderConfig::getDouble(const char* key,
+                                     double* val) {
+    GError* error = nullptr;
+    double ret = g_key_file_get_double(keyFile_, group_.get(), key, &error);
+    if(error) {
+        g_error_free(error);
+        return FALSE;
+    }
+    *val = ret;
+    return TRUE;
+}
+
+bool FolderConfig::getBoolean(const char* key, bool* val) {
+    GErrorPtr err;
+    auto ret = g_key_file_get_boolean(keyFile_, group_.get(), key, &err);
+    if(err) {
+        return false;
+    }
+    *val = ret;
+    return true;
+}
+
+char* FolderConfig::getString(const char* key) {
+    return g_key_file_get_string(keyFile_, group_.get(), key, nullptr);
+}
+
+char** FolderConfig::getStringList(const char* key, gsize* length) {
+    return g_key_file_get_string_list(keyFile_, group_.get(), key, length, nullptr);
+}
+
+
+void FolderConfig::setInteger(const char* key, int val) {
+    changed_ = TRUE;
+    g_key_file_set_integer(keyFile_, group_.get(), key, val);
+}
+
+void FolderConfig::setUint64(const char* key, uint64_t val) {
+    changed_ = TRUE;
+#if GLIB_CHECK_VERSION(2, 26, 0)
+    g_key_file_set_uint64(keyFile_, group_.get(), key, val);
+#else
+    gchar* result = g_strdup_printf("%" G_GUINT64_FORMAT, val);
+    g_key_file_set_value(keyFile_, group_.get(), key, result);
+    g_free(result);
+#endif
+}
+
+void FolderConfig::setDouble(const char* key, double val) {
+    changed_ = TRUE;
+    g_key_file_set_double(keyFile_, group_.get(), key, val);
+}
+
+void FolderConfig::setBoolean(const char* key, bool val) {
+    changed_ = TRUE;
+    g_key_file_set_boolean(keyFile_, group_.get(), key, val);
+}
+
+void FolderConfig::setString(const char* key, const char* string) {
+    changed_ = TRUE;
+    g_key_file_set_string(keyFile_, group_.get(), key, string);
+}
+
+void FolderConfig::setStringList(const char* key,
+                                      const gchar* const list[], gsize length) {
+    changed_ = TRUE;
+    g_key_file_set_string_list(keyFile_, group_.get(), key, list, length);
+}
+
+void FolderConfig::removeKey(const char* key) {
+    changed_ = TRUE;
+    g_key_file_remove_key(keyFile_, group_.get(), key, nullptr);
+}
+
+void FolderConfig::purge() {
+    changed_ = TRUE;
+    g_key_file_remove_group(keyFile_, group_.get(), nullptr);
+}
+
+// static
+void FolderConfig::saveCache(void) {
+    char* out;
+    gsize len;
+
+    /* if per-directory cache was changed since last invocation then save it */
+    if(fc_cache_changed && (out = g_key_file_to_data(fc_cache, &len, nullptr))) {
+        /* FIXME: create dir */
+        /* create temp file with settings */
+        GFilePtr gfile{g_file_new_for_path(globalConfigFile_.get()), false};
+        GErrorPtr err;
+        /* do safe replace now, the file is important enough to be lost */
+        if(g_file_replace_contents(gfile.get(), out, len, nullptr, true, G_FILE_CREATE_PRIVATE, nullptr, nullptr, &err)) {
+            fc_cache_changed = FALSE;
+        }
+        else {
+            g_warning("cannot save %s: %s", globalConfigFile_.get(), err->message);
+        }
+        g_free(out);
+    }
+}
+
+// static
+void FolderConfig::finalize(void) {
+    saveCache();
+    g_key_file_free(fc_cache);
+    fc_cache = nullptr;
+}
+
+// static
+void FolderConfig::init(const char* globalConfigFile) {
+    globalConfigFile_ = CStrPtr{g_strdup(globalConfigFile)};
+    fc_cache = g_key_file_new();
+    if(!g_key_file_load_from_file(fc_cache, globalConfigFile_.get(), G_KEY_FILE_NONE, nullptr)) {
+        // fail to load the config file.
+        // fallback to the legacy libfm config file for backward compatibility
+        CStrPtr legacyConfigFlie{g_build_filename(g_get_user_config_dir(), "libfm/dir-settings.conf", nullptr)};
+        g_key_file_load_from_file(fc_cache, legacyConfigFlie.get(), G_KEY_FILE_NONE, nullptr);
+    }
+}
+
+} // namespace Fm

--- a/libfm-qt/core/folderconfig.h
+++ b/libfm-qt/core/folderconfig.h
@@ -1,0 +1,80 @@
+#ifndef FOLDERCONFIG_H
+#define FOLDERCONFIG_H
+
+#include "../libfmqtglobals.h"
+
+#include "filepath.h"
+#include "gioptrs.h"
+
+#include <cstdint>
+
+namespace Fm {
+
+class LIBFM_QT_API FolderConfig {
+public:
+    FolderConfig();
+
+    explicit FolderConfig(const Fm::FilePath& path);
+
+    ~FolderConfig();
+
+    bool open(const Fm::FilePath& path);
+
+    bool close(GErrorPtr& err);
+
+    bool isOpened() const;
+
+    void purge(void);
+
+    void removeKey(const char* key);
+
+    void setStringList(const char* key, const gchar* const list[], gsize length);
+
+    void setString(const char* key, const char* string);
+
+    void setBoolean(const char* key, bool val);
+
+    void setDouble(const char* key, double val);
+
+    void setUint64(const char* key, std::uint64_t val);
+
+    void setInteger(const char* key, int val);
+
+    char** getStringList(const char* key, gsize* length);
+
+    char* getString(const char* key);
+
+    bool getBoolean(const char* key, bool* val);
+
+    bool getDouble(const char* key, double* val);
+
+    bool getUint64(const char* key, std::uint64_t* val);
+
+    bool getInteger(const char* key, int* val);
+
+    bool isEmpty(void);
+
+    // this needs to be called before using Fm::FolderConfig
+    static void init(const char* globalConfigFile);
+
+    static void finalize();
+
+    static void saveCache(void);
+
+// the object cannot be copied.
+private:
+    FolderConfig(const FolderConfig& other) = delete;
+    FolderConfig& operator=(const FolderConfig& other) = delete;
+
+private:
+    GKeyFile *keyFile_;
+    CStrPtr group_; /* allocated if not in cache */
+    CStrPtr configFilePath_; /* NULL if in cache */
+    bool changed_;
+
+    static CStrPtr globalConfigFile_;
+};
+
+} // namespace Fm
+
+#endif // FOLDERCONFIG_H

--- a/libfm-qt/core/gioptrs.h
+++ b/libfm-qt/core/gioptrs.h
@@ -1,0 +1,140 @@
+#ifndef GIOPTRS_H
+#define GIOPTRS_H
+// define smart pointers for GIO data types
+
+#include <glib.h>
+#include <gio/gio.h>
+#include "gobjectptr.h"
+#include "cstrptr.h"
+
+namespace Fm {
+
+typedef GObjectPtr<GFile> GFilePtr;
+typedef GObjectPtr<GFileInfo> GFileInfoPtr;
+typedef GObjectPtr<GFileMonitor> GFileMonitorPtr;
+typedef GObjectPtr<GCancellable> GCancellablePtr;
+typedef GObjectPtr<GFileEnumerator> GFileEnumeratorPtr;
+
+typedef GObjectPtr<GInputStream> GInputStreamPtr;
+typedef GObjectPtr<GFileInputStream> GFileInputStreamPtr;
+typedef GObjectPtr<GOutputStream> GOutputStreamPtr;
+typedef GObjectPtr<GFileOutputStream> GFileOutputStreamPtr;
+
+typedef GObjectPtr<GIcon> GIconPtr;
+
+typedef GObjectPtr<GVolumeMonitor> GVolumeMonitorPtr;
+typedef GObjectPtr<GVolume> GVolumePtr;
+typedef GObjectPtr<GMount> GMountPtr;
+
+typedef GObjectPtr<GAppInfo> GAppInfoPtr;
+
+
+class GErrorPtr {
+public:
+    GErrorPtr(): err_{nullptr} {
+    }
+
+    GErrorPtr(GError*&& err) noexcept: err_{err} {
+        err = nullptr;
+    }
+
+    GErrorPtr(const GErrorPtr& other) = delete;
+
+    GErrorPtr(GErrorPtr&& other) noexcept: err_{other.err_} {
+        other.err_ = nullptr;
+    }
+
+    GErrorPtr(std::uint32_t domain, unsigned int code, const char* msg):
+        GErrorPtr{g_error_new_literal(domain, code, msg)} {
+    }
+
+    GErrorPtr(std::uint32_t domain, unsigned int code, const QString& msg):
+        GErrorPtr{domain, code, msg.toUtf8().constData()} {
+    }
+
+    ~GErrorPtr() {
+        reset();
+    }
+
+    std::uint32_t domain() const {
+        if(err_ != nullptr) {
+            return err_->domain;
+        }
+        return 0;
+    }
+
+    unsigned int code() const {
+        if(err_ != nullptr) {
+            return err_->code;
+        }
+        return 0;
+    }
+
+    QString message() const {
+        if(err_ != nullptr) {
+            return QString::fromUtf8(err_->message);
+        }
+        return QString();
+    }
+
+    void reset() {
+        if(err_) {
+            g_error_free(err_);
+        }
+        err_ = nullptr;
+    }
+
+    GError* get() const {
+        return err_;
+    }
+
+    GErrorPtr& operator = (const GErrorPtr& other) = delete;
+
+    GErrorPtr& operator = (GErrorPtr&& other) noexcept {
+        reset();
+        err_ = other.err_;
+        other.err_ = nullptr;
+        return *this;
+    }
+
+    GErrorPtr& operator = (GError*&& err) {
+        reset();
+        err_ = err;
+        return *this;
+    }
+
+    GError** operator&() {
+        return &err_;
+    }
+
+    GError* operator->() {
+        return err_;
+    }
+
+    const GError* operator->() const {
+        return err_;
+    }
+
+    bool operator == (const GErrorPtr& other) const {
+        return err_ == other.err_;
+    }
+
+    bool operator == (GError* err) const {
+        return err_ == err;
+    }
+
+    bool operator != (std::nullptr_t) const {
+        return err_ != nullptr;
+    }
+
+    operator bool() const {
+        return err_ != nullptr;
+    }
+
+private:
+    GError* err_;
+};
+
+} //namespace Fm
+
+#endif // GIOPTRS_H

--- a/libfm-qt/core/gobjectptr.h
+++ b/libfm-qt/core/gobjectptr.h
@@ -1,0 +1,104 @@
+#ifndef FM2_GOBJECTPTR_H
+#define FM2_GOBJECTPTR_H
+
+#include "../libfmqtglobals.h"
+#include <glib.h>
+#include <glib-object.h>
+#include <cstddef>
+#include <QDebug>
+
+namespace Fm {
+
+template <typename T>
+class LIBFM_QT_API GObjectPtr {
+public:
+
+    explicit GObjectPtr(): gobj_{nullptr} {
+    }
+
+    explicit GObjectPtr(T* gobj, bool add_ref = true): gobj_{gobj} {
+        if(gobj_ != nullptr && add_ref)
+            g_object_ref(gobj_);
+    }
+
+    GObjectPtr(const GObjectPtr& other): gobj_{other.gobj_ ? reinterpret_cast<T*>(g_object_ref(other.gobj_)) : nullptr} {
+    }
+
+    GObjectPtr(GObjectPtr&& other) noexcept: gobj_{other.release()} {
+    }
+
+    ~GObjectPtr() {
+        if(gobj_ != nullptr)
+            g_object_unref(gobj_);
+    }
+
+    T* get() const {
+        return gobj_;
+    }
+
+    T* release() {
+        T* tmp = gobj_;
+        gobj_ = nullptr;
+        return tmp;
+    }
+
+    void reset() {
+        if(gobj_ != nullptr)
+            g_object_unref(gobj_);
+        gobj_ = nullptr;
+    }
+
+    GObjectPtr& operator = (const GObjectPtr& other) {
+        if (*this == other)
+            return *this;
+
+        if(gobj_ != nullptr)
+            g_object_unref(gobj_);
+        gobj_ = other.gobj_ ? reinterpret_cast<T*>(g_object_ref(other.gobj_)) : nullptr;
+        return *this;
+    }
+
+    GObjectPtr& operator = (GObjectPtr&& other) noexcept {
+        if (this == &other)
+            return *this;
+
+        if(gobj_ != nullptr)
+            g_object_unref(gobj_);
+        gobj_ = other.release();
+        return *this;
+    }
+
+    GObjectPtr& operator = (T* gobj) {
+        if (*this == gobj)
+            return *this;
+
+        if(gobj_ != nullptr)
+            g_object_unref(gobj_);
+        gobj_ = gobj ? reinterpret_cast<T*>(g_object_ref(gobj_)) : nullptr;
+        return *this;
+    }
+
+    bool operator == (const GObjectPtr& other) const {
+        return gobj_ == other.gobj_;
+    }
+
+    bool operator == (T* gobj) const {
+        return gobj_ == gobj;
+    }
+
+    bool operator != (std::nullptr_t) const {
+        return gobj_ != nullptr;
+    }
+
+    operator bool() const {
+        return gobj_ != nullptr;
+    }
+
+private:
+    mutable T* gobj_;
+};
+
+
+} // namespace Fm
+
+#endif // FM2_GOBJECTPTR_H

--- a/libfm-qt/core/iconinfo.cpp
+++ b/libfm-qt/core/iconinfo.cpp
@@ -1,0 +1,164 @@
+#include "iconinfo.h"
+#include "iconinfo_p.h"
+#include <cstring>
+
+namespace Fm {
+
+std::unordered_map<GIcon*, std::shared_ptr<IconInfo>, IconInfo::GIconHash, IconInfo::GIconEqual> IconInfo::cache_;
+std::mutex IconInfo::mutex_;
+QList<QIcon> IconInfo::fallbackQicons_;
+
+static const char* fallbackIconNames[] = {
+    "unknown",
+    "application-octet-stream",
+    "application-x-generic",
+    "text-x-generic",
+    nullptr
+};
+
+static QIcon getFirst(const QList<QIcon> & icons)
+{
+    for (const auto & icon : icons) {
+        if (!icon.isNull())
+            return icon;
+    }
+    return QIcon{};
+}
+
+IconInfo::IconInfo(const char* name):
+    gicon_{g_themed_icon_new(name), false} {
+}
+
+IconInfo::IconInfo(const GIconPtr gicon):
+    gicon_{std::move(gicon)} {
+}
+
+IconInfo::~IconInfo() {
+}
+
+// static
+std::shared_ptr<const IconInfo> IconInfo::fromName(const char* name) {
+    GObjectPtr<GIcon> gicon{g_themed_icon_new(name), false};
+    return fromGIcon(gicon);
+}
+
+// static
+std::shared_ptr<const IconInfo> IconInfo::fromGIcon(GIconPtr gicon) {
+    if(Q_LIKELY(gicon)) {
+        std::lock_guard<std::mutex> lock{mutex_};
+        auto it = cache_.find(gicon.get());
+        if(it != cache_.end()) {
+            return it->second;
+        }
+        // not found in the cache, create a new entry for it.
+        auto icon = std::make_shared<IconInfo>(std::move(gicon));
+        cache_.insert(std::make_pair(icon->gicon_.get(), icon));
+        return icon;
+    }
+    return std::shared_ptr<const IconInfo>{};
+}
+
+void IconInfo::updateQIcons() {
+    std::lock_guard<std::mutex> lock{mutex_};
+    for(auto& elem: cache_) {
+        auto& info = elem.second;
+        info->internalQicons_.clear();
+    }
+}
+
+QIcon IconInfo::qicon() const {
+    if(Q_UNLIKELY(qicon_.isNull() && gicon_)) {
+        if(!G_IS_FILE_ICON(gicon_.get())) {
+            qicon_ = QIcon(new IconEngine{shared_from_this()});
+        }
+        else {
+            qicon_ = getFirst(internalQicons_);
+        }
+    }
+    return qicon_;
+}
+
+QList<QIcon> IconInfo::qiconsFromNames(const char* const* names) {
+    QList<QIcon> icons;
+    // qDebug("names: %p", names);
+    for(const gchar* const* name = names; *name; ++name) {
+        // qDebug("icon name=%s", *name);
+        icons.push_back(QIcon::fromTheme(QString::fromUtf8(*name)));
+    }
+    return icons;
+}
+
+std::forward_list<std::shared_ptr<const IconInfo>> IconInfo::emblems() const {
+    std::forward_list<std::shared_ptr<const IconInfo>> result;
+    if(hasEmblems()) {
+        const GList* emblems_glist = g_emblemed_icon_get_emblems(G_EMBLEMED_ICON(gicon_.get()));
+        for(auto l = emblems_glist; l; l = l->next) {
+            auto gemblem = G_EMBLEM(l->data);
+            GIconPtr gemblem_icon{g_emblem_get_icon(gemblem), true};
+            result.emplace_front(fromGIcon(gemblem_icon));
+        }
+        result.reverse();
+    }
+    return result;
+}
+
+QIcon IconInfo::internalQicon() const {
+    QIcon ret_icon;
+    if(Q_UNLIKELY(internalQicons_.isEmpty())) {
+        GIcon* gicon = gicon_.get();
+        if(G_IS_EMBLEMED_ICON(gicon_.get())) {
+            gicon = g_emblemed_icon_get_icon(G_EMBLEMED_ICON(gicon));
+        }
+        if(G_IS_THEMED_ICON(gicon)) {
+            const gchar* const* names = g_themed_icon_get_names(G_THEMED_ICON(gicon));
+            internalQicons_ = qiconsFromNames(names);
+        }
+        else if(G_IS_FILE_ICON(gicon)) {
+            GFile* file = g_file_icon_get_file(G_FILE_ICON(gicon));
+            CStrPtr fpath{g_file_get_path(file)};
+            internalQicons_.push_back(QIcon(QString::fromUtf8(fpath.get())));
+        }
+
+    }
+
+    ret_icon = getFirst(internalQicons_);
+
+    // fallback to default icon
+    if(Q_UNLIKELY(ret_icon.isNull())) {
+        if(Q_UNLIKELY(fallbackQicons_.isEmpty())) {
+            fallbackQicons_ = qiconsFromNames(fallbackIconNames);
+        }
+        ret_icon = getFirst(fallbackQicons_);
+    }
+    return ret_icon;
+}
+
+// compatibility function for leagcy libfm
+// FIXME: deprecate this later.
+extern "C" GIcon* _fm_icon_from_name(const char* name) {
+    GIcon* gicon = nullptr;
+    if(G_LIKELY(name)) {
+        gchar *dot;
+        if(g_path_is_absolute(name)) {
+            GFile* gicon_file = g_file_new_for_path(name);
+            gicon = g_file_icon_new(gicon_file);
+            g_object_unref(gicon_file);
+        }
+        else if(G_UNLIKELY((dot = strrchr((char*)name, '.')) != nullptr && dot > name &&
+                (g_ascii_strcasecmp(&dot[1], "png") == 0
+                 || g_ascii_strcasecmp(&dot[1], "svg") == 0
+                 || g_ascii_strcasecmp(&dot[1], "xpm") == 0))) {
+            /* some desktop entries have invalid icon name which contains
+               suffix so let strip the suffix from such invalid name */
+            dot = g_strndup(name, dot - name);
+            gicon = g_themed_icon_new_with_default_fallbacks(dot);
+            g_free(dot);
+        }
+        else {
+            gicon = g_themed_icon_new_with_default_fallbacks(name);
+        }
+    }
+    return gicon;
+}
+
+} // namespace Fm

--- a/libfm-qt/core/iconinfo.h
+++ b/libfm-qt/core/iconinfo.h
@@ -1,0 +1,111 @@
+/*
+ *      fm-icon.h
+ *
+ *      Copyright 2009 Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *      Copyright 2013 Andriy Grytsenko (LStranger) <andrej@rep.kiev.ua>
+ *
+ *      This file is a part of the Libfm library.
+ *
+ *      This library is free software; you can redistribute it and/or
+ *      modify it under the terms of the GNU Lesser General Public
+ *      License as published by the Free Software Foundation; either
+ *      version 2.1 of the License, or (at your option) any later version.
+ *
+ *      This library is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *      Lesser General Public License for more details.
+ *
+ *      You should have received a copy of the GNU Lesser General Public
+ *      License along with this library; if not, write to the Free Software
+ *      Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+
+#ifndef __FM2_ICON_INFO_H__
+#define __FM2_ICON_INFO_H__
+
+#include "../libfmqtglobals.h"
+#include <gio/gio.h>
+#include "gioptrs.h"
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <forward_list>
+#include <QIcon>
+
+
+namespace Fm {
+
+class LIBFM_QT_API IconInfo: public std::enable_shared_from_this<IconInfo> {
+public:
+    friend class IconEngine;
+
+    explicit IconInfo() {}
+
+    explicit IconInfo(const char* name);
+
+    explicit IconInfo(const GIconPtr gicon);
+
+    ~IconInfo();
+
+    static std::shared_ptr<const IconInfo> fromName(const char* name);
+
+    static std::shared_ptr<const IconInfo> fromGIcon(GIconPtr gicon);
+
+    static std::shared_ptr<const IconInfo> fromGIcon(GIcon* gicon) {
+        return fromGIcon(GIconPtr{gicon, true});
+    }
+
+    static void updateQIcons();
+
+    GIconPtr gicon() const {
+        return gicon_;
+    }
+
+    QIcon qicon() const;
+
+    bool hasEmblems() const {
+        return G_IS_EMBLEMED_ICON(gicon_.get());
+    }
+
+    std::forward_list<std::shared_ptr<const IconInfo>> emblems() const;
+
+    bool isValid() const {
+        return gicon_ != nullptr;
+    }
+
+private:
+
+    static QList<QIcon> qiconsFromNames(const char* const* names);
+
+    // actual QIcon loaded by QIcon::fromTheme
+    QIcon internalQicon() const;
+
+    struct GIconHash {
+        std::size_t operator()(GIcon* gicon) const {
+            return g_icon_hash(gicon);
+        }
+    };
+
+    struct GIconEqual {
+        bool operator()(GIcon* gicon1, GIcon* gicon2) const {
+            return g_icon_equal(gicon1, gicon2);
+        }
+    };
+
+private:
+    GIconPtr gicon_;
+    mutable QIcon qicon_;
+    mutable QList<QIcon> internalQicons_;
+
+    static std::unordered_map<GIcon*, std::shared_ptr<IconInfo>, GIconHash, GIconEqual> cache_;
+    static std::mutex mutex_;
+    static QList<QIcon> fallbackQicons_;
+};
+
+} // namespace Fm
+
+Q_DECLARE_METATYPE(std::shared_ptr<const Fm::IconInfo>)
+
+#endif /* __FM2_ICON_INFO_H__ */

--- a/libfm-qt/core/iconinfo_p.h
+++ b/libfm-qt/core/iconinfo_p.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2016  Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef FM_ICONENGINE_H
+#define FM_ICONENGINE_H
+
+#include <QIconEngine>
+#include <QPainter>
+#include "../libfmqtglobals.h"
+#include "iconinfo.h"
+#include <gio/gio.h>
+
+namespace Fm {
+
+class IconEngine: public QIconEngine {
+public:
+
+    IconEngine(std::shared_ptr<const Fm::IconInfo> info);
+
+    ~IconEngine() override;
+
+    QSize actualSize(const QSize& size, QIcon::Mode mode, QIcon::State state) override;
+
+    // not supported
+    void addFile(const QString& /*fileName*/, const QSize& /*size*/, QIcon::Mode /*mode*/, QIcon::State /*state*/) override {}
+
+    // not supported
+    void addPixmap(const QPixmap& /*pixmap*/, QIcon::Mode /*mode*/, QIcon::State /*state*/) override {}
+
+    QIconEngine* clone() const override;
+
+    QString key() const override;
+
+    void paint(QPainter* painter, const QRect& rect, QIcon::Mode mode, QIcon::State state) override;
+
+    QPixmap pixmap(const QSize& size, QIcon::Mode mode, QIcon::State state) override;
+
+    void virtual_hook(int id, void* data) override;
+
+private:
+    std::weak_ptr<const Fm::IconInfo> info_;
+};
+
+IconEngine::IconEngine(std::shared_ptr<const IconInfo> info): info_{info} {
+}
+
+IconEngine::~IconEngine() {
+}
+
+QSize IconEngine::actualSize(const QSize& size, QIcon::Mode mode, QIcon::State state) {
+    auto info = info_.lock();
+    return info ? info->internalQicon().actualSize(size, mode, state) : QSize{};
+}
+
+QIconEngine* IconEngine::clone() const {
+    IconEngine* engine = new IconEngine(info_.lock());
+    return engine;
+}
+
+QString IconEngine::key() const {
+    return QStringLiteral("Fm::IconEngine");
+}
+
+void IconEngine::paint(QPainter* painter, const QRect& rect, QIcon::Mode mode, QIcon::State state) {
+    auto info = info_.lock();
+    if(info) {
+        info->internalQicon().paint(painter, rect, Qt::AlignCenter, mode, state);
+    }
+}
+
+QPixmap IconEngine::pixmap(const QSize& size, QIcon::Mode mode, QIcon::State state) {
+    auto info = info_.lock();
+    return info ? info->internalQicon().pixmap(size, mode, state) : QPixmap{};
+}
+
+void IconEngine::virtual_hook(int id, void* data) {
+    auto info = info_.lock();
+    switch(id) {
+    case QIconEngine::AvailableSizesHook: {
+        auto* args = reinterpret_cast<QIconEngine::AvailableSizesArgument*>(data);
+        args->sizes = info ? info->internalQicon().availableSizes(args->mode, args->state) : QList<QSize>{};
+        break;
+    }
+    case QIconEngine::IconNameHook: {
+        QString* result = reinterpret_cast<QString*>(data);
+        *result = info ? info->internalQicon().name() : QString{};
+        break;
+    }
+    case QIconEngine::IsNullHook: {
+        bool* result = reinterpret_cast<bool*>(data);
+        *result = info ? info->internalQicon().isNull() : true;
+        break;
+    }
+    case QIconEngine::ScaledPixmapHook: {
+        auto* arg = reinterpret_cast<QIconEngine::ScaledPixmapArgument*>(data);
+        arg->pixmap = info ? info->internalQicon().pixmap(arg->size, arg->mode, arg->state) : QPixmap{};
+        break;
+    }
+    }
+}
+
+} // namespace Fm
+
+#endif // FM_ICONENGINE_H

--- a/libfm-qt/core/job.cpp
+++ b/libfm-qt/core/job.cpp
@@ -1,0 +1,57 @@
+#include "job.h"
+#include "job_p.h"
+
+namespace Fm {
+
+Job::Job():
+    paused_{false},
+    cancellable_{g_cancellable_new(), false},
+    cancellableHandler_{g_signal_connect(cancellable_.get(), "cancelled", G_CALLBACK(_onCancellableCancelled), this)} {
+}
+
+Job::~Job() {
+    if(cancellable_) {
+        g_cancellable_disconnect(cancellable_.get(), cancellableHandler_);
+    }
+}
+
+void Job::runAsync(QThread::Priority priority) {
+    auto thread = new JobThread(this);
+    connect(thread, &QThread::finished, thread, &QThread::deleteLater);
+    if(autoDelete()) {
+        connect(this, &Job::finished, this, &Job::deleteLater);
+    }
+    thread->start(priority);
+}
+
+void Job::cancel() {
+    g_cancellable_cancel(cancellable_.get());
+}
+
+void Job::run() {
+    exec();
+    Q_EMIT finished();
+}
+
+
+Job::ErrorAction Job::emitError(const GErrorPtr &err, Job::ErrorSeverity severity) {
+    ErrorAction response = ErrorAction::CONTINUE;
+    // if the error is already handled, don't emit it.
+    if(err.domain() == G_IO_ERROR && err.code() == G_IO_ERROR_FAILED_HANDLED) {
+        return response;
+    }
+    Q_EMIT error(err, severity, response);
+
+    if(severity == ErrorSeverity::CRITICAL || response == ErrorAction::ABORT) {
+        cancel();
+    }
+    else if(response == ErrorAction::RETRY ) {
+        /* If the job is already cancelled, retry is not allowed. */
+        if(isCancelled() || (err.domain() == G_IO_ERROR && err.code() == G_IO_ERROR_CANCELLED)) {
+            response = ErrorAction::CONTINUE;
+        }
+    }
+    return response;
+}
+
+} // namespace Fm

--- a/libfm-qt/core/job.h
+++ b/libfm-qt/core/job.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2016 Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef __LIBFM_QT_FM_JOB_H__
+#define __LIBFM_QT_FM_JOB_H__
+
+#include <QObject>
+#include <QtGlobal>
+#include <QThread>
+#include <QRunnable>
+#include <memory>
+#include <gio/gio.h>
+#include "gobjectptr.h"
+#include "gioptrs.h"
+#include "../libfmqtglobals.h"
+
+
+namespace Fm {
+
+/*
+ * Fm::Job can be used in several different modes.
+ * 1. run with QThreadPool::start()
+ * 2. call runAsync(), which will create a new QThread and move the object to the thread.
+ * 3. create a new QThread, and connect the started() signal to the slot Job::run()
+ * 4. Directly call Job::run(), which executes synchrounously as a normal blocking call
+*/
+
+class LIBFM_QT_API Job: public QObject, public QRunnable {
+    Q_OBJECT
+public:
+
+    enum class ErrorAction{
+        CONTINUE,
+        RETRY,
+        ABORT
+    };
+
+    enum class ErrorSeverity {
+        UNKNOWN,
+        WARNING,
+        MILD,
+        MODERATE,
+        SEVERE,
+        CRITICAL
+    };
+
+    explicit Job();
+
+    ~Job() override;
+
+    bool isCancelled() const {
+        return g_cancellable_is_cancelled(cancellable_.get());
+    }
+
+    void runAsync(QThread::Priority priority = QThread::InheritPriority);
+
+    bool pause();
+
+    void resume();
+
+    const GCancellablePtr& cancellable() const {
+        return cancellable_;
+    }
+
+Q_SIGNALS:
+    void cancelled();
+
+    void finished();
+
+    // this signal should be connected with Qt::BlockingQueuedConnection
+    void error(const GErrorPtr& err, ErrorSeverity severity, ErrorAction& response);
+
+public Q_SLOTS:
+
+    void cancel();
+
+    void run() override;
+
+protected:
+    ErrorAction emitError(const GErrorPtr& err, ErrorSeverity severity = ErrorSeverity::MODERATE);
+
+    // all derived job subclasses should do their work in this method.
+    virtual void exec() = 0;
+
+private:
+    static void _onCancellableCancelled(GCancellable* cancellable, Job* _this) {
+        _this->onCancellableCancelled(cancellable);
+    }
+
+    void onCancellableCancelled(GCancellable* /*cancellable*/) {
+        Q_EMIT cancelled();
+    }
+
+private:
+    bool paused_;
+    GCancellablePtr cancellable_;
+    gulong cancellableHandler_;
+};
+
+
+}
+
+#endif // __LIBFM_QT_FM_JOB_H__

--- a/libfm-qt/core/job_p.h
+++ b/libfm-qt/core/job_p.h
@@ -1,0 +1,26 @@
+#ifndef JOB_P_H
+#define JOB_P_H
+
+#include <QThread>
+#include "job.h"
+
+namespace Fm {
+
+class JobThread: public QThread {
+    Q_OBJECT
+public:
+    JobThread(Job* job): job_{job} {
+    }
+
+protected:
+
+    void run() override {
+        job_->run();
+    }
+
+    Job* job_;
+};
+
+} // namespace Fm
+
+#endif // JOB_P_H

--- a/libfm-qt/core/legacy/fm-app-info.c
+++ b/libfm-qt/core/legacy/fm-app-info.c
@@ -1,0 +1,523 @@
+/*
+ *      fm-app-info.c
+ *
+ *      Copyright 2010 Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *      Copyright 2012-2015 Andriy Grytsenko (LStranger) <andrej@rep.kiev.ua>
+ *
+ *      This file is a part of the Libfm library.
+ *
+ *      This library is free software; you can redistribute it and/or
+ *      modify it under the terms of the GNU Lesser General Public
+ *      License as published by the Free Software Foundation; either
+ *      version 2.1 of the License, or (at your option) any later version.
+ *
+ *      This library is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *      Lesser General Public License for more details.
+ *
+ *      You should have received a copy of the GNU Lesser General Public
+ *      License along with this library; if not, write to the Free Software
+ *      Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/**
+ * SECTION:fm-app-info
+ * @short_description: FM application launch handlers
+ * @title: GAppInfo extensions
+ *
+ * @include: libfm/fm.h
+ *
+ */
+
+#include "fm-app-info.h"
+#include "fm-config.h"
+
+#include <string.h>
+#include <gio/gdesktopappinfo.h>
+
+static void append_file_to_cmd(GFile* gf, GString* cmd)
+{
+    char* file = g_file_get_path(gf);
+    char* quote;
+    if(file == NULL) /* trash:// gvfs is incomplete in resolving it */
+    {
+        /* we can retrieve real path from GVFS >= 1.13.3 */
+        if(g_file_has_uri_scheme(gf, "trash"))
+        {
+            GFileInfo *inf;
+            const char *orig_path;
+
+            inf = g_file_query_info(gf, G_FILE_ATTRIBUTE_STANDARD_TARGET_URI,
+                                    G_FILE_QUERY_INFO_NONE, NULL, NULL);
+            if(inf == NULL) /* failed */
+                return;
+            orig_path = g_file_info_get_attribute_string(inf, G_FILE_ATTRIBUTE_STANDARD_TARGET_URI);
+            if(orig_path != NULL) /* success */
+                file = g_filename_from_uri(orig_path, NULL, NULL);
+            g_object_unref(inf);
+        }
+        if(file == NULL)
+            return;
+    }
+    quote = g_shell_quote(file);
+    g_string_append(cmd, quote);
+    g_string_append_c(cmd, ' ');
+    g_free(quote);
+    g_free(file);
+}
+
+static void append_uri_to_cmd(GFile* gf, GString* cmd)
+{
+    char* uri = NULL;
+    if(!g_file_has_uri_scheme(gf, "file"))
+    {
+        /* When gvfs-fuse is in use, try to convert all URIs that are not file:// to 
+         * their corresponding FUSE-mounted local paths.  GDesktopAppInfo internally does this, too.
+         * With this, non-gtk+ applications can correctly open files in gvfs-mounted remote filesystems.
+         */
+        char* path = g_file_get_path(gf);
+        if(path)
+        {
+            uri = g_filename_to_uri(path, NULL, NULL);
+            g_free(path);
+        }
+    }
+    if(!uri)
+    {
+        uri = g_file_get_uri(gf);
+    }
+
+    if(uri)
+    {
+        char* quote = g_shell_quote(uri);
+        g_string_append(cmd, quote);
+        g_string_append_c(cmd, ' ');
+        g_free(quote);
+        g_free(uri);
+    }
+}
+
+static char* expand_exec_macros(GAppInfo* app, const char* full_desktop_path,
+                                GKeyFile* kf, GList** gfiles, GList **launching)
+{
+    GString* cmd;
+    const char* exec = g_app_info_get_commandline(app);
+    const char* p;
+    GFile *file = NULL;
+    GList *fl = NULL;
+
+    if (exec == NULL)
+        return NULL;
+    cmd = g_string_sized_new(1024);
+    for(p = exec; *p; ++p)
+    {
+        if(*p == '%')
+        {
+            ++p;
+            if(!*p)
+                break;
+            switch(*p)
+            {
+            case 'f':
+                if (file == NULL && *gfiles)
+                {
+                    *launching = *gfiles;
+                    file = G_FILE((*gfiles)->data);
+                    *gfiles = g_list_remove_link(*gfiles, *gfiles);
+                }
+                if (file)
+                    append_file_to_cmd(file, cmd);
+                break;
+            case 'F':
+                if (*gfiles)
+                    *launching = fl = *gfiles;
+                *gfiles = NULL;
+                g_list_foreach(fl, (GFunc)append_file_to_cmd, cmd);
+                break;
+            case 'u':
+                if (file == NULL && *gfiles)
+                {
+                    *launching = *gfiles;
+                    file = G_FILE((*gfiles)->data);
+                    *gfiles = g_list_remove_link(*gfiles, *gfiles);
+                }
+                if (file)
+                    append_uri_to_cmd(file, cmd);
+                break;
+            case 'U':
+                if (*gfiles)
+                    *launching = fl = *gfiles;
+                *gfiles = NULL;
+                g_list_foreach(fl, (GFunc)append_uri_to_cmd, cmd);
+                break;
+            case '%':
+                g_string_append_c(cmd, '%');
+                break;
+            case 'i':
+                if (kf == NULL)
+                    break;
+                {
+                    char* icon_name = g_key_file_get_locale_string(kf, "Desktop Entry",
+                                                                   "Icon", NULL, NULL);
+                    if(icon_name)
+                    {
+                        g_string_append(cmd, "--icon ");
+                        g_string_append(cmd, icon_name);
+                        g_free(icon_name);
+                    }
+                    break;
+                }
+            case 'c':
+                {
+                    const char* name = g_app_info_get_name(app);
+                    if(name)
+                    {
+                        char *quoted = g_shell_quote(name);
+                        g_string_append(cmd, quoted);
+                        g_free(quoted);
+                    }
+                    break;
+                }
+            case 'k':
+                /* append the file path of the desktop file */
+                if(full_desktop_path)
+                {
+                    /* FIXME: how about quoting here? */
+                    char* desktop_location = g_path_get_dirname(full_desktop_path);
+                    g_string_append(cmd, desktop_location);
+                    g_free(desktop_location);
+                }
+                break;
+            }
+        }
+        else
+            g_string_append_c(cmd, *p);
+    }
+
+    /* if files are provided but the Exec key doesn't contain %f, %F, %u, or %U */
+    if(*gfiles && !*launching)
+    {
+        /* treat as %f */
+        *launching = *gfiles;
+        file = G_FILE((*gfiles)->data);
+        *gfiles = g_list_remove_link(*gfiles, *gfiles);
+        g_string_append_c(cmd, ' ');
+        append_file_to_cmd(file, cmd);
+    }
+
+    return g_string_free(cmd, FALSE);
+}
+
+struct ChildSetup
+{
+    char* display;
+    char* sn_id;
+    pid_t pgid;
+};
+
+static void child_setup(gpointer user_data)
+{
+    struct ChildSetup* data = (struct ChildSetup*)user_data;
+    if(data->display)
+        g_setenv ("DISPLAY", data->display, TRUE);
+    if(data->sn_id)
+        g_setenv ("DESKTOP_STARTUP_ID", data->sn_id, TRUE);
+    /* Move child to grandparent group so it will not die with parent */
+    setpgid(0, data->pgid);
+}
+
+static void child_watch(GPid pid, gint status, gpointer user_data)
+{
+    /*
+     * Ensure that we don't double fork and break pkexec
+     */
+    g_spawn_close_pid(pid);
+}
+
+// defined in terminal.cpp
+char* expand_terminal(char* cmd, gboolean keep_open, GError** error);
+
+
+static gboolean do_launch(GAppInfo* appinfo, const char* full_desktop_path,
+                          GKeyFile* kf, GList** inp, GAppLaunchContext* ctx,
+                          GError** err)
+{
+    gboolean ret = FALSE;
+    GList *gfiles = NULL;
+    char* cmd, *path;
+    char** argv;
+    int argc;
+    gboolean use_terminal;
+    GAppInfoCreateFlags flags;
+    GPid pid;
+
+    cmd = expand_exec_macros(appinfo, full_desktop_path, kf, inp, &gfiles);
+    g_print("%s\n", cmd);
+    if (cmd == NULL || cmd[0] == '\0')
+    {
+        g_free(cmd);
+        /* FIXME: localize the string below in 1.3.0 */
+        g_set_error_literal(err, G_IO_ERROR, G_IO_ERROR_FAILED,
+                            "Desktop entry contains no valid Exec line");
+        return FALSE;
+    }
+    /* FIXME: do check for TryExec/Exec */
+    if(G_LIKELY(kf))
+        use_terminal = g_key_file_get_boolean(kf, "Desktop Entry", "Terminal", NULL);
+    else
+    {
+        flags = GPOINTER_TO_UINT(g_object_get_data(G_OBJECT(appinfo), "flags"));
+        use_terminal = (flags & G_APP_INFO_CREATE_NEEDS_TERMINAL) != 0;
+    }
+
+    if(use_terminal)
+    {
+        /* FIXME: is it right key to mark this option? */
+        gboolean keep_open = FALSE;
+        char* term_cmd;
+
+        if(G_LIKELY(kf))
+            keep_open = g_key_file_get_boolean(kf, "Desktop Entry",
+                                               "X-KeepTerminal", NULL);
+        term_cmd = expand_terminal(cmd, keep_open, err);
+        g_free(cmd);
+        if(!term_cmd)
+        {
+            g_list_free(gfiles);
+            return FALSE;
+        }
+        cmd = term_cmd;
+    }
+
+    g_debug("launch command: <%s>", cmd);
+    if(g_shell_parse_argv(cmd, &argc, &argv, err))
+    {
+        struct ChildSetup data;
+        if(ctx)
+        {
+            gboolean use_sn;
+            if(G_LIKELY(kf) && g_key_file_has_key(kf, "Desktop Entry", "StartupNotify", NULL))
+                use_sn = g_key_file_get_boolean(kf, "Desktop Entry", "StartupNotify", NULL);
+            else if(fm_config->force_startup_notify)
+            {
+                /* if the app doesn't explicitly ask us not to use sn,
+                 * and fm_config->force_startup_notify is TRUE, then
+                 * use it by default, unless it's a console app. */
+                use_sn = !use_terminal; /* we only use sn for GUI apps by default */
+                /* FIXME: console programs should use sn_id of terminal emulator instead. */
+            }
+            else
+                use_sn = FALSE;
+            data.display = g_app_launch_context_get_display(ctx, appinfo, gfiles);
+
+            if(use_sn)
+                data.sn_id = g_app_launch_context_get_startup_notify_id(ctx, appinfo, gfiles);
+            else
+                data.sn_id = NULL;
+        }
+        else
+        {
+            data.display = NULL;
+            data.sn_id = NULL;
+        }
+        g_debug("sn_id = %s", data.sn_id);
+
+        if(G_LIKELY(kf))
+            path = g_key_file_get_string(kf, "Desktop Entry", "Path", NULL);
+        else
+            path = NULL;
+
+        data.pgid = getpgid(getppid());
+                        /* only absolute path is usable, ignore others */
+        ret = g_spawn_async((path && path[0] == '/') ? path : NULL, argv, NULL,
+                            G_SPAWN_SEARCH_PATH | G_SPAWN_DO_NOT_REAP_CHILD,
+                            child_setup, &data, &pid, err);
+        if (ret)
+            /* Ensure that we don't double fork and break pkexec */
+            g_child_watch_add(pid, child_watch, NULL);
+        else if (data.sn_id)
+            /* Notify launch context about failure */
+            g_app_launch_context_launch_failed(ctx, data.sn_id);
+
+        g_free(path);
+        g_free(data.display);
+        g_free(data.sn_id);
+
+        g_strfreev(argv);
+    }
+    g_free(cmd);
+    g_list_free(gfiles);
+    return ret;
+}
+
+/**
+ * fm_app_info_launch
+ * @appinfo: application info to launch
+ * @files: (element-type GFile): files to use in run substitutions
+ * @launch_context: (allow-none): a launch context
+ * @error: (out) (allow-none): location to store error
+ *
+ * Launches desktop application doing substitutions in application info.
+ *
+ * Returns: %TRUE if application was launched.
+ *
+ * Since: 0.1.15
+ */
+gboolean fm_app_info_launch(GAppInfo *appinfo, GList *files,
+                            GAppLaunchContext *launch_context, GError **error)
+{
+    gboolean supported = FALSE, ret = FALSE;
+    GList *launch_list = g_list_copy(files);
+    if(G_IS_DESKTOP_APP_INFO(appinfo))
+    {
+        const char *id;
+
+#if GLIB_CHECK_VERSION(2,24,0)
+        /* if GDesktopAppInfo knows the filename then let use it */
+        id = g_desktop_app_info_get_filename(G_DESKTOP_APP_INFO(appinfo));
+        if(id) /* this is a desktop entry file */
+        {
+            /* load the desktop entry file to obtain more info */
+            GKeyFile* kf = g_key_file_new();
+            supported = g_key_file_load_from_file(kf, id, 0, NULL);
+            if(supported) do {
+                ret = do_launch(appinfo, id, kf, &launch_list, launch_context, error);
+            } while (launch_list && ret);
+            g_key_file_free(kf);
+            id = NULL;
+        }
+        else /* otherwise try application id */
+#endif
+            id = g_app_info_get_id(appinfo);
+        if(id) /* this is an installed application */
+        {
+            /* load the desktop entry file to obtain more info */
+            GKeyFile* kf = g_key_file_new();
+            char* rel_path = g_strconcat("applications/", id, NULL);
+            char* full_desktop_path;
+            supported = g_key_file_load_from_data_dirs(kf, rel_path,
+                                                       &full_desktop_path, 0, NULL);
+            g_free(rel_path);
+            if(supported)
+            {
+                do {
+                    ret = do_launch(appinfo, full_desktop_path, kf, &launch_list,
+                                    launch_context, error);
+                } while (launch_list && ret);
+                g_free(full_desktop_path);
+            }
+            g_key_file_free(kf);
+        }
+        else
+        {
+#if GLIB_CHECK_VERSION(2,24,0)
+            if (!supported) /* it was launched otherwise, see above */
+#endif
+            {
+                /* If this is created with fm_app_info_create_from_commandline() */
+                if(g_object_get_data(G_OBJECT(appinfo), "flags"))
+                {
+                    supported = TRUE;
+                    do {
+                        ret = do_launch(appinfo, NULL, NULL, &launch_list,
+                                        launch_context, error);
+                    } while (launch_list && ret);
+                }
+            }
+        }
+    }
+    else
+        supported = FALSE;
+    g_list_free(launch_list);
+
+    if(!supported) /* fallback to GAppInfo::launch */
+        return g_app_info_launch(appinfo, files, launch_context, error);
+    return ret;
+}
+
+/**
+ * fm_app_info_launch_uris
+ * @appinfo: application info to launch
+ * @uris: (element-type char *): URIs to use in run substitutions
+ * @launch_context: (allow-none): a launch context
+ * @error: (out) (allow-none): location to store error
+ *
+ * Launches desktop application doing substitutions in application info.
+ *
+ * Returns: %TRUE if application was launched.
+ *
+ * Since: 0.1.15
+ */
+gboolean fm_app_info_launch_uris(GAppInfo *appinfo, GList *uris,
+                                 GAppLaunchContext *launch_context, GError **error)
+{
+    GList* gfiles = NULL;
+    gboolean ret;
+
+    for(;uris; uris = uris->next)
+    {
+        GFile* gf = g_file_new_for_uri((char*)uris->data);
+        if(gf)
+            gfiles = g_list_prepend(gfiles, gf);
+    }
+
+    gfiles = g_list_reverse(gfiles);
+    ret = fm_app_info_launch(appinfo, gfiles, launch_context, error);
+
+    g_list_foreach(gfiles, (GFunc)g_object_unref, NULL);
+    g_list_free(gfiles);
+    return ret;
+}
+
+/**
+ * fm_app_info_launch_default_for_uri
+ * @uri: the uri to show
+ * @launch_context: (allow-none): a launch context
+ * @error: (out) (allow-none): location to store error
+ *
+ * Utility function that launches the default application
+ * registered to handle the specified uri. Synchronous I/O
+ * is done on the uri to detect the type of the file if
+ * required.
+ *
+ * Returns: %TRUE if application was launched.
+ *
+ * Since: 0.1.15
+ */
+gboolean fm_app_info_launch_default_for_uri(const char *uri,
+                                            GAppLaunchContext *launch_context,
+                                            GError **error)
+{
+    /* FIXME: implement this */
+    return g_app_info_launch_default_for_uri(uri, launch_context, error);
+}
+
+/**
+ * fm_app_info_create_from_commandline
+ * @commandline: the commandline to use
+ * @application_name: (allow-none): the application name, or %NULL to use @commandline
+ * @flags: flags that can specify details of the created #GAppInfo
+ * @error: (out) (allow-none): location to store error
+ *
+ * Creates a new #GAppInfo from the given information.
+ *
+ * Note that for @commandline, the quoting rules of the Exec key of the
+ * <ulink url="http://freedesktop.org/Standards/desktop-entry-spec">freedesktop.org Desktop
+ * Entry Specification</ulink> are applied. For example, if the @commandline contains
+ * percent-encoded URIs, the percent-character must be doubled in order to prevent it from
+ * being swallowed by Exec key unquoting. See the specification for exact quoting rules.
+ *
+ * Returns: (transfer full): new #GAppInfo for given command.
+ *
+ * Since: 0.1.15
+ */
+GAppInfo* fm_app_info_create_from_commandline(const char *commandline,
+                                              const char *application_name,
+                                              GAppInfoCreateFlags flags,
+                                              GError **error)
+{
+    GAppInfo* app = g_app_info_create_from_commandline(commandline, application_name, flags, error);
+    g_object_set_data(G_OBJECT(app), "flags", GUINT_TO_POINTER(flags));
+    return app;
+}

--- a/libfm-qt/core/legacy/fm-app-info.h
+++ b/libfm-qt/core/legacy/fm-app-info.h
@@ -1,0 +1,47 @@
+/*
+ *      fm-app-info.h
+ *
+ *      Copyright 2010 Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *
+ *      This file is a part of the Libfm library.
+ *
+ *      This library is free software; you can redistribute it and/or
+ *      modify it under the terms of the GNU Lesser General Public
+ *      License as published by the Free Software Foundation; either
+ *      version 2.1 of the License, or (at your option) any later version.
+ *
+ *      This library is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *      Lesser General Public License for more details.
+ *
+ *      You should have received a copy of the GNU Lesser General Public
+ *      License along with this library; if not, write to the Free Software
+ *      Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef __FM_APP_INFO_H__
+#define __FM_APP_INFO_H__
+
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+gboolean fm_app_info_launch(GAppInfo *appinfo, GList *files,
+                            GAppLaunchContext *launch_context, GError **error);
+
+gboolean fm_app_info_launch_uris(GAppInfo *appinfo, GList *uris,
+                                 GAppLaunchContext *launch_context, GError **error);
+
+gboolean fm_app_info_launch_default_for_uri(const char *uri,
+                                            GAppLaunchContext *launch_context,
+                                            GError **error);
+
+GAppInfo* fm_app_info_create_from_commandline(const char *commandline,
+                                              const char *application_name,
+                                              GAppInfoCreateFlags flags,
+                                              GError **error);
+
+G_END_DECLS
+
+#endif /* __FM_APP_INFO_H__ */

--- a/libfm-qt/core/legacy/fm-config.c
+++ b/libfm-qt/core/legacy/fm-config.c
@@ -1,0 +1,89 @@
+/*
+ *      fm-config.c
+ *
+ *      Copyright 2009 PCMan <pcman.tw@gmail.com>
+ *      Copyright 2009 Juergen Hoetzel <juergen@archlinux.org>
+ *      Copyright 2012-2014 Andriy Grytsenko (LStranger) <andrej@rep.kiev.ua>
+ *      Copyright 2016 Mamoru TASAKA <mtasaka@fedoraproject.org>
+ *
+ *      This file is a part of the Libfm library.
+ *
+ *      This library is free software; you can redistribute it and/or
+ *      modify it under the terms of the GNU Lesser General Public
+ *      License as published by the Free Software Foundation; either
+ *      version 2.1 of the License, or (at your option) any later version.
+ *
+ *      This library is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *      Lesser General Public License for more details.
+ *
+ *      You should have received a copy of the GNU Lesser General Public
+ *      License along with this library; if not, write to the Free Software
+ *      Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/**
+ * SECTION:fm-config
+ * @short_description: Configuration file support for applications that use libfm.
+ * @title: FmConfig
+ *
+ * @include: libfm/fm.h
+ *
+ * The #FmConfig represents basic configuration options that are used by
+ * libfm classes and methods. Methods of class #FmConfig allow use either
+ * default file (~/.config/libfm/libfm.conf) or another one to load the
+ * configuration and to save it.
+ */
+
+#include "fm-config.h"
+
+/* global config object */
+static FmConfig globalConfig_;
+FmConfig* fm_config = &globalConfig_;
+
+void fm_config_init() {
+    FmConfig *self = fm_config;
+    self->single_click = FM_CONFIG_DEFAULT_SINGLE_CLICK;
+    self->auto_selection_delay = FM_CONFIG_DEFAULT_AUTO_SELECTION_DELAY;
+    self->use_trash = FM_CONFIG_DEFAULT_USE_TRASH;
+    self->confirm_del = FM_CONFIG_DEFAULT_CONFIRM_DEL;
+    self->confirm_trash = FM_CONFIG_DEFAULT_CONFIRM_TRASH;
+    self->big_icon_size = FM_CONFIG_DEFAULT_BIG_ICON_SIZE;
+    self->small_icon_size = FM_CONFIG_DEFAULT_SMALL_ICON_SIZE;
+    self->pane_icon_size = FM_CONFIG_DEFAULT_PANE_ICON_SIZE;
+    self->thumbnail_size = FM_CONFIG_DEFAULT_THUMBNAIL_SIZE;
+    self->show_thumbnail = FM_CONFIG_DEFAULT_SHOW_THUMBNAIL;
+    self->thumbnail_local = FM_CONFIG_DEFAULT_THUMBNAIL_LOCAL;
+    self->thumbnail_max = FM_CONFIG_DEFAULT_THUMBNAIL_MAX;
+    self->external_thumbnail_max = FM_CONFIG_DEFAULT_EXTERNAL_THUMBNAIL_MAX;
+    /* show_internal_volumes defaulted to FALSE */
+    /* si_unit defaulted to FALSE */
+    /* terminal and archiver defaulted to NULL */
+    /* drop_default_action defaulted to 0 */
+    /* modules_blacklist and modules_whitelist defaulted to NULL */
+    /* format_cmd defaulted to NULL */
+    /* list_view_size_units defaulted to NULL */
+    /* saved_search defaulted to NULL */
+    self->advanced_mode = FALSE;
+    self->force_startup_notify = FM_CONFIG_DEFAULT_FORCE_S_NOTIFY;
+    self->backup_as_hidden = FM_CONFIG_DEFAULT_BACKUP_HIDDEN;
+    self->no_usb_trash = FM_CONFIG_DEFAULT_NO_USB_TRASH;
+    self->no_child_non_expandable = FM_CONFIG_DEFAULT_NO_EXPAND_EMPTY;
+    self->show_full_names = FM_CONFIG_DEFAULT_SHOW_FULL_NAMES;
+    self->shadow_hidden = FM_CONFIG_DEFAULT_SHADOW_HIDDEN;
+    self->only_user_templates = FM_CONFIG_DEFAULT_ONLY_USER_TEMPLATES;
+    self->template_run_app = FM_CONFIG_DEFAULT_TEMPLATE_RUN_APP;
+    self->template_type_once = FM_CONFIG_DEFAULT_TEMPL_TYPE_ONCE;
+    self->defer_content_test = FM_CONFIG_DEFAULT_DEFER_CONTENT_TEST;
+    self->quick_exec = FM_CONFIG_DEFAULT_QUICK_EXEC;
+    self->places_home = FM_CONFIG_DEFAULT_PLACES_HOME;
+    self->places_desktop = FM_CONFIG_DEFAULT_PLACES_DESKTOP;
+    self->places_root = FM_CONFIG_DEFAULT_PLACES_ROOT;
+    self->places_computer = FM_CONFIG_DEFAULT_PLACES_COMPUTER;
+    self->places_trash = FM_CONFIG_DEFAULT_PLACES_TRASH;
+    self->places_applications = FM_CONFIG_DEFAULT_PLACES_APPLICATIONS;
+    self->places_network = FM_CONFIG_DEFAULT_PLACES_NETWORK;
+    self->places_unmounted = FM_CONFIG_DEFAULT_PLACES_UNMOUNTED;
+    self->smart_desktop_autodrop = FM_CONFIG_DEFAULT_SMART_DESKTOP_AUTODROP;
+}

--- a/libfm-qt/core/legacy/fm-config.h
+++ b/libfm-qt/core/legacy/fm-config.h
@@ -1,0 +1,202 @@
+/*
+ *      fm-config.h
+ *
+ *      Copyright 2009 PCMan <pcman.tw@gmail.com>
+ *      Copyright 2009 Juergen Hoetzel <juergen@archlinux.org>
+ *      Copyright 2012-2014 Andriy Grytsenko (LStranger) <andrej@rep.kiev.ua>
+ *
+ *      This file is a part of the Libfm library.
+ *
+ *      This library is free software; you can redistribute it and/or
+ *      modify it under the terms of the GNU Lesser General Public
+ *      License as published by the Free Software Foundation; either
+ *      version 2.1 of the License, or (at your option) any later version.
+ *
+ *      This library is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *      Lesser General Public License for more details.
+ *
+ *      You should have received a copy of the GNU Lesser General Public
+ *      License along with this library; if not, write to the Free Software
+ *      Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+
+#ifndef __FM_CONFIG_H__
+#define __FM_CONFIG_H__
+
+#include <glib-object.h>
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+typedef struct _FmConfig            FmConfig;
+
+#define     FM_CONFIG_DEFAULT_SINGLE_CLICK      FALSE
+#define     FM_CONFIG_DEFAULT_USE_TRASH         TRUE
+#define     FM_CONFIG_DEFAULT_CONFIRM_DEL       TRUE
+#define     FM_CONFIG_DEFAULT_CONFIRM_TRASH     TRUE
+#define     FM_CONFIG_DEFAULT_NO_USB_TRASH      TRUE
+
+#define     FM_CONFIG_DEFAULT_BIG_ICON_SIZE     48
+#define     FM_CONFIG_DEFAULT_SMALL_ICON_SIZE   16
+#define     FM_CONFIG_DEFAULT_PANE_ICON_SIZE    16
+#define     FM_CONFIG_DEFAULT_THUMBNAIL_SIZE    128
+
+#define     FM_CONFIG_DEFAULT_SHOW_THUMBNAIL    TRUE
+#define     FM_CONFIG_DEFAULT_THUMBNAIL_LOCAL   TRUE
+#define     FM_CONFIG_DEFAULT_THUMBNAIL_MAX     2048
+#define     FM_CONFIG_DEFAULT_EXTERNAL_THUMBNAIL_MAX -1
+
+#define     FM_CONFIG_DEFAULT_FORCE_S_NOTIFY    TRUE
+#define     FM_CONFIG_DEFAULT_BACKUP_HIDDEN     TRUE
+#define     FM_CONFIG_DEFAULT_NO_EXPAND_EMPTY   FALSE
+#define     FM_CONFIG_DEFAULT_SHOW_FULL_NAMES   FALSE
+#define     FM_CONFIG_DEFAULT_ONLY_USER_TEMPLATES FALSE
+#define     FM_CONFIG_DEFAULT_TEMPLATE_RUN_APP  FALSE
+#define     FM_CONFIG_DEFAULT_TEMPL_TYPE_ONCE   FALSE
+#define     FM_CONFIG_DEFAULT_SHADOW_HIDDEN     FALSE
+#define     FM_CONFIG_DEFAULT_DEFER_CONTENT_TEST FALSE
+#define     FM_CONFIG_DEFAULT_QUICK_EXEC        FALSE
+#define     FM_CONFIG_DEFAULT_SMART_DESKTOP_AUTODROP TRUE
+
+#define     FM_CONFIG_DEFAULT_PLACES_HOME       TRUE
+#define     FM_CONFIG_DEFAULT_PLACES_DESKTOP    TRUE
+#define     FM_CONFIG_DEFAULT_PLACES_ROOT       FALSE
+#define     FM_CONFIG_DEFAULT_PLACES_COMPUTER   FALSE
+#define     FM_CONFIG_DEFAULT_PLACES_TRASH      TRUE
+#define     FM_CONFIG_DEFAULT_PLACES_APPLICATIONS TRUE
+#define     FM_CONFIG_DEFAULT_PLACES_NETWORK    FALSE
+#define     FM_CONFIG_DEFAULT_PLACES_UNMOUNTED  TRUE
+
+#define     FM_CONFIG_DEFAULT_AUTO_SELECTION_DELAY 600
+
+
+/**
+ * FmConfig:
+ * @terminal: command line to launch terminal emulator
+ * @archiver: desktop_id of the archiver used
+ * @big_icon_size: size of big icons
+ * @small_icon_size: size of small icons
+ * @pane_icon_size: size of side pane icons
+ * @thumbnail_size: size of thumbnail icons
+ * @thumbnail_max: internally create thumbnails only for images not bigger than this, in KB or Kpix
+ * @external_thumbnail_max: allow external thumbnail creation only for files not bigger than this, in KB or Kpix
+ * @auto_selection_delay: (since 1.2.0) delay for autoselection in single-click mode, in ms
+ * @drop_default_action: (since 1.2.0) default action on drop (see #FmDndDestDropAction)
+ * @single_click: single click to open file
+ * @use_trash: delete file to trash can
+ * @confirm_del: ask before deleting files
+ * @confirm_trash: (since 1.2.0) ask before moving files to trash can
+ * @show_thumbnail: show thumbnails
+ * @thumbnail_local: show thumbnails for local files only
+ * @show_internal_volumes: show system internal volumes in side pane. (udisks-only)
+ * @si_unit: use SI prefix for file sizes
+ * @advanced_mode: enable advanced features for experienced user
+ * @force_startup_notify: (since 1.0.1) use startup notify by default
+ * @backup_as_hidden: (since 1.0.1) treat backup files as hidden
+ * @no_usb_trash: (since 1.0.1) don't create trash folder on removable media
+ * @no_child_non_expandable: (since 1.0.1) hide expanders on empty folder
+ * @show_full_names: (since 1.2.0) always show full names in Icon View mode
+ * @shadow_hidden: (since 1.2.0) show icons of hidden files shadowed in the view
+ * @places_home: (since 1.2.0) show 'Home' item in Places
+ * @places_desktop: (since 1.2.0) show 'Desktop' item in Places
+ * @places_applications: (since 1.2.0) show 'Applications' item in Places
+ * @places_trash: (since 1.2.0) show 'Trash' item in Places
+ * @places_root: (since 1.2.0) show '/' item in Places
+ * @places_computer: (since 1.2.0) show 'My computer' item in Places
+ * @places_network: (since 1.2.0) show 'Network' item in Places
+ * @places_unmounted: (since 1.2.0) show unmounted internal volumes in Places
+ * @only_user_templates: (since 1.2.0) show only user defined templates in 'Create...' menu
+ * @template_run_app: (since 1.2.0) run default application after creation from template
+ * @template_type_once: (since 1.2.0) use only one template of each MIME type
+ * @defer_content_test: (since 1.2.0) defer test for content type on folder loading
+ * @quick_exec: (since 1.2.0) don't ask user for action on executable launch
+ * @modules_blacklist: (since 1.2.0) list of modules (mask in form "type:name") to never load
+ * @modules_whitelist: (since 1.2.0) list of excemptions from @modules_blacklist
+ * @list_view_size_units: (since 1.2.0) file size units in list view: h, k, M, G
+ * @format_cmd: (since 1.2.0) command to format the volume (device will be added)
+ * @smart_desktop_autodrop: (since 1.2.0) enable "smart shortcut" auto-action for ~/Desktop
+ * @saved_search: (since 1.2.0) internal saved data of fm_launch_search_simple()
+ */
+struct _FmConfig
+{
+    /*< private >*/
+    GObject parent;
+    char *_cfg_name;
+
+    /*< public >*/
+    char* terminal;
+    char* archiver;
+
+    gint big_icon_size;
+    gint small_icon_size;
+    gint pane_icon_size;
+    gint thumbnail_size;
+    gint thumbnail_max;
+    gint external_thumbnail_max;
+    gint auto_selection_delay;
+    gint drop_default_action;
+
+    gboolean single_click;
+    gboolean use_trash;
+    gboolean confirm_del;
+    gboolean confirm_trash;
+    gboolean show_thumbnail;
+    gboolean thumbnail_local;
+    gboolean show_internal_volumes;
+    gboolean si_unit;
+    gboolean advanced_mode;
+    gboolean force_startup_notify;
+    gboolean backup_as_hidden;
+    gboolean no_usb_trash;
+    gboolean no_child_non_expandable;
+    gboolean show_full_names;
+    gboolean shadow_hidden;
+
+    gboolean places_home;
+    gboolean places_desktop;
+    gboolean places_applications;
+    gboolean places_trash;
+    gboolean places_root;
+    gboolean places_computer;
+    gboolean places_network;
+    gboolean places_unmounted;
+
+    gboolean only_user_templates;
+    gboolean template_run_app;
+    gboolean template_type_once;
+    gboolean defer_content_test;
+    gboolean quick_exec;
+
+    gchar **modules_blacklist;
+    gchar **modules_whitelist;
+    /*< private >*/
+    gchar **system_modules_blacklist; /* concatenated from system, don't save! */
+    /*< public >*/
+
+    gchar *list_view_size_units;
+    gchar *format_cmd;
+
+    gboolean smart_desktop_autodrop;
+    gchar *saved_search;
+    /*< private >*/
+    gpointer _reserved1; /* reserved space for updates until next ABI */
+    gpointer _reserved2;
+    gpointer _reserved3;
+    gpointer _reserved4;
+    gpointer _reserved5;
+    gpointer _reserved6;
+    gpointer _reserved7;
+    GFileMonitor *_cfg_mon;
+};
+
+/* global config object */
+G_MODULE_EXPORT extern FmConfig* fm_config;
+
+void fm_config_init();
+
+G_END_DECLS
+
+#endif /* __FM_CONFIG_H__ */

--- a/libfm-qt/core/legacy/glib-compat.h
+++ b/libfm-qt/core/legacy/glib-compat.h
@@ -1,0 +1,86 @@
+/*
+ *      glib-compat.h
+ *
+ *      Copyright 2011 Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *
+ *      This file is a part of the Libfm library.
+ *
+ *      This library is free software; you can redistribute it and/or
+ *      modify it under the terms of the GNU Lesser General Public
+ *      License as published by the Free Software Foundation; either
+ *      version 2.1 of the License, or (at your option) any later version.
+ *
+ *      This library is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *      Lesser General Public License for more details.
+ *
+ *      You should have received a copy of the GNU Lesser General Public
+ *      License along with this library; if not, write to the Free Software
+ *      Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef __GLIB_COMPAT_H__
+#define __GLIB_COMPAT_H__
+#include <glib.h>
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+/* GLib prior 2.24 have no such macro */
+#ifndef G_DEFINE_INTERFACE
+#   define G_DEFINE_INTERFACE(TN, t_n, T_P) \
+static void     t_n##_default_init        (TN##Interface *klass); \
+GType t_n##_get_type (void) \
+{ \
+  static volatile gsize g_define_type_id__volatile = 0; \
+  if (g_once_init_enter (&g_define_type_id__volatile))  \
+    { \
+      GType g_define_type_id = \
+        g_type_register_static_simple (G_TYPE_INTERFACE, \
+                                       g_intern_static_string (#TN), \
+                                       sizeof (TN##Interface), \
+                                       (GClassInitFunc)t_n##_default_init, \
+                                       0, \
+                                       (GInstanceInitFunc)NULL, \
+                                       (GTypeFlags) 0); \
+      if (T_P) \
+        g_type_interface_add_prerequisite (g_define_type_id, T_P); \
+      g_once_init_leave (&g_define_type_id__volatile, g_define_type_id); \
+    } \
+  return g_define_type_id__volatile; \
+} /* closes t_n##_get_type() */
+#endif /* G_DEFINE_INTERFACE */
+
+#if !GLIB_CHECK_VERSION(2, 28, 0)
+
+/* This API was added in glib 2.28 */
+
+#define g_slist_free_full(slist, free_func)	\
+{ \
+g_slist_foreach(slist, (GFunc)free_func, NULL); \
+g_slist_free(slist); \
+}
+
+#define g_list_free_full(list, free_func)	\
+{ \
+g_list_foreach(list, (GFunc)free_func, NULL); \
+g_list_free(list); \
+}
+
+#endif
+
+#if !GLIB_CHECK_VERSION(2, 34, 0)
+/* This useful API was added in glib 2.34 */
+static inline GSList *g_slist_copy_deep(GSList *list, GCopyFunc func, gpointer user_data)
+{
+    GSList *new_list = g_slist_copy(list), *l;
+    for(l = new_list; l; l = l->next)
+        l->data = func(l->data, user_data);
+    return new_list;
+}
+#endif
+
+G_END_DECLS
+
+#endif

--- a/libfm-qt/core/mimetype.cpp
+++ b/libfm-qt/core/mimetype.cpp
@@ -1,0 +1,64 @@
+#include "mimetype.h"
+#include <cstring>
+
+#include <glib.h>
+#include <gio/gio.h>
+
+using namespace std;
+
+namespace Fm {
+
+std::unordered_map<const char*, std::shared_ptr<const MimeType>, CStrHash, CStrEqual> MimeType::cache_;
+std::mutex MimeType::mutex_;
+
+std::shared_ptr<const MimeType> MimeType::inodeDirectory_;  // inode/directory
+std::shared_ptr<const MimeType> MimeType::inodeShortcut_;  // inode/x-shortcut
+std::shared_ptr<const MimeType> MimeType::inodeMountPoint_;  // inode/mount-point
+std::shared_ptr<const MimeType> MimeType::desktopEntry_; // application/x-desktop
+
+
+MimeType::MimeType(const char* typeName):
+    name_{g_strdup(typeName)},
+    desc_{nullptr} {
+
+    GObjectPtr<GIcon> gicon{g_content_type_get_icon(typeName), false};
+    if(strcmp(typeName, "inode/directory") == 0)
+        g_themed_icon_prepend_name(G_THEMED_ICON(gicon.get()), "folder");
+    else if(g_content_type_can_be_executable(typeName))
+        g_themed_icon_append_name(G_THEMED_ICON(gicon.get()), "application-x-executable");
+
+    icon_ = IconInfo::fromGIcon(gicon);
+}
+
+MimeType::~MimeType () {
+}
+
+//static
+std::shared_ptr<const MimeType> MimeType::fromName(const char* typeName) {
+    std::shared_ptr<const MimeType> ret;
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = cache_.find(typeName);
+    if(it == cache_.end()) {
+        ret = std::make_shared<MimeType>(typeName);
+        cache_.insert(std::make_pair(ret->name_.get(), ret));
+    }
+    else {
+        ret = it->second;
+    }
+    return ret;
+}
+
+// static
+std::shared_ptr<const MimeType> MimeType::guessFromFileName(const char* fileName) {
+    gboolean uncertain;
+    /* let skip scheme and host from non-native names */
+    auto uri_scheme = g_strstr_len(fileName, -1, "://");
+    if(uri_scheme)
+        fileName = strchr(uri_scheme + 3, '/');
+    if(fileName == nullptr)
+        fileName = "unknown";
+    auto type = CStrPtr{g_content_type_guess(fileName, nullptr, 0, &uncertain)};
+    return fromName(type.get());
+}
+
+} // namespace Fm

--- a/libfm-qt/core/mimetype.h
+++ b/libfm-qt/core/mimetype.h
@@ -1,0 +1,172 @@
+/*
+ *      fm-mime-type.h
+ *
+ *      Copyright 2009 - 2012 Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *
+ *      This file is a part of the Libfm library.
+ *
+ *      This library is free software; you can redistribute it and/or
+ *      modify it under the terms of the GNU Lesser General Public
+ *      License as published by the Free Software Foundation; either
+ *      version 2.1 of the License, or (at your option) any later version.
+ *
+ *      This library is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *      Lesser General Public License for more details.
+ *
+ *      You should have received a copy of the GNU Lesser General Public
+ *      License along with this library; if not, write to the Free Software
+ *      Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef _FM2_MIME_TYPE_H_
+#define _FM2_MIME_TYPE_H_
+
+#include "../libfmqtglobals.h"
+#include <glib.h>
+#include <gio/gio.h>
+
+#include <memory>
+#include <vector>
+#include <string>
+#include <mutex>
+#include <cstring>
+#include <forward_list>
+#include <functional>
+
+#include "cstrptr.h"
+#include "gobjectptr.h"
+#include "iconinfo.h"
+#include "thumbnailer.h"
+
+namespace Fm {
+
+class LIBFM_QT_API MimeType {
+public:
+    friend class Thumbnailer;
+
+    explicit MimeType(const char* typeName);
+
+    MimeType() = delete;
+
+    ~MimeType();
+
+    std::shared_ptr<const Thumbnailer> firstThumbnailer() const {
+        std::lock_guard<std::mutex> lock{mutex_};
+        return thumbnailers_.empty() ? nullptr : thumbnailers_.front();
+    }
+
+    void forEachThumbnailer(std::function<bool(const std::shared_ptr<const Thumbnailer>&)> func) const {
+        std::lock_guard<std::mutex> lock{mutex_};
+        for(auto& thumbnailer: thumbnailers_) {
+            if(func(thumbnailer)) {
+                break;
+            }
+        }
+    }
+
+    const std::shared_ptr<const IconInfo>& icon() const {
+        return icon_;
+    }
+
+    const char* name() const {
+        return name_.get();
+    }
+
+    const char* desc() const {
+        if(!desc_) {
+            desc_ = CStrPtr{g_content_type_get_description(name_.get())};
+        }
+        return desc_.get();
+    }
+
+    static std::shared_ptr<const MimeType> fromName(const char* typeName);
+
+    static std::shared_ptr<const MimeType> guessFromFileName(const char* fileName);
+
+    bool isUnknownType() const {
+        return g_content_type_is_unknown(name_.get());
+    }
+
+    bool isDesktopEntry() const {
+        return this == desktopEntry().get();
+    }
+
+    bool isText() const {
+        return g_content_type_is_a(name_.get(), "text/plain");
+    }
+
+    bool isImage() const {
+        return !std::strncmp("image/", name_.get(), 6);
+    }
+
+    bool isMountable() const {
+        return this == inodeMountPoint().get();
+    }
+
+    bool isShortcut() const {
+        return this == inodeShortcut().get();
+    }
+
+    bool isDir() const {
+        return this == inodeDirectory().get();
+    }
+
+    bool canBeExecutable() const {
+        return g_content_type_can_be_executable(name_.get());
+    }
+
+    static std::shared_ptr<const MimeType> inodeDirectory() {   // inode/directory
+        if(!inodeDirectory_)
+            inodeDirectory_ = fromName("inode/directory");
+        return inodeDirectory_;
+    }
+
+    static std::shared_ptr<const MimeType> inodeShortcut() {  // inode/x-shortcut
+        if(!inodeShortcut_)
+            inodeShortcut_ = fromName("inode/x-shortcut");
+        return inodeShortcut_;
+    }
+
+    static std::shared_ptr<const MimeType> inodeMountPoint() {  // inode/mount-point
+        if(!inodeMountPoint_)
+            inodeMountPoint_ = fromName("inode/mount-point");
+        return inodeMountPoint_;
+    }
+
+    static std::shared_ptr<const MimeType> desktopEntry() { // application/x-desktop
+        if(!desktopEntry_)
+            desktopEntry_ = fromName("application/x-desktop");
+        return desktopEntry_;
+    }
+
+private:
+    void removeThumbnailer(std::shared_ptr<const Thumbnailer>& thumbnailer) {
+        std::lock_guard<std::mutex> lock{mutex_};
+        thumbnailers_.remove(thumbnailer);
+    }
+
+    void addThumbnailer(std::shared_ptr<const Thumbnailer> thumbnailer) {
+        std::lock_guard<std::mutex> lock{mutex_};
+        thumbnailers_.push_front(std::move(thumbnailer));
+    }
+
+private:
+    std::shared_ptr<const IconInfo> icon_;
+    CStrPtr name_;
+    mutable CStrPtr desc_;
+    std::forward_list<std::shared_ptr<const Thumbnailer>> thumbnailers_;
+    static std::unordered_map<const char*, std::shared_ptr<const MimeType>, CStrHash, CStrEqual> cache_;
+    static std::mutex mutex_;
+
+    static std::shared_ptr<const MimeType> inodeDirectory_;  // inode/directory
+    static std::shared_ptr<const MimeType> inodeShortcut_;  // inode/x-shortcut
+    static std::shared_ptr<const MimeType> inodeMountPoint_;  // inode/mount-point
+    static std::shared_ptr<const MimeType> desktopEntry_; // application/x-desktop
+};
+
+
+} // namespace Fm
+
+#endif

--- a/libfm-qt/core/templates.cpp
+++ b/libfm-qt/core/templates.cpp
@@ -1,0 +1,151 @@
+#include "templates.h"
+#include "gioptrs.h"
+#include "core/legacy/fm-config.h"
+
+#include <algorithm>
+#include <QDebug>
+
+using namespace std;
+
+namespace Fm {
+
+std::weak_ptr<Templates> Templates::globalInstance_;
+
+TemplateItem::TemplateItem(std::shared_ptr<const FileInfo> file): fileInfo_{file} {
+}
+
+FilePath TemplateItem::filePath() const {
+    auto& target = fileInfo_->target();
+    if(fileInfo_->isDesktopEntry() && !target.empty()) {
+        if(target[0] == '/') { // target is an absolute path
+            return FilePath::fromLocalPath(target.c_str());
+        }
+        else { // resolve relative path
+            return fileInfo_->dirPath().relativePath(target.c_str());
+        }
+    }
+    return fileInfo_->path();
+}
+
+Templates::Templates() : QObject() {
+    if(!fm_config || !fm_config->only_user_templates) {
+        auto* data_dirs = g_get_system_data_dirs();
+        // system-wide template dirs
+        for(auto data_dir = data_dirs; *data_dir; ++data_dir) {
+            CStrPtr dir_name{g_build_filename(*data_dir, "templates", nullptr)};
+            addTemplateDir(dir_name.get());
+        }
+    }
+
+    // user-specific template dir
+    CStrPtr dir_name{g_build_filename(g_get_user_data_dir(), "templates", nullptr)};
+    addTemplateDir(dir_name.get());
+
+    // $XDG_TEMPLATES_DIR (FIXME: this might change at runtime)
+    const gchar *special_dir = g_get_user_special_dir(G_USER_DIRECTORY_TEMPLATES);
+    if (special_dir) {
+        addTemplateDir(special_dir);
+    }
+}
+
+shared_ptr<Templates> Templates::globalInstance() {
+    auto templates = globalInstance_.lock();
+    if(!templates) {
+        templates = make_shared<Templates>();
+        globalInstance_ = templates;
+    }
+    return templates;
+}
+
+void Templates::addTemplateDir(const char* dirPathName) {
+    auto dir_path = FilePath::fromLocalPath(dirPathName);
+    if(dir_path.isValid()) {
+        auto folder = Folder::fromPath(dir_path);
+        if(folder->isLoaded()) {
+            bool typeOnce(fm_config && fm_config->template_type_once);
+            const auto files = folder->files();
+            for(auto& file : files) {
+                if(!typeOnce || std::find(types_.cbegin(), types_.cend(), file->mimeType()) == types_.cend()) {
+                    items_.emplace_back(std::make_shared<TemplateItem>(file));
+                    if(typeOnce) {
+                        types_.emplace_back(file->mimeType());
+                    }
+                }
+            }
+        }
+        connect(folder.get(), &Folder::filesAdded, this, &Templates::onFilesAdded);
+        connect(folder.get(), &Folder::filesChanged, this, &Templates::onFilesChanged);
+        connect(folder.get(), &Folder::filesRemoved, this, &Templates::onFilesRemoved);
+        connect(folder.get(), &Folder::removed, this, &Templates::onTemplateDirRemoved);
+        templateFolders_.emplace_back(std::move(folder));
+    }
+}
+
+void Templates::onFilesAdded(FileInfoList& addedFiles) {
+    for(auto& file : addedFiles) {
+        // FIXME: we do not support subdirs right now (only XFCE supports this)
+        if(file->isHidden() || file->isDir()) {
+            continue;
+        }
+        bool typeOnce(fm_config && fm_config->template_type_once);
+        if(!typeOnce || std::find(types_.cbegin(), types_.cend(), file->mimeType()) == types_.cend()) {
+            items_.emplace_back(std::make_shared<TemplateItem>(file));
+            if(typeOnce) {
+                types_.emplace_back(file->mimeType());
+            }
+            // emit a signal for the addition
+            Q_EMIT itemAdded(items_.back());
+        }
+    }
+}
+
+void Templates::onFilesChanged(std::vector<FileInfoPair>& changePairs) {
+    for(auto& change: changePairs) {
+        auto& old_file = change.first;
+        auto& new_file = change.second;
+        auto it = std::find_if(items_.begin(), items_.end(), [&](const std::shared_ptr<TemplateItem>& item) {
+            return item->fileInfo() == old_file;
+        });
+        if(it != items_.end()) {
+            // emit a signal for the change
+            auto old = *it;
+            *it = std::make_shared<TemplateItem>(new_file);
+            Q_EMIT itemChanged(old, *it);
+        }
+    }
+}
+
+void Templates::onFilesRemoved(FileInfoList& removedFiles) {
+    for(auto& file : removedFiles) {
+        auto filePath = file->path();
+        auto it = std::remove_if(items_.begin(), items_.end(), [&](const std::shared_ptr<TemplateItem>& item) {
+            return item->fileInfo() == file;
+        });
+        for(auto removed_it = it; it != items_.end(); ++it) {
+            // emit a signal for the removal
+            Q_EMIT itemRemoved(*removed_it);
+        }
+        items_.erase(it, items_.end());
+    }
+}
+
+void Templates::onTemplateDirRemoved() {
+    // the whole template dir is removed
+    auto folder = static_cast<Folder*>(sender());
+    if(!folder) {
+        return;
+    }
+    auto dirPath = folder->path();
+
+    // remote all files under this dir
+    auto it = std::remove_if(items_.begin(), items_.end(), [&](const std::shared_ptr<TemplateItem>& item) {
+        return dirPath.isPrefixOf(item->filePath());
+    });
+    for(auto removed_it = it; it != items_.end(); ++it) {
+        // emit a signal for the removal
+        Q_EMIT itemRemoved(*removed_it);
+    }
+    items_.erase(it, items_.end());
+}
+
+} // namespace Fm

--- a/libfm-qt/core/templates.h
+++ b/libfm-qt/core/templates.h
@@ -1,0 +1,101 @@
+#ifndef TEMPLATES_H
+#define TEMPLATES_H
+
+#include "../libfmqtglobals.h"
+
+#include <QObject>
+#include <memory>
+#include <vector>
+#include "folder.h"
+#include "fileinfo.h"
+#include "mimetype.h"
+#include "iconinfo.h"
+
+namespace Fm {
+
+class LIBFM_QT_API TemplateItem {
+public:
+    explicit TemplateItem(std::shared_ptr<const FileInfo> fileInfo);
+
+    QString displayName() const {
+        return fileInfo_->displayName();
+    }
+
+    const std::string& name() const {
+        return fileInfo_->name();
+    }
+
+    std::shared_ptr<const IconInfo> icon() const {
+        return fileInfo_->icon();
+    }
+
+    std::shared_ptr<const FileInfo> fileInfo() const {
+        return fileInfo_;
+    }
+
+    std::shared_ptr<const MimeType> mimeType() const {
+        return fileInfo_->mimeType();
+    }
+
+    FilePath filePath() const;
+
+private:
+    std::shared_ptr<const FileInfo> fileInfo_;
+};
+
+
+class LIBFM_QT_API Templates : public QObject {
+    Q_OBJECT
+public:
+    explicit Templates();
+
+    // FIXME: the first call to this method will get no templates since dir loading is in progress.
+    static std::shared_ptr<Templates> globalInstance();
+
+    void forEachItem(std::function<void (const std::shared_ptr<const TemplateItem>&)> func) const {
+        for(const auto& item : items_) {
+            func(item);
+        }
+    }
+
+    std::vector<std::shared_ptr<const TemplateItem>> items() const {
+        std::vector<std::shared_ptr<const TemplateItem>> tmp_items;
+        for(auto& item: items_) {
+            tmp_items.emplace_back(item);
+        }
+        return tmp_items;
+    }
+
+    bool hasTemplates() const {
+        return !items_.empty();
+    }
+
+Q_SIGNALS:
+    void itemAdded(const std::shared_ptr<const TemplateItem>& item);
+
+    void itemChanged(const std::shared_ptr<const TemplateItem>& oldItem, const std::shared_ptr<const TemplateItem>& newItem);
+
+    void itemRemoved(const std::shared_ptr<const TemplateItem>& item);
+
+private:
+    void addTemplateDir(const char* dirPathName);
+
+private Q_SLOTS:
+    void onFilesAdded(FileInfoList& addedFiles);
+
+    void onFilesChanged(std::vector<FileInfoPair>& changePairs);
+
+    void onFilesRemoved(FileInfoList& removedFiles);
+
+    void onTemplateDirRemoved();
+
+private:
+    std::vector<std::shared_ptr<TemplateItem>> items_;
+    std::vector<std::shared_ptr<Folder>> templateFolders_;
+    std::vector<std::shared_ptr<const MimeType>> types_;
+    static std::weak_ptr<Templates> globalInstance_;
+};
+
+} // namespace Fm
+
+#endif // TEMPLATES_H

--- a/libfm-qt/core/terminal.cpp
+++ b/libfm-qt/core/terminal.cpp
@@ -1,0 +1,183 @@
+#include "terminal.h"
+
+#include <glib.h>
+#include <gio/gdesktopappinfo.h>
+#include <cstring>
+#include <unistd.h>
+
+namespace Fm {
+
+static std::string defaultTerminalName{"xterm"};
+
+#if !GLIB_CHECK_VERSION(2, 28, 0) && !HAVE_DECL_ENVIRON
+extern char** environ;
+#endif
+
+static void child_setup(gpointer user_data) {
+    /* Move child to grandparent group so it will not die with parent */
+    setpgid(0, (pid_t)(gsize)user_data);
+}
+
+bool launchTerminal(const char* programName, const FilePath& workingDir, Fm::GErrorPtr& error) {
+    /* read system terminals file */
+    GKeyFile* kf = g_key_file_new();
+    if(!g_key_file_load_from_file(kf, LIBFM_QT_DATA_DIR "/terminals.list", G_KEY_FILE_NONE, &error)) {
+        g_key_file_free(kf);
+        return false;
+    }
+    auto launch = g_key_file_get_string(kf, programName, "launch", nullptr);
+    auto desktop_id = g_key_file_get_string(kf, programName, "desktop_id", nullptr);
+
+    GDesktopAppInfo* appinfo = nullptr;
+    if(desktop_id) {
+        appinfo = g_desktop_app_info_new(desktop_id);
+    }
+
+    const gchar* cmd;
+    gchar* _cmd = nullptr;
+    if(appinfo) {
+        cmd = g_app_info_get_commandline(G_APP_INFO(appinfo));
+    }
+    else if(launch) {
+        cmd = _cmd = g_strdup_printf("%s %s", programName, launch);
+    }
+    else {
+        cmd = programName;
+    }
+
+#if 0 // FIXME: what's this?
+    if(custom_args) {
+        cmd = g_strdup_printf("%s %s", cmd, custom_args);
+        g_free(_cmd);
+        _cmd = (char*)cmd;
+    }
+#endif
+
+    char** argv;
+    int argc;
+    if(!g_shell_parse_argv(cmd, &argc, &argv, nullptr)) {
+        argv = nullptr;
+    }
+    g_free(_cmd);
+
+    if(appinfo) {
+        g_object_unref(appinfo);
+    }
+    if(!argv) { /* parsing failed */
+        return false;
+    }
+    char** envp;
+#if GLIB_CHECK_VERSION(2, 28, 0)
+    envp = g_get_environ();
+#else
+    envp = g_strdupv(environ);
+#endif
+
+    auto dir = workingDir ? workingDir.localPath() : nullptr;
+    if(dir) {
+#if GLIB_CHECK_VERSION(2, 32, 0)
+        envp = g_environ_setenv(envp, "PWD", dir.get(), TRUE);
+#else
+        char** env = envp;
+
+        if(env) while(*env != nullptr) {
+                if(strncmp(*env, "PWD=", 4) == 0) {
+                    break;
+                }
+                env++;
+            }
+        if(env == nullptr || *env == nullptr) {
+            gint length;
+
+            length = envp ? g_strv_length(envp) : 0;
+            envp = g_renew(gchar*, envp, length + 2);
+            env = &envp[length];
+            env[1] = nullptr;
+        }
+        else {
+            g_free(*env);
+        }
+        *env = g_strdup_printf("PWD=%s", dir);
+#endif
+    }
+
+    bool ret = g_spawn_async(dir.get(), argv, envp, G_SPAWN_SEARCH_PATH,
+                             child_setup, (gpointer)(gsize)getpgid(getppid()),
+                             nullptr, &error);
+    g_strfreev(argv);
+    g_strfreev(envp);
+    g_key_file_free(kf);
+    return ret;
+}
+
+std::vector<CStrPtr> allKnownTerminals() {
+    std::vector<CStrPtr> terminals;
+    GKeyFile* kf = g_key_file_new();
+    if(g_key_file_load_from_file(kf, LIBFM_QT_DATA_DIR "/terminals.list", G_KEY_FILE_NONE, nullptr)) {
+        gsize n;
+        auto programs = g_key_file_get_groups(kf, &n);
+        terminals.reserve(n);
+        for(auto name = programs; *name; ++name) {
+            terminals.emplace_back(*name);
+        }
+        g_free(programs);
+    }
+    g_key_file_free(kf);
+    return terminals;
+}
+
+// used by fm-app-info.c
+extern "C" char* expand_terminal(char* cmd, gboolean keep_open, GError** error) {
+    const char* program = nullptr;
+    CStrPtr open_arg;
+    CStrPtr noclose_arg;
+    CStrPtr custom_args;
+
+    /* read system terminals file */
+    GKeyFile* kf = g_key_file_new();
+    if(g_key_file_load_from_file(kf, LIBFM_QT_DATA_DIR "/terminals.list", G_KEY_FILE_NONE, error)) {
+        if(g_key_file_has_group(kf, defaultTerminalName.c_str())) {
+            program = defaultTerminalName.c_str();
+            open_arg = CStrPtr{g_key_file_get_string(kf, program, "open_arg", nullptr)};
+            noclose_arg = CStrPtr{g_key_file_get_string(kf, program, "noclose_arg", nullptr)};
+            custom_args = CStrPtr{g_key_file_get_string(kf, program, "custom_args", nullptr)};
+        }
+    }
+    g_key_file_free(kf);
+
+    const char* opts;
+    /* if %s is not found, fallback to -e */
+    /* bug #3457335: Crash on application start with Terminal=true. */
+    /* fallback to xterm if a terminal emulator is not found. */
+    if(!program) {
+        /* FIXME: we should not hard code xterm here. :-(
+         * It's better to prompt the user and let he or she set
+         * his preferred terminal emulator. */
+        program = "xterm";
+        open_arg = CStrPtr{g_strdup("-e")};
+    }
+
+    if(keep_open && noclose_arg)
+        opts = noclose_arg.get();
+    else
+        opts = open_arg.get();
+
+    char* ret = nullptr;
+    if(custom_args)
+        ret = g_strdup_printf("%s %s %s %s", program, custom_args.get(),
+                              opts, cmd);
+    else
+        ret = g_strdup_printf("%s %s %s", program, opts, cmd);
+
+    return ret;
+}
+
+const std::string defaultTerminal() {
+    return defaultTerminalName;
+}
+
+void setDefaultTerminal(std::string program) {
+    defaultTerminalName = program;
+}
+
+} // namespace Fm

--- a/libfm-qt/core/terminal.h
+++ b/libfm-qt/core/terminal.h
@@ -1,0 +1,26 @@
+#ifndef TERMINAL_H
+#define TERMINAL_H
+
+#include "../libfmqtglobals.h"
+#include "gioptrs.h"
+#include "filepath.h"
+#include <vector>
+#include <string>
+
+namespace Fm {
+
+LIBFM_QT_API bool launchTerminal(const char* programName, const FilePath& workingDir, GErrorPtr& error);
+
+LIBFM_QT_API std::vector<CStrPtr> allKnownTerminals();
+
+LIBFM_QT_API const std::string defaultTerminal();
+
+LIBFM_QT_API void setDefaultTerminal(std::string program);
+
+inline bool launchDefaultTerminal(const FilePath& workingDir, GErrorPtr& error) {
+    return launchTerminal(defaultTerminal().c_str(), workingDir, error);
+}
+
+} // namespace Fm
+
+#endif // TERMINAL_H

--- a/libfm-qt/core/thumbnailer.cpp
+++ b/libfm-qt/core/thumbnailer.cpp
@@ -1,0 +1,141 @@
+#include "thumbnailer.h"
+#include "mimetype.h"
+#include <string>
+#include <QDebug>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+namespace Fm {
+
+std::mutex Thumbnailer::mutex_;
+std::vector<std::shared_ptr<Thumbnailer>> Thumbnailer::allThumbnailers_;
+
+Thumbnailer::Thumbnailer(const char* id, GKeyFile* kf):
+    id_{g_strdup(id)},
+    try_exec_{g_key_file_get_string(kf, "Thumbnailer Entry", "TryExec", nullptr)},
+    exec_{g_key_file_get_string(kf, "Thumbnailer Entry", "Exec", nullptr)} {
+}
+
+CStrPtr Thumbnailer::commandForUri(const char* uri, const char* output_file, guint size) const {
+    if(exec_) {
+        /* FIXME: how to handle TryExec? */
+
+        /* parse the command line and do required substitutions according to:
+         * https://developer.gnome.org/integration-guide/stable/thumbnailer.html.en
+         */
+        GString* cmd_line = g_string_sized_new(1024);
+        const char* p;
+        for(p = exec_.get(); *p; ++p) {
+            if(G_LIKELY(*p != '%')) {
+                g_string_append_c(cmd_line, *p);
+            }
+            else {
+                char* quoted;
+                ++p;
+                switch(*p) {
+                case '\0':
+                    break;
+                case 's':
+                    g_string_append_printf(cmd_line, "%d", size);
+                    break;
+                case 'i': {
+                    char* src_path = g_filename_from_uri(uri, nullptr, nullptr);
+                    if(src_path) {
+                        quoted = g_shell_quote(src_path);
+                        g_string_append(cmd_line, quoted);
+                        g_free(quoted);
+                        g_free(src_path);
+                    }
+                    break;
+                }
+                case 'u':
+                    quoted = g_shell_quote(uri);
+                    g_string_append(cmd_line, quoted);
+                    g_free(quoted);
+                    break;
+                case 'o':
+                    g_string_append(cmd_line, output_file);
+                    break;
+                default:
+                    g_string_append_c(cmd_line, '%');
+                    if(*p != '%') {
+                        g_string_append_c(cmd_line, *p);
+                    }
+                }
+            }
+        }
+        return CStrPtr{g_string_free(cmd_line, FALSE)};
+    }
+    return nullptr;
+}
+
+bool Thumbnailer::run(const char* uri, const char* output_file, int size) const {
+    auto cmd = commandForUri(uri, output_file, size);
+    qDebug() << cmd.get();
+    int status;
+    bool ret = g_spawn_command_line_sync(cmd.get(), nullptr, nullptr, &status, nullptr);
+    return ret && status == 0;
+}
+
+static void find_thumbnailers_in_data_dir(std::unordered_map<std::string, const char*>& hash, const char* data_dir) {
+    CStrPtr dir_path{g_build_filename(data_dir, "thumbnailers", nullptr)};
+    GDir* dir = g_dir_open(dir_path.get(), 0, nullptr);
+    if(dir) {
+        const char* basename;
+        while((basename = g_dir_read_name(dir)) != nullptr) {
+            /* we only want filenames with .thumbnailer extension */
+            if(G_LIKELY(g_str_has_suffix(basename, ".thumbnailer"))) {
+                hash.insert(std::make_pair(basename, data_dir));
+            }
+        }
+        g_dir_close(dir);
+    }
+}
+
+void Thumbnailer::loadAll() {
+    const gchar* const* data_dirs = g_get_system_data_dirs();
+    const gchar* const* data_dir;
+
+    /* use a temporary hash table to collect thumbnailer basenames
+     * key: basename of thumbnailer entry file
+     * value: data dir the thumbnailer entry file is in */
+    std::unordered_map<std::string, const char*> hash;
+
+    /* load user-specific thumbnailers */
+    find_thumbnailers_in_data_dir(hash, g_get_user_data_dir());
+
+    /* load system-wide thumbnailers */
+    for(data_dir = data_dirs; *data_dir; ++data_dir) {
+        find_thumbnailers_in_data_dir(hash, *data_dir);
+    }
+
+    /* load all found thumbnailers */
+    if(!hash.empty()) {
+        std::lock_guard<std::mutex> lock{mutex_};
+        GKeyFile* kf = g_key_file_new();
+        for(auto& item: hash) {
+            auto& base_name = item.first;
+            auto& dir_path = item.second;
+            CStrPtr file_path{g_build_filename(dir_path, "thumbnailers", base_name.c_str(), nullptr)};
+            if(g_key_file_load_from_file(kf, file_path.get(), G_KEY_FILE_NONE, nullptr)) {
+                auto thumbnailer = std::make_shared<Thumbnailer>(base_name.c_str(), kf);
+                if(thumbnailer->exec_) {
+                    char** mime_types = g_key_file_get_string_list(kf, "Thumbnailer Entry", "MimeType", nullptr, nullptr);
+                    if(mime_types) {
+                        for(char** name = mime_types; *name; ++name) {
+                            auto mime_type = MimeType::fromName(*name);
+                            if(mime_type) {
+                                std::const_pointer_cast<MimeType>(mime_type)->addThumbnailer(thumbnailer);
+                            }
+                        }
+                        g_strfreev(mime_types);
+                    }
+                }
+                allThumbnailers_.push_back(std::move(thumbnailer));
+            }
+        }
+        g_key_file_free(kf);
+    }
+}
+
+} // namespace Fm

--- a/libfm-qt/core/thumbnailer.h
+++ b/libfm-qt/core/thumbnailer.h
@@ -1,0 +1,37 @@
+#ifndef FM2_THUMBNAILER_H
+#define FM2_THUMBNAILER_H
+
+#include "../libfmqtglobals.h"
+#include "cstrptr.h"
+#include <unordered_map>
+#include <vector>
+#include <memory>
+#include <mutex>
+
+namespace Fm {
+
+class MimeType;
+
+class LIBFM_QT_API Thumbnailer {
+public:
+    explicit Thumbnailer(const char *id, GKeyFile *kf);
+
+    CStrPtr commandForUri(const char* uri, const char* output_file, guint size) const;
+
+    bool run(const char* uri, const char* output_file, int size) const;
+
+    static void loadAll();
+
+private:
+    CStrPtr id_;
+    CStrPtr try_exec_; /* FIXME: is this useful? */
+    CStrPtr exec_;
+    //std::vector<std::shared_ptr<const MimeType>> mimeTypes_;
+
+    static std::mutex mutex_;
+    static std::vector<std::shared_ptr<Thumbnailer>> allThumbnailers_;
+};
+
+} // namespace Fm
+
+#endif // FM2_THUMBNAILER_H

--- a/libfm-qt/core/thumbnailjob.cpp
+++ b/libfm-qt/core/thumbnailjob.cpp
@@ -1,0 +1,314 @@
+#include "thumbnailjob.h"
+#include <string>
+#include <memory>
+#include <algorithm>
+#include <libexif/exif-loader.h>
+#include <QImageReader>
+#include <QDir>
+#include "thumbnailer.h"
+
+#include "core/legacy/fm-config.h"
+
+namespace Fm {
+
+QThreadPool* ThumbnailJob::threadPool_ = nullptr;
+
+bool ThumbnailJob::localFilesOnly_ = true;
+int ThumbnailJob::maxThumbnailFileSize_ = 4096; // in KiB
+int ThumbnailJob::maxExternalThumbnailFileSize_ = -1;
+
+ThumbnailJob::ThumbnailJob(FileInfoList files, int size):
+    files_{std::move(files)},
+    size_{size},
+    md5Calc_{g_checksum_new(G_CHECKSUM_MD5)} {
+}
+
+ThumbnailJob::~ThumbnailJob() {
+    g_checksum_free(md5Calc_);
+    // qDebug("delete  ThumbnailJob");
+}
+
+void ThumbnailJob::exec() {
+    for(auto& file: files_) {
+        if(isCancelled()) {
+            break;
+        }
+        auto image = loadForFile(file);
+        Q_EMIT thumbnailLoaded(file, size_, image);
+        results_.emplace_back(std::move(image));
+    }
+}
+
+QImage ThumbnailJob::readImageFromStream(GInputStream* stream, size_t len) {
+    // The size limit has been set in generateThumbnail().
+    std::unique_ptr<unsigned char[]> buffer{new unsigned char[len]}; // allocate enough buffer
+    unsigned char* pbuffer = buffer.get();
+    size_t totalReadSize = 0;
+    while(!isCancelled() && totalReadSize < len) {
+        size_t bytesToRead = totalReadSize + 4096 > len ? len - totalReadSize : 4096;
+        gssize readSize = g_input_stream_read(stream, pbuffer, bytesToRead, cancellable_.get(), nullptr);
+        if(readSize == 0) { // end of file
+            break;
+        }
+        else if(readSize == -1) { // error
+            return QImage();
+        }
+        totalReadSize += readSize;
+        pbuffer += readSize;
+    }
+    QImage image;
+    image.loadFromData(buffer.get(), totalReadSize);
+    return image;
+}
+
+QImage ThumbnailJob::loadForFile(const std::shared_ptr<const FileInfo> &file) {
+    if(!file->canThumbnail()) {
+        return QImage();
+    }
+
+    // thumbnails are stored in $XDG_CACHE_HOME/thumbnails/large|normal|failed
+    QString thumbnailDir{QString::fromUtf8(g_get_user_cache_dir())};
+    thumbnailDir += QLatin1String("/thumbnails/");
+
+    // don't make thumbnails for files inside the thumbnail directory
+    if(FilePath::fromLocalPath(thumbnailDir.toLocal8Bit().constData()).isParentOf(file->dirPath())) {
+        return QImage();
+    }
+
+    QLatin1String subdir = size_ > 128 ? QLatin1String("large") : QLatin1String("normal");
+    thumbnailDir += subdir;
+
+    // generate base name of the thumbnail  => {md5 of uri}.png
+    auto origPath = file->path();
+    CStrPtr uri;
+    if(file->isSymlink()) {
+        // use the symlink target in the name to update the thumbnail
+        // if the file is changed to a symlink with the same time stamp
+        auto target = file->target();
+        if(!target.empty()) {
+            uri = FilePath::fromLocalPath(target.c_str()).uri();
+        }
+    }
+    if(!uri) {
+        uri = origPath.uri();
+    }
+
+    char thumbnailName[32 + 5];
+    // calculate md5 hash for the uri of the original file
+    g_checksum_update(md5Calc_, reinterpret_cast<const unsigned char*>(uri.get()), -1);
+    memcpy(thumbnailName, g_checksum_get_string(md5Calc_), 32);
+    memcpy(thumbnailName + 32, ".png", 5);
+    g_checksum_reset(md5Calc_); // reset the checksum calculator for next use
+
+    QString thumbnailFilename = thumbnailDir;
+    thumbnailFilename += QLatin1Char('/');
+    thumbnailFilename += QString::fromUtf8(thumbnailName);
+    // qDebug() << "thumbnail:" << file->getName().c_str() << thumbnailFilename;
+
+    // try to load the thumbnail file if it exists
+    QImage thumbnail{thumbnailFilename};
+    if(thumbnail.isNull() || isThumbnailOutdated(file, thumbnail)) {
+        // the existing thumbnail cannot be loaded, generate a new one
+
+        // create the thumbnail dir as needd (FIXME: Qt file I/O is slow)
+        QDir().mkpath(thumbnailDir);
+
+        thumbnail = generateThumbnail(file, origPath, uri.get(), thumbnailFilename);
+    }
+    // resize to the size we need
+    if(thumbnail.width() > size_ || thumbnail.height() > size_) {
+        thumbnail = thumbnail.scaled(size_, size_, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    }
+    return thumbnail;
+}
+
+bool ThumbnailJob::isSupportedImageType(const std::shared_ptr<const MimeType>& mimeType) const {
+    if(mimeType->isImage()) {
+        auto supportedTypes = QImageReader::supportedMimeTypes();
+        auto found = std::find(supportedTypes.cbegin(), supportedTypes.cend(), mimeType->name());
+        if(found != supportedTypes.cend())
+            return true;
+    }
+    return false;
+}
+
+bool ThumbnailJob::isThumbnailOutdated(const std::shared_ptr<const FileInfo>& file, const QImage &thumbnail) const {
+    QString thumb_mtime = thumbnail.text(QStringLiteral("Thumb::MTime"));
+    return (thumb_mtime.isEmpty() || thumb_mtime.toULongLong() != file->mtime());
+}
+
+bool ThumbnailJob::readJpegExif(GInputStream *stream, QImage& thumbnail, QTransform& matrix) {
+    /* try to extract thumbnails embedded in jpeg files */
+    ExifLoader* exif_loader = exif_loader_new();
+    while(!isCancelled()) {
+        unsigned char buf[4096];
+        gssize read_size = g_input_stream_read(stream, buf, 4096, cancellable_.get(), nullptr);
+        if(read_size <= 0) { // EOF or error
+            break;
+        }
+        if(exif_loader_write(exif_loader, buf, read_size) == 0) {
+            break;    // no more EXIF data
+        }
+    }
+    ExifData* exif_data = exif_loader_get_data(exif_loader);
+    exif_loader_unref(exif_loader);
+    if(exif_data) {
+        /* reference for EXIF orientation tag:
+         * https://www.impulseadventure.com/photo/exif-orientation.html */
+        ExifEntry* orient_ent = exif_data_get_entry(exif_data, EXIF_TAG_ORIENTATION);
+        if(orient_ent) { /* orientation flag found in EXIF */
+            gushort orient;
+            ExifByteOrder bo = exif_data_get_byte_order(exif_data);
+            /* bo == EXIF_BYTE_ORDER_INTEL ; */
+            orient = exif_get_short(orient_ent->data, bo);
+            switch(orient) {
+            case 2: // mirror horizontally
+                matrix.scale(-1, 1);
+                break;
+            case 3:
+                matrix.rotate(180);
+                break;
+            case 4: // mirror vertically
+                matrix.scale(1, -1);
+                break;
+            case 5: // transpose
+                matrix.rotate(-90);
+                matrix.scale(1, -1);
+                break;
+            case 6:
+                matrix.rotate(90);
+                break;
+            case 7: // transverse
+                matrix.rotate(90);
+                matrix.scale(1, -1);
+                break;
+            case 8:
+                matrix.rotate(270);
+                break;
+            case 1: // no rotation
+            default:
+                break;
+            }
+        }
+        if(exif_data->data) { // if an embedded thumbnail is available, load it
+            thumbnail.loadFromData(exif_data->data, exif_data->size);
+        }
+        exif_data_unref(exif_data);
+    }
+    return !thumbnail.isNull();
+}
+
+QImage ThumbnailJob::generateThumbnail(const std::shared_ptr<const FileInfo>& file, const FilePath& origPath, const char* uri, const QString& thumbnailFilename) {
+    QImage result;
+    auto mime_type = file->mimeType();
+    if(isSupportedImageType(mime_type)) {
+        if (file->size() > static_cast<uint64_t>(maxThumbnailFileSize_) * 1024) {
+            return result;
+        }
+        GFileInputStreamPtr ins{g_file_read(origPath.gfile().get(), cancellable_.get(), nullptr), false};
+        if(!ins) {
+            return result;
+        }
+        bool fromExif = false;
+        QTransform matrix;
+        if(strcmp(mime_type->name(), "image/jpeg") == 0) { // if this is a jpeg file
+            // try to get the thumbnail embedded in EXIF data
+            if(readJpegExif(G_INPUT_STREAM(ins.get()), result, matrix)) {
+                fromExif = true;
+            }
+        }
+        if(!fromExif) {  // not able to generate a thumbnail from the EXIF data
+            // load the original file and do the scaling ourselves
+            g_seekable_seek(G_SEEKABLE(ins.get()), 0, G_SEEK_SET, cancellable_.get(), nullptr);
+            result = readImageFromStream(G_INPUT_STREAM(ins.get()), file->size());
+        }
+        g_input_stream_close(G_INPUT_STREAM(ins.get()), nullptr, nullptr);
+
+        if(!result.isNull()) { // the image is successfully loaded
+            // scale the image as needed
+            int target_size = size_ > 128 ? 256 : 128;
+
+            // only scale the original image if it's too large
+            if(result.width() > target_size || result.height() > target_size) {
+                result = result.scaled(target_size, target_size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+            }
+
+            if(!matrix.isIdentity()) { // transform the image if needed
+                result = result.transformed(matrix);
+            }
+
+            // save the generated thumbnail to disk (don't save png thumbnails for JPEG EXIF thumbnails since loading them is cheap)
+            if(!fromExif) {
+                result.setText(QStringLiteral("Thumb::MTime"), QString::number(file->mtime()));
+                result.setText(QStringLiteral("Thumb::URI"), QString::fromUtf8(uri));
+                result.save(thumbnailFilename, "PNG");
+            }
+            // qDebug() << "save thumbnail:" << thumbnailFilename;
+        }
+    }
+    else { // the image format is not supported, try to find an external thumbnailer
+        if (maxExternalThumbnailFileSize_ >= 0
+            && file->size() > static_cast<uint64_t>(maxExternalThumbnailFileSize_) * 1024) {
+            return result;
+        }
+        // try all available external thumbnailers for it until sucess
+        int target_size = size_ > 128 ? 256 : 128;
+        file->mimeType()->forEachThumbnailer([&](const std::shared_ptr<const Thumbnailer>& thumbnailer) {
+            if(thumbnailer->run(uri, thumbnailFilename.toLocal8Bit().constData(), target_size)) {
+                result = QImage(thumbnailFilename);
+            }
+            return !result.isNull(); // return true on success, and forEachThumbnailer() will stop.
+        });
+
+        if(!result.isNull()) {
+            // Some thumbnailers did not write the proper metadata required by the xdg spec to the output (such as evince-thumbnailer)
+            // Here we waste some time to fix them so next time we don't need to re-generate these thumbnails. :-(
+            bool changed = false;
+            if(Q_UNLIKELY(result.text(QStringLiteral("Thumb::MTime")).isEmpty())) {
+                result.setText(QStringLiteral("Thumb::MTime"), QString::number(file->mtime()));
+                changed = true;
+            }
+            if(Q_UNLIKELY(result.text(QStringLiteral("Thumb::URI")).isEmpty())) {
+                result.setText(QStringLiteral("Thumb::URI"), QString::fromUtf8(uri));
+                changed = true;
+            }
+            if(Q_UNLIKELY(changed)) {
+                // save the modified PNG file containing metadata to a file.
+                result.save(thumbnailFilename, "PNG");
+            }
+        }
+    }
+    return result;
+}
+
+QThreadPool* ThumbnailJob::threadPool() {
+    if(Q_UNLIKELY(threadPool_ == nullptr)) {
+        threadPool_ = new QThreadPool();
+        threadPool_->setMaxThreadCount(1);
+    }
+    return threadPool_;
+}
+
+void ThumbnailJob::setLocalFilesOnly(bool value) {
+    localFilesOnly_ = value;
+    if(fm_config) {
+        fm_config->thumbnail_local = localFilesOnly_;
+    }
+}
+
+void ThumbnailJob::setMaxThumbnailFileSize(int size) {
+    maxThumbnailFileSize_ = qMax(size, 0);
+    if(fm_config) {
+        fm_config->thumbnail_max = maxThumbnailFileSize_;
+    }
+}
+
+void ThumbnailJob::setMaxExternalThumbnailFileSize(int size) {
+    maxExternalThumbnailFileSize_ = size;
+    if(fm_config) {
+        fm_config->external_thumbnail_max = maxExternalThumbnailFileSize_;
+    }
+}
+
+
+} // namespace Fm

--- a/libfm-qt/core/thumbnailjob.h
+++ b/libfm-qt/core/thumbnailjob.h
@@ -1,0 +1,85 @@
+#ifndef FM2_THUMBNAILJOB_H
+#define FM2_THUMBNAILJOB_H
+
+#include "../libfmqtglobals.h"
+#include "fileinfo.h"
+#include "gioptrs.h"
+#include "job.h"
+#include <QThreadPool>
+
+namespace Fm {
+
+class LIBFM_QT_API ThumbnailJob: public Job {
+    Q_OBJECT
+public:
+
+    explicit ThumbnailJob(FileInfoList files, int size);
+
+    ~ThumbnailJob() override;
+
+    int size() const {
+        return size_;
+    }
+
+    static QThreadPool* threadPool();
+
+    static void setLocalFilesOnly(bool value);
+
+    static bool localFilesOnly() {
+        return localFilesOnly_;
+    }
+
+    static int maxThumbnailFileSize() {
+        return maxThumbnailFileSize_;
+    }
+
+    static void setMaxThumbnailFileSize(int size);
+
+    static int maxExternalThumbnailFileSize() {
+        return maxExternalThumbnailFileSize_;
+    }
+
+    static void setMaxExternalThumbnailFileSize(int size);
+
+    const std::vector<QImage>& results() const {
+        return results_;
+    }
+
+Q_SIGNALS:
+    void thumbnailLoaded(const std::shared_ptr<const FileInfo>& file, int size, QImage thumbnail);
+
+protected:
+
+    void exec() override;
+
+private:
+
+    bool isSupportedImageType(const std::shared_ptr<const MimeType>& mimeType) const;
+
+    bool isThumbnailOutdated(const std::shared_ptr<const FileInfo>& file, const QImage& thumbnail) const;
+
+    QImage generateThumbnail(const std::shared_ptr<const FileInfo>& file, const FilePath& origPath, const char* uri, const QString& thumbnailFilename);
+
+    QImage readImageFromStream(GInputStream* stream, size_t len);
+
+    QImage loadForFile(const std::shared_ptr<const FileInfo>& file);
+
+    bool readJpegExif(GInputStream* stream, QImage& thumbnail, QTransform& matrix);
+
+private:
+    FileInfoList files_;
+    int size_;
+    std::vector<QImage> results_;
+    GCancellablePtr cancellable_;
+    GChecksum* md5Calc_;
+
+    static QThreadPool* threadPool_;
+
+    static bool localFilesOnly_;
+    static int maxThumbnailFileSize_;
+    static int maxExternalThumbnailFileSize_;
+};
+
+} // namespace Fm
+
+#endif // FM2_THUMBNAILJOB_H

--- a/libfm-qt/core/totalsizejob.cpp
+++ b/libfm-qt/core/totalsizejob.cpp
@@ -1,0 +1,141 @@
+#include "totalsizejob.h"
+
+namespace Fm {
+
+static const char query_str[] =
+    G_FILE_ATTRIBUTE_STANDARD_TYPE","
+    G_FILE_ATTRIBUTE_STANDARD_NAME","
+    G_FILE_ATTRIBUTE_STANDARD_IS_VIRTUAL","
+    G_FILE_ATTRIBUTE_STANDARD_SIZE","
+    G_FILE_ATTRIBUTE_STANDARD_ALLOCATED_SIZE","
+    G_FILE_ATTRIBUTE_ID_FILESYSTEM;
+
+
+TotalSizeJob::TotalSizeJob(FilePathList paths, Flags flags):
+    paths_{std::move(paths)},
+    flags_{flags},
+    totalSize_{0},
+    totalOndiskSize_{0},
+    fileCount_{0},
+    dest_fs_id{nullptr} {
+}
+
+
+void TotalSizeJob::exec(FilePath path, GFileInfoPtr inf) {
+    GFileType type;
+    const char* fs_id;
+    bool descend;
+
+_retry_query_info:
+    if(!inf) {
+        GErrorPtr err;
+        inf = GFileInfoPtr {
+            g_file_query_info(path.gfile().get(), query_str,
+            (flags_ & FOLLOW_LINKS) ? G_FILE_QUERY_INFO_NONE : G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+            cancellable().get(), &err),
+            false
+        };
+        if(!inf) {
+            ErrorAction act = emitError( err, ErrorSeverity::MILD);
+            err = nullptr;
+            if(act == ErrorAction::RETRY) {
+                goto _retry_query_info;
+            }
+            return;
+        }
+    }
+    if(isCancelled()) {
+        return;
+    }
+
+    type = g_file_info_get_file_type(inf.get());
+    descend = true;
+
+    ++fileCount_;
+    /* SF bug #892: dir file size is not relevant in the summary */
+    if(type != G_FILE_TYPE_DIRECTORY) {
+        totalSize_ += g_file_info_get_size(inf.get());
+    }
+    totalOndiskSize_ += g_file_info_get_attribute_uint64(inf.get(), G_FILE_ATTRIBUTE_STANDARD_ALLOCATED_SIZE);
+
+    /* prepare for moving across different devices */
+    if(flags_ & PREPARE_MOVE) {
+        fs_id = g_file_info_get_attribute_string(inf.get(), G_FILE_ATTRIBUTE_ID_FILESYSTEM);
+        if(fs_id && dest_fs_id && (strcmp(fs_id, dest_fs_id) == 0 || g_str_has_prefix(fs_id, "trash"))) {
+            // same filesystem or move from trash:///
+            descend = false;
+        }
+        else {
+            /* files on different device requires an additional 'delete' for the source file. */
+            ++totalSize_; /* this is for the additional delete */
+            ++totalOndiskSize_;
+            ++fileCount_;
+            descend = true;
+        }
+    }
+
+    if(type == G_FILE_TYPE_DIRECTORY) {
+        /* check if we need to decends into the dir. */
+        /* trash:/// doesn't support deleting files recursively (but we want to descend into trash root "trash:///" */
+        if(flags_ & PREPARE_DELETE && path.hasUriScheme("trash") && path.baseName()[0] != '/') {
+            descend = false;
+        }
+        else {
+            /* only descends into files on the same filesystem */
+            if(flags_ & SAME_FS) {
+                fs_id = g_file_info_get_attribute_string(inf.get(), G_FILE_ATTRIBUTE_ID_FILESYSTEM);
+                descend = (g_strcmp0(fs_id, dest_fs_id) == 0);
+            }
+        }
+
+        inf = nullptr;
+        if(descend) {
+_retry_enum_children:
+            GErrorPtr err;
+            auto enu = GFileEnumeratorPtr {
+                g_file_enumerate_children(path.gfile().get(), query_str,
+                G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+                cancellable().get(), &err),
+                false
+            };
+            if(enu) {
+                while(!isCancelled()) {
+                    inf = GFileInfoPtr{g_file_enumerator_next_file(enu.get(), cancellable().get(), &err), false};
+                    if(inf) {
+                        FilePath child = path.child(g_file_info_get_name(inf.get()));
+                        exec(std::move(child), std::move(inf));
+                    }
+                    else {
+                        if(err) { /* error! */
+                            /* ErrorAction::RETRY is not supported */
+                            emitError( err, ErrorSeverity::MILD);
+                            err = nullptr;
+                        }
+                        else {
+                            /* EOF is reached, do nothing. */
+                            break;
+                        }
+                    }
+                }
+                g_file_enumerator_close(enu.get(), nullptr, nullptr);
+            }
+            else {
+                ErrorAction act = emitError( err, ErrorSeverity::MILD);
+                err = nullptr;
+                if(act == ErrorAction::RETRY) {
+                    goto _retry_enum_children;
+                }
+            }
+        }
+    }
+}
+
+
+void TotalSizeJob::exec() {
+    for(auto& path : paths_) {
+        exec(path, GFileInfoPtr{});
+    }
+}
+
+
+} // namespace Fm

--- a/libfm-qt/core/totalsizejob.h
+++ b/libfm-qt/core/totalsizejob.h
@@ -1,0 +1,56 @@
+#ifndef FM2_TOTALSIZEJOB_H
+#define FM2_TOTALSIZEJOB_H
+
+#include "../libfmqtglobals.h"
+#include "fileoperationjob.h"
+#include "filepath.h"
+#include <cstdint>
+#include "gioptrs.h"
+
+namespace Fm {
+
+class LIBFM_QT_API TotalSizeJob : public Fm::FileOperationJob {
+    Q_OBJECT
+public:
+    enum Flags {
+        DEFAULT = 0,
+        FOLLOW_LINKS = 1 << 0,
+        SAME_FS = 1 << 1,
+        PREPARE_MOVE = 1 << 2,
+        PREPARE_DELETE = 1 << 3
+    };
+
+    explicit TotalSizeJob(FilePathList paths = FilePathList{}, Flags flags = DEFAULT);
+
+    std::uint64_t totalSize() const {
+        return totalSize_;
+    }
+
+    std::uint64_t totalOnDiskSize() const {
+        return totalOndiskSize_;
+    }
+
+    unsigned int fileCount() const {
+        return fileCount_;
+    }
+
+protected:
+
+    void exec() override;
+
+private:
+    void exec(FilePath path, GFileInfoPtr inf);
+
+private:
+    FilePathList paths_;
+
+    int flags_;
+    std::uint64_t totalSize_;
+    std::uint64_t totalOndiskSize_;
+    unsigned int fileCount_;
+    const char* dest_fs_id;
+};
+
+} // namespace Fm
+
+#endif // FM2_TOTALSIZEJOB_H

--- a/libfm-qt/core/trashjob.cpp
+++ b/libfm-qt/core/trashjob.cpp
@@ -1,0 +1,74 @@
+#include "trashjob.h"
+
+#include "core/legacy/fm-config.h"
+
+namespace Fm {
+
+TrashJob::TrashJob(FilePathList paths): paths_{std::move(paths)} {
+    // calculate progress using finished file counts rather than their sizes
+    setCalcProgressUsingSize(false);
+}
+
+void TrashJob::exec() {
+    setTotalAmount(paths_.size(), paths_.size());
+    Q_EMIT preparedToRun();
+
+    /* FIXME: we shouldn't trash a file already in trash:/// */
+    for(auto& path : paths_) {
+        if(isCancelled()) {
+            break;
+        }
+
+        setCurrentFile(path);
+
+        // TODO: get parent dir of the current path.
+        //       if there is a Fm::Folder object created for it, block the update for the folder temporarily.
+
+        for(;;) {  // retry the i/o operation on errors
+            auto gf = path.gfile();
+            bool ret = false;
+            // FIXME: do not depend on fm_config
+            if(fm_config->no_usb_trash) {
+                GMountPtr mnt{g_file_find_enclosing_mount(gf.get(), nullptr, nullptr), false};
+                if(mnt) {
+                    ret = g_mount_can_unmount(mnt.get()); /* TRUE if it's removable media */
+                    if(ret) {
+                        unsupportedFiles_.push_back(path);
+                        break;  // don't trash the file
+                    }
+                }
+            }
+
+            // move the file to trash
+            GErrorPtr err;
+            ret = g_file_trash(gf.get(), cancellable().get(), &err);
+            if(ret) {  // trash operation succeeded
+                break;
+            }
+            else {  // failed
+                // if trashing is not supported by the file system
+                if(err.domain() == G_IO_ERROR && err.code() == G_IO_ERROR_NOT_SUPPORTED) {
+                    unsupportedFiles_.push_back(path);
+                     break;
+                }
+                else {
+                    ErrorAction act = emitError(err, ErrorSeverity::MODERATE);
+                    if(act == ErrorAction::RETRY) {
+                        err.reset();
+                    }
+                    else if(act == ErrorAction::ABORT) {
+                        cancel();
+                        return;
+                    }
+                    else {
+                        break;
+                    }
+                }
+            }
+        }
+        addFinishedAmount(1, 1);
+    }
+}
+
+
+} // namespace Fm

--- a/libfm-qt/core/trashjob.h
+++ b/libfm-qt/core/trashjob.h
@@ -1,0 +1,30 @@
+#ifndef FM2_TRASHJOB_H
+#define FM2_TRASHJOB_H
+
+#include "../libfmqtglobals.h"
+#include "fileoperationjob.h"
+#include "filepath.h"
+
+namespace Fm {
+
+class LIBFM_QT_API TrashJob : public Fm::FileOperationJob {
+    Q_OBJECT
+public:
+    explicit TrashJob(FilePathList paths);
+
+    FilePathList unsupportedFiles() const {
+        return unsupportedFiles_;
+    }
+
+protected:
+
+    void exec() override;
+
+private:
+    FilePathList paths_;
+    FilePathList unsupportedFiles_;
+};
+
+} // namespace Fm
+
+#endif // FM2_TRASHJOB_H

--- a/libfm-qt/core/untrashjob.cpp
+++ b/libfm-qt/core/untrashjob.cpp
@@ -1,0 +1,75 @@
+#include "untrashjob.h"
+#include "filetransferjob.h"
+
+namespace Fm {
+
+UntrashJob::UntrashJob(FilePathList srcPaths):
+    srcPaths_{std::move(srcPaths)} {
+}
+
+void UntrashJob::exec() {
+    // preparing for the job
+    FilePathList validSrcPaths;
+    FilePathList origPaths;
+    for(auto& srcPath: srcPaths_) {
+        if(isCancelled()) {
+            break;
+        }
+        GErrorPtr err;
+        GFileInfoPtr srcInfo{
+            g_file_query_info(srcPath.gfile().get(),
+                              "trash::orig-path",
+                              G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+                              cancellable().get(),
+                              &err),
+            false
+        };
+        if(srcInfo) {
+            const char* orig_path_str = g_file_info_get_attribute_byte_string(srcInfo.get(), "trash::orig-path");
+            if(orig_path_str) {
+                validSrcPaths.emplace_back(srcPath);
+                origPaths.emplace_back(FilePath::fromPathStr(orig_path_str));
+            }
+            else {
+                g_set_error(&err, G_IO_ERROR, G_IO_ERROR_FAILED,
+                            tr("Cannot untrash file '%s': original path not known").toUtf8().constData(),
+                            g_file_info_get_display_name(srcInfo.get()));
+                // FIXME: do we need to retry here?
+                emitError(err, ErrorSeverity::MODERATE);
+            }
+        }
+        else {
+            // FIXME: do we need to retry here?
+            emitError(err);
+        }
+    }
+
+    // collected original paths of the trashed files
+    // use the file transfer job to handle the actual file move
+    FileTransferJob fileTransferJob{std::move(validSrcPaths), std::move(origPaths), FileTransferJob::Mode::MOVE};
+    // FIXME:
+    // I'm not sure why specifying Qt::DirectConnection is needed here since the caller & receiver are in the same thread. :-(
+    // However without this, the signals/slots here will cause deadlocks.
+    connect(&fileTransferJob, &FileTransferJob::preparedToRun, this, &UntrashJob::preparedToRun, Qt::DirectConnection);
+    connect(&fileTransferJob, &FileTransferJob::error, this, &UntrashJob::error, Qt::DirectConnection);
+    connect(&fileTransferJob, &FileTransferJob::fileExists, this, &UntrashJob::fileExists, Qt::DirectConnection);
+
+    // cancel the file transfer subjob if the parent job is cancelled
+    connect(this, &UntrashJob::cancelled, &fileTransferJob,
+            [&fileTransferJob]() {
+                if(!fileTransferJob.isCancelled()) {
+                    fileTransferJob.cancel();
+                }
+            }, Qt::DirectConnection);
+
+    // cancel the parent job if the file transfer subjob is cancelled
+    connect(&fileTransferJob, &FileTransferJob::cancelled, this,
+            [this]() {
+                if(!isCancelled()) {
+                    cancel();
+                }
+            }, Qt::DirectConnection);
+    fileTransferJob.run();
+}
+
+} // namespace Fm

--- a/libfm-qt/core/untrashjob.h
+++ b/libfm-qt/core/untrashjob.h
@@ -1,0 +1,22 @@
+#ifndef FM2_UNTRASHJOB_H
+#define FM2_UNTRASHJOB_H
+
+#include "../libfmqtglobals.h"
+#include "fileoperationjob.h"
+
+namespace Fm {
+
+class LIBFM_QT_API UntrashJob : public FileOperationJob {
+public:
+    explicit UntrashJob(FilePathList srcPaths);
+
+protected:
+    void exec() override;
+
+private:
+    FilePathList srcPaths_;
+};
+
+} // namespace Fm
+
+#endif // FM2_UNTRASHJOB_H

--- a/libfm-qt/core/userinfocache.cpp
+++ b/libfm-qt/core/userinfocache.cpp
@@ -1,0 +1,47 @@
+#include "userinfocache.h"
+#include <pwd.h>
+#include <grp.h>
+
+namespace Fm {
+
+UserInfoCache* UserInfoCache::globalInstance_ = nullptr;
+std::mutex UserInfoCache::mutex_;
+
+UserInfoCache::UserInfoCache() : QObject() {
+}
+
+const std::shared_ptr<const UserInfo>& UserInfoCache::userFromId(uid_t uid) {
+    std::lock_guard<std::mutex> lock{mutex_};
+    auto it = users_.find(uid);
+    if(it != users_.end())
+        return it->second;
+    std::shared_ptr<const UserInfo> user;
+    auto pw = getpwuid(uid);
+    if(pw) {
+        user = std::make_shared<UserInfo>(uid, pw->pw_name, pw->pw_gecos);
+    }
+    return (users_[uid] = user);
+}
+
+const std::shared_ptr<const GroupInfo>& UserInfoCache::groupFromId(gid_t gid) {
+    std::lock_guard<std::mutex> lock{mutex_};
+    auto it = groups_.find(gid);
+    if(it != groups_.end())
+        return it->second;
+    std::shared_ptr<const GroupInfo> group;
+    auto gr = getgrgid(gid);
+    if(gr) {
+        group = std::make_shared<GroupInfo>(gid, gr->gr_name);
+    }
+    return (groups_[gid] = group);
+}
+
+// static
+UserInfoCache* UserInfoCache::globalInstance() {
+    std::lock_guard<std::mutex> lock{mutex_};
+    if(!globalInstance_)
+        globalInstance_ = new UserInfoCache();
+    return globalInstance_;
+}
+
+} // namespace Fm

--- a/libfm-qt/core/userinfocache.h
+++ b/libfm-qt/core/userinfocache.h
@@ -1,0 +1,82 @@
+#ifndef FM2_USERINFOCACHE_H
+#define FM2_USERINFOCACHE_H
+
+#include "../libfmqtglobals.h"
+#include <QObject>
+#include <string>
+#include <unordered_map>
+#include <sys/types.h>
+#include <memory>
+#include <mutex>
+
+namespace Fm {
+
+class LIBFM_QT_API UserInfo {
+public:
+    explicit UserInfo(uid_t uid, const char* name, const char* realName):
+        uid_{uid}, name_{QString::fromUtf8(name)}, realName_{QString::fromUtf8(realName)} {
+    }
+
+    uid_t uid() const {
+        return uid_;
+    }
+
+    const QString& name() const {
+        return name_;
+    }
+
+    const QString& realName() const {
+        return realName_;
+    }
+
+private:
+    uid_t uid_;
+    QString name_;
+    QString realName_;
+
+};
+
+class LIBFM_QT_API GroupInfo {
+public:
+    explicit GroupInfo(gid_t gid, const char* name): gid_{gid}, name_{QString::fromUtf8(name)} {
+    }
+
+    gid_t gid() const {
+        return gid_;
+    }
+
+    const QString& name() const {
+        return name_;
+    }
+
+private:
+    gid_t gid_;
+    QString name_;
+};
+
+// FIXME: handle file changes
+
+class LIBFM_QT_API UserInfoCache : public QObject {
+    Q_OBJECT
+public:
+    explicit UserInfoCache();
+
+    const std::shared_ptr<const UserInfo>& userFromId(uid_t uid);
+
+    const std::shared_ptr<const GroupInfo>& groupFromId(gid_t gid);
+
+    static UserInfoCache* globalInstance();
+
+Q_SIGNALS:
+    void changed();
+
+private:
+    std::unordered_map<uid_t, std::shared_ptr<const UserInfo>> users_;
+    std::unordered_map<gid_t, std::shared_ptr<const GroupInfo>> groups_;
+    static UserInfoCache* globalInstance_;
+    static std::mutex mutex_;
+};
+
+} // namespace Fm
+
+#endif // FM2_USERINFOCACHE_H

--- a/libfm-qt/core/vfs/fm-file.c
+++ b/libfm-qt/core/vfs/fm-file.c
@@ -1,0 +1,118 @@
+/*
+ *      fm-file.c
+ *
+ *      Copyright 2012-2013 Andriy Grytsenko (LStranger) <andrej@rep.kiev.ua>
+ *
+ *      This file is a part of the Libfm library.
+ *
+ *      This library is free software; you can redistribute it and/or
+ *      modify it under the terms of the GNU Lesser General Public
+ *      License as published by the Free Software Foundation; either
+ *      version 2.1 of the License, or (at your option) any later version.
+ *
+ *      This library is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *      Lesser General Public License for more details.
+ *
+ *      You should have received a copy of the GNU Lesser General Public
+ *      License along with this library; if not, write to the Free Software
+ *      Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/**
+ * SECTION:fm-file
+ * @short_description: Extensions for GFile interface.
+ * @title: FmFile
+ *
+ * @include: libfm/fm.h
+ *
+ * The #FmFile represents interface to build extensions to GFile which
+ * will handle schemas that are absent in Glib/GVFS - such as "search:".
+ *
+ * To use it the GFile implementation should also implement FmFile vtable
+ * calls. The implementation should be added to list of known schemes via
+ * call to fm_file_add_vfs() then calls such as fm_file_new_for_uri() can
+ * use it.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#include "glib-compat.h"
+#define CHECK_MODULES() // this is not needed for libfm-qt
+
+#include "fm-file.h"
+
+#include <string.h>
+
+static GHashTable *schemes = NULL;
+
+#define FM_FILE_MODULE_MIN_VERSION 1
+#define FM_FILE_MODULE_MAX_VERSION 1
+
+G_LOCK_DEFINE_STATIC(vfs);
+
+G_DEFINE_INTERFACE(FmFile, fm_file, G_TYPE_FILE)
+
+static gboolean fm_file_wants_incremental_false(GFile *unused)
+{
+    return FALSE;
+}
+
+static void fm_file_default_init(FmFileInterface *iface)
+{
+    iface->wants_incremental = fm_file_wants_incremental_false;
+}
+
+
+static inline FmFileInitTable *fm_find_scheme(const char *name)
+{
+    FmFileInitTable *t;
+    CHECK_MODULES();
+    G_LOCK(vfs);
+    t = (FmFileInitTable*)g_hash_table_lookup(schemes, name);
+    G_UNLOCK(vfs);
+    return t;
+}
+
+/**
+ * fm_file_add_vfs
+ * @name: scheme to act upon
+ * @init: table of functions
+ *
+ * Adds VFS to list of extensions that will be applied on next call to
+ * fm_file_new_for_uri() or fm_file_new_for_commandline_arg(). The @name
+ * is a schema which will be handled by those calls.
+ *
+ * Since: 1.0.2
+ */
+void fm_file_add_vfs(const char *name, FmFileInitTable *init)
+{
+    G_LOCK(vfs);
+    if(g_hash_table_lookup(schemes, name) == NULL)
+        g_hash_table_insert(schemes, g_strdup(name), init);
+    G_UNLOCK(vfs);
+}
+
+/**
+ * fm_file_wants_incremental
+ * @file: file to inspect
+ *
+ * Checks if contents of directory @file cannot be retrieved at once so
+ * scanning it may be done in incremental manner for the best results.
+ *
+ * Returns: %TRUE if retrieve of contents of @file will be incremental.
+ *
+ * Since: 1.0.2
+ */
+gboolean fm_file_wants_incremental(GFile* file)
+{
+    FmFileInterface *iface;
+
+    g_return_val_if_fail(file != NULL, FALSE);
+    if(!FM_IS_FILE(file))
+        return FALSE;
+    iface = FM_FILE_GET_IFACE(file);
+    return iface->wants_incremental ? iface->wants_incremental(file) : FALSE;
+}

--- a/libfm-qt/core/vfs/fm-file.h
+++ b/libfm-qt/core/vfs/fm-file.h
@@ -1,0 +1,100 @@
+/*
+ *      fm-file.h
+ *
+ *      Copyright 2012 Andriy Grytsenko (LStranger) <andrej@rep.kiev.ua>
+ *
+ *      This file is a part of the Libfm library.
+ *
+ *      This library is free software; you can redistribute it and/or
+ *      modify it under the terms of the GNU Lesser General Public
+ *      License as published by the Free Software Foundation; either
+ *      version 2.1 of the License, or (at your option) any later version.
+ *
+ *      This library is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *      Lesser General Public License for more details.
+ *
+ *      You should have received a copy of the GNU Lesser General Public
+ *      License along with this library; if not, write to the Free Software
+ *      Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef _FM_FILE_H_
+#define _FM_FILE_H_ 1
+
+// #include "fm-module.h"
+
+#include <glib.h>
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+#define FM_TYPE_FILE                    (fm_file_get_type())
+#define FM_FILE(obj)                    (G_TYPE_CHECK_INSTANCE_CAST((obj),\
+                                                FM_TYPE_FILE, FmFile))
+#define FM_IS_FILE(obj)                 (G_TYPE_CHECK_INSTANCE_TYPE((obj),\
+                                                FM_TYPE_FILE))
+#define FM_FILE_GET_IFACE(obj)          (G_TYPE_INSTANCE_GET_INTERFACE((obj),\
+                                                FM_TYPE_FILE, FmFileInterface))
+
+typedef struct _FmFile                  FmFile; /* Dummy typedef */
+typedef struct _FmFileInterface         FmFileInterface;
+
+/**
+ * FmFileInterface:
+ * @wants_incremental: VTable func, see fm_file_wants_incremental()
+ */
+struct _FmFileInterface
+{
+    /*< private >*/
+    GTypeInterface g_iface;
+
+    /*< public >*/
+    gboolean (*wants_incremental)(GFile* file);
+
+    /*< private >*/
+    gpointer _reserved1;
+    gpointer _reserved2;
+};
+
+typedef struct _FmFileInitTable         FmFileInitTable;
+
+/**
+ * FmFileInitTable:
+ * @new_for_uri: function to create new #GFile object from URI
+ *
+ * Functions to initialize FmFile instance.
+ *
+ * This structure is used for "vfs" module initialization. The key for
+ * module of this type is scheme name to support.
+ */
+struct _FmFileInitTable
+{
+    /*< public >*/
+    GFile * (*new_for_uri)(const char *uri);
+    /*< private >*/
+    gpointer _reserved1;
+    gpointer _reserved2;
+};
+
+GType           fm_file_get_type(void);
+
+void            fm_file_add_vfs(const char *name, FmFileInitTable *init);
+
+/* VTable calls */
+gboolean        fm_file_wants_incremental(GFile* file);
+
+/* Gfile functions replacements */
+GFile          *fm_file_new_for_uri(const char *uri);
+GFile          *fm_file_new_for_commandline_arg(const char *arg);
+
+void _fm_file_init(void);
+void _fm_file_finalize(void);
+
+/* for modules */
+#define FM_MODULE_vfs_VERSION 1
+// extern FmFileInitTable fm_module_init_vfs;
+
+G_END_DECLS
+#endif /* _FM_FILE_H_ */

--- a/libfm-qt/core/vfs/fm-xml-file.c
+++ b/libfm-qt/core/vfs/fm-xml-file.c
@@ -1,0 +1,1519 @@
+/*
+ *      fm-xml-file.c
+ *
+ *      Copyright 2013 Andriy Grytsenko (LStranger) <andrej@rep.kiev.ua>
+ *
+ *      This file is a part of libfm-extra package.
+ *
+ *      This library is free software; you can redistribute it and/or
+ *      modify it under the terms of the GNU Lesser General Public
+ *      License as published by the Free Software Foundation; either
+ *      version 2.1 of the License, or (at your option) any later version.
+ *
+ *      This library is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *      Lesser General Public License for more details.
+ *
+ *      You should have received a copy of the GNU Lesser General Public
+ *      License along with this library; if not, write to the Free Software
+ *      Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/**
+ * SECTION:fm-xml-file
+ * @short_description: Simple XML parser.
+ * @title: FmXmlFile
+ *
+ * @include: libfm/fm-extra.h
+ *
+ * The FmXmlFile represents content of some XML file in form that can
+ * be altered and saved later.
+ *
+ * This parser has some simplifications on XML parsing:
+ * * Only UTF-8 encoding is supported
+ * * No user-defined entities, those should be converted externally
+ * * Processing instructions, comments and the doctype declaration are parsed but are not interpreted in any way
+ * The markup format does support:
+ * * Elements
+ * * Attributes
+ * * 5 standard entities: &amp;amp; &amp;lt; &amp;gt; &amp;quot; &amp;apos;
+ * * Character references
+ * * Sections marked as CDATA
+ *
+ * The application should respect g_type_init() if this parser is used
+ * without usage of libfm.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "fm-xml-file.h"
+
+#include <glib/gi18n-lib.h>
+#include "glib-compat.h"
+
+#include <stdlib.h>
+#include <errno.h>
+
+typedef struct
+{
+    gchar *name;
+    FmXmlFileHandler handler;
+    gboolean in_line : 1;
+} FmXmlFileTagDesc;
+
+struct _FmXmlFile
+{
+    GObject parent;
+    GList *items;
+    GString *data;
+    char *comment_pre;
+    FmXmlFileItem *current_item;
+    FmXmlFileTagDesc *tags; /* tags[0].name contains DTD */
+    guint n_tags; /* number of elements in tags */
+    guint line, pos;
+};
+
+struct _FmXmlFileClass
+{
+    GObjectClass parent_class;
+};
+
+struct _FmXmlFileItem
+{
+    FmXmlFileTag tag;
+    union {
+        gchar *tag_name; /* only for tag == FM_XML_FILE_TAG_NOT_HANDLED */
+        gchar *text; /* only for tag == FM_XML_FILE_TEXT, NULL if directive */
+    };
+    char **attribute_names;
+    char **attribute_values;
+    FmXmlFile *file;
+    FmXmlFileItem *parent;
+    GList **parent_list; /* points to file->items or to parent->children */
+    GList *children;
+    gchar *comment; /* a little trick: it is equal to text if it is CDATA */
+};
+
+
+G_DEFINE_TYPE(FmXmlFile, fm_xml_file, G_TYPE_OBJECT);
+
+static void fm_xml_file_finalize(GObject *object)
+{
+    FmXmlFile *self;
+    guint i;
+
+    g_return_if_fail(object != NULL);
+    g_return_if_fail(FM_IS_XML_FILE(object));
+
+    self = (FmXmlFile*)object;
+    self->current_item = NULL; /* we destroying it */
+    while (self->items)
+    {
+        g_assert(((FmXmlFileItem*)self->items->data)->file == self);
+        g_assert(((FmXmlFileItem*)self->items->data)->parent == NULL);
+        fm_xml_file_item_destroy(self->items->data);
+    }
+    for (i = 0; i < self->n_tags; i++)
+        g_free(self->tags[i].name);
+    g_free(self->tags);
+    if (self->data)
+        g_string_free(self->data, TRUE);
+    g_free(self->comment_pre);
+
+    G_OBJECT_CLASS(fm_xml_file_parent_class)->finalize(object);
+}
+
+static void fm_xml_file_class_init(FmXmlFileClass *klass)
+{
+    GObjectClass *g_object_class;
+
+    g_object_class = G_OBJECT_CLASS(klass);
+    g_object_class->finalize = fm_xml_file_finalize;
+}
+
+static void fm_xml_file_init(FmXmlFile *self)
+{
+    self->tags = g_new0(FmXmlFileTagDesc, 1);
+    self->n_tags = 1;
+    self->line = 1;
+}
+
+/**
+ * fm_xml_file_new
+ * @sibling: (allow-none): container to copy handlers data
+ *
+ * Creates new empty #FmXmlFile container. If @sibling is not %NULL
+ * then new container will have callbacks identical to set in @sibling.
+ * Use @sibling parameter if you need to work with few XML files that
+ * share the same schema or if you need to use the same tag ids for more
+ * than one file.
+ *
+ * Returns: (transfer full): newly created object.
+ *
+ * Since: 1.2.0
+ */
+FmXmlFile *fm_xml_file_new(FmXmlFile *sibling)
+{
+    FmXmlFile *self;
+    FmXmlFileTag i;
+
+    self = (FmXmlFile*)g_object_new(FM_XML_FILE_TYPE, NULL);
+    if (sibling && sibling->n_tags > 1)
+    {
+        self->n_tags = sibling->n_tags;
+        self->tags = g_renew(FmXmlFileTagDesc, self->tags, self->n_tags);
+        for (i = 1; i < self->n_tags; i++)
+        {
+            self->tags[i].name = g_strdup(sibling->tags[i].name);
+            self->tags[i].handler = sibling->tags[i].handler;
+        }
+    }
+    return self;
+}
+
+/**
+ * fm_xml_file_set_handler
+ * @file: the parser container
+ * @tag: tag to use @handler for
+ * @handler: callback for @tag
+ * @in_line: %TRUE if tag should not receive new line by fm_xml_file_to_data()
+ * @error: (allow-none) (out): location to save error
+ *
+ * Sets @handler for @file to be called on parse when @tag is found
+ * in XML data. This function will fail if some handler for @tag was
+ * aready set, in this case @error will be set appropriately.
+ *
+ * Returns: id for the @tag.
+ *
+ * Since: 1.2.0
+ */
+FmXmlFileTag fm_xml_file_set_handler(FmXmlFile *file, const char *tag,
+                                     FmXmlFileHandler handler, gboolean in_line,
+                                     GError **error)
+{
+    FmXmlFileTag i;
+
+    g_return_val_if_fail(file != NULL && FM_IS_XML_FILE(file), FM_XML_FILE_TAG_NOT_HANDLED);
+    g_return_val_if_fail(handler != NULL, FM_XML_FILE_TAG_NOT_HANDLED);
+    g_return_val_if_fail(tag != NULL, FM_XML_FILE_TAG_NOT_HANDLED);
+    for (i = 1; i < file->n_tags; i++)
+        if (strcmp(file->tags[i].name, tag) == 0)
+        {
+            g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_UNKNOWN_ELEMENT,
+                        _("Duplicate handler for tag <%s>"), tag);
+            return i;
+        }
+    file->tags = g_renew(FmXmlFileTagDesc, file->tags, i + 1);
+    file->tags[i].name = g_strdup(tag);
+    file->tags[i].handler = handler;
+    file->tags[i].in_line = in_line;
+    file->n_tags = i + 1;
+    /* g_debug("XML parser: added handler '%s' id %u", tag, (guint)i); */
+    return i;
+}
+
+
+/* parse */
+
+/*
+ * This function was taken from GLib sources and adapted to be used here.
+ * Copyright 2000, 2003 Red Hat, Inc.
+ *
+ * re-write the GString in-place, unescaping anything that escaped.
+ * most XML does not contain entities, or escaping.
+ */
+static gboolean
+unescape_gstring_inplace (//GMarkupParseContext  *context,
+                          GString              *string,
+                          //gboolean             *is_ascii,
+                          guint                *line_num,
+                          guint                *pos,
+                          gboolean              normalize_attribute,
+                          GError              **error)
+{
+  //char mask, *to;
+  char *to;
+  //int line_num = 1;
+  const char *from, *sol;
+
+  //*is_ascii = FALSE;
+
+  /*
+   * Meeks' theorum: unescaping can only shrink text.
+   * for &lt; etc. this is obvious, for &#xffff; more
+   * thought is required, but this is patently so.
+   */
+  //mask = 0;
+  for (from = to = string->str; *from != '\0'; from++, to++)
+    {
+      *to = *from;
+
+      //mask |= *to;
+      if (*to == '\n')
+      {
+        (*line_num)++;
+        *pos = 0;
+      }
+      if (normalize_attribute && (*to == '\t' || *to == '\n'))
+        *to = ' ';
+      if (*to == '\r')
+        {
+          *to = normalize_attribute ? ' ' : '\n';
+          if (from[1] == '\n')
+          {
+            from++;
+            (*line_num)++;
+            *pos = 0;
+          }
+        }
+      sol = from;
+      if (*from == '&')
+        {
+          from++;
+          if (*from == '#')
+            {
+              gboolean is_hex = FALSE;
+              gulong l;
+              gchar *end = NULL;
+
+              from++;
+
+              if (*from == 'x')
+                {
+                  is_hex = TRUE;
+                  from++;
+                }
+
+              /* digit is between start and p */
+              errno = 0;
+              if (is_hex)
+                l = strtoul (from, &end, 16);
+              else
+                l = strtoul (from, &end, 10);
+
+              if (end == from || errno != 0)
+                {
+                  g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
+                              _("Failed to parse '%-.*s', which "
+                                "should have been a digit "
+                                "inside a character reference "
+                                "(&#234; for example) - perhaps "
+                                "the digit is too large"),
+                              (int)(end - from), from);
+                  return FALSE;
+                }
+              else if (*end != ';')
+                {
+                  g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
+                              _("Character reference did not end with a "
+                                "semicolon; "
+                                "most likely you used an ampersand "
+                                "character without intending to start "
+                                "an entity - escape ampersand as &amp;"));
+                  return FALSE;
+                }
+              else
+                {
+                  /* characters XML 1.1 permits */
+                  if ((0 < l && l <= 0xD7FF) ||
+                      (0xE000 <= l && l <= 0xFFFD) ||
+                      (0x10000 <= l && l <= 0x10FFFF))
+                    {
+                      gchar buf[8];
+                      memset (buf, 0, 8);
+                      g_unichar_to_utf8 (l, buf);
+                      strncpy (to, buf, 8);
+                      to += strlen (buf) - 1;
+                      from = end;
+                      //if (l >= 0x80) /* not ascii */
+                        //mask |= 0x80;
+                    }
+                  else
+                    {
+                      g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
+                                  _("Character reference '%-.*s' does not "
+                                    "encode a permitted character"),
+                                  (int)(end - from), from);
+                      return FALSE;
+                    }
+                }
+            }
+
+          else if (strncmp (from, "lt;", 3) == 0)
+            {
+              *to = '<';
+              from += 2;
+            }
+          else if (strncmp (from, "gt;", 3) == 0)
+            {
+              *to = '>';
+              from += 2;
+            }
+          else if (strncmp (from, "amp;", 4) == 0)
+            {
+              *to = '&';
+              from += 3;
+            }
+          else if (strncmp (from, "quot;", 5) == 0)
+            {
+              *to = '"';
+              from += 4;
+            }
+          else if (strncmp (from, "apos;", 5) == 0)
+            {
+              *to = '\'';
+              from += 4;
+            }
+          else
+            {
+              if (*from == ';')
+                g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
+                            _("Empty entity '&;' seen; valid "
+                              "entities are: &amp; &quot; &lt; &gt; &apos;"));
+              else
+                {
+                  const char *end = strchr (from, ';');
+                  if (end)
+                    g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
+                                _("Entity name '%-.*s' is not known"),
+                                (int)(end-from), from);
+                  else
+                    g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
+                                _("Entity did not end with a semicolon; "
+                                  "most likely you used an ampersand "
+                                  "character without intending to start "
+                                  "an entity - escape ampersand as &amp;"));
+                }
+              return FALSE;
+            }
+        }
+      *pos += (from - sol) + 1;
+    }
+
+  /* g_debug("unescape_gstring_inplace completed"); */
+  g_assert (to - string->str <= (gint)string->len);
+  if (to - string->str != (gint)string->len)
+    g_string_truncate (string, to - string->str);
+
+  //*is_ascii = !(mask & 0x80);
+
+  return TRUE;
+}
+
+
+static inline void _update_file_ptr_part(FmXmlFile *file, const char *start,
+                                         const char *end)
+{
+    while (start < end)
+    {
+        if (*start == '\n')
+        {
+            file->line++;
+            file->pos = 0;
+        }
+        else
+            /* FIXME: advance by chars not bytes? */
+            file->pos++;
+        start++;
+    }
+}
+
+static inline void _update_file_ptr(FmXmlFile *file, int add_cols)
+{
+    guint i;
+    char *p;
+
+    for (i = file->data->len, p = file->data->str; i > 0; i--, p++)
+    {
+        if (*p == '\n')
+        {
+            file->line++;
+            file->pos = 0;
+        }
+        else
+            /* FIXME: advance by chars not bytes? */
+            file->pos++;
+    }
+    file->pos += add_cols;
+}
+
+static inline gboolean _is_space(char c)
+{
+    return (c == ' ' || c == '\t' || c == '\n' || c == '\r');
+}
+
+/**
+ * fm_xml_file_parse_data
+ * @file: the parser container
+ * @text: data to parse
+ * @size: size of @text
+ * @error: (allow-none) (out): location to save error
+ * @user_data: data to pass to handlers
+ *
+ * Parses next chunk of @text data. Parsing stops at end of data or at any
+ * error. In latter case @error will be set appropriately.
+ *
+ * See also: fm_xml_file_finish_parse().
+ *
+ * Returns: %FALSE if parsing failed.
+ *
+ * Since: 1.2.0
+ */
+gboolean fm_xml_file_parse_data(FmXmlFile *file, const char *text,
+                                gsize size, GError **error, gpointer user_data)
+{
+    gsize ptr, len;
+    char *dst, *end, *tag, *name, *value;
+    GString *buff;
+    FmXmlFileItem *item;
+    gboolean closing, selfdo;
+    FmXmlFileTag i;
+    char **attrib_names, **attrib_values;
+    guint attribs;
+    char quote;
+
+    g_return_val_if_fail(file != NULL && FM_IS_XML_FILE(file), FALSE);
+_restart:
+    if (size == 0)
+        return TRUE;
+    /* if file->data has '<' as first char then we stopped at tag */
+    if (file->data && file->data->len && file->data->str[0] == '<')
+    {
+        for (ptr = 0; ptr < size; ptr++)
+            if (text[ptr] == '>')
+                break;
+        if (ptr == size) /* still no end of that tag */
+        {
+            g_string_append_len(file->data, text, size);
+            return TRUE;
+        }
+        /* we got a complete tag, nice, let parse it */
+        g_string_append_len(file->data, text, ptr);
+        ptr++;
+        text += ptr;
+        size -= ptr;
+        /* check for CDATA first */
+        if (file->data->len >= 11 /* <![CDATA[]] */ &&
+            strncmp(file->data->str, "<![CDATA[", 9) == 0)
+        {
+            end = file->data->str + file->data->len;
+            if (end[-2] != ']' || end[-1] != ']') /* find end of CDATA */
+            {
+                g_string_append_c(file->data, '>');
+                goto _restart;
+            }
+            if (file->current_item == NULL) /* CDATA at top level! */
+                g_warning("FmXmlFile: line %u: junk CDATA in XML file ignored",
+                          file->line);
+            else
+            {
+                item = fm_xml_file_item_new(FM_XML_FILE_TEXT);
+                item->text = item->comment = g_strndup(&file->data->str[9],
+                                                       file->data->len - 11);
+                fm_xml_file_item_append_child(file->current_item, item);
+            }
+            _update_file_ptr(file, 1);
+            g_string_truncate(file->data, 0);
+            goto _restart;
+        }
+        /* check for comment */
+        if (file->data->len >= 7 /* <!-- -- */ &&
+            strncmp(file->data->str, "<!--", 4) == 0)
+        {
+            end = file->data->str + file->data->len;
+            if (end[-2] != '-' || end[-1] != '-') /* find end of comment */
+            {
+                g_string_append_c(file->data, '>');
+                goto _restart;
+            }
+            g_free(file->comment_pre);
+            /* FIXME: not ignore duplicate comments */
+            if (_is_space(end[-3]))
+                file->comment_pre = g_strndup(&file->data->str[5],
+                                              file->data->len - 8);
+            else /* FIXME: check: XML spec says it should be not '-' */
+                file->comment_pre = g_strndup(&file->data->str[5],
+                                              file->data->len - 7);
+            _update_file_ptr(file, 1);
+            g_string_truncate(file->data, 0);
+            goto _restart;
+        }
+        /* check for DTD - it may be only at top level */
+        if (file->current_item == NULL && file->data->len >= 10 &&
+            strncmp(file->data->str, "<!DOCTYPE", 9) == 0 &&
+            _is_space(file->data->str[9]))
+        {
+            /* FIXME: can DTD contain any tags? count '<' and '>' pairs */
+            if (file->tags[0].name) /* duplicate DTD! */
+                g_warning("FmXmlFile: line %u: duplicate DTD, ignored",
+                          file->line);
+            else
+                file->tags[0].name = g_strndup(&file->data->str[10],
+                                               file->data->len - 10);
+            _update_file_ptr(file, 1);
+            g_string_truncate(file->data, 0);
+            goto _restart;
+        }
+        /* support directives such as <?xml ..... ?> */
+        if (file->data->len >= 4 /* <?x? */ &&
+            file->data->str[1] == '?' &&
+            file->data->str[file->data->len-1] == '?')
+        {
+            item = fm_xml_file_item_new(FM_XML_FILE_TEXT);
+            item->comment = g_strndup(&file->data->str[2], file->data->len - 3);
+            if (file->current_item != NULL)
+                fm_xml_file_item_append_child(file->current_item, item);
+            else
+            {
+                item->file = file;
+                item->parent_list = &file->items;
+                file->items = g_list_append(file->items, item);
+            }
+            _update_file_ptr(file, 1);
+            g_string_truncate(file->data, 0);
+            goto _restart;
+        }
+        closing = (file->data->str[1] == '/');
+        end = file->data->str + file->data->len;
+        selfdo = (!closing && end[-1] == '/');
+        if (selfdo)
+            end--;
+        tag = closing ? &file->data->str[2] : &file->data->str[1];
+        for (dst = tag; dst < end; dst++)
+            if (_is_space(*dst))
+                break;
+        _update_file_ptr_part(file, file->data->str, dst + 1);
+        *dst = '\0'; /* terminate the tag */
+        if (closing)
+        {
+            if (dst != end) /* we got a space char in closing tag */
+            {
+                g_set_error_literal(error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
+                                    _("Space isn't allowed in the close tag"));
+                return FALSE;
+            }
+            /* g_debug("XML parser: found closing tag '%s' for %p at %d:%d", tag,
+                    file->current_item, file->line, file->pos); */
+            item = file->current_item;
+            if (item == NULL) /* no tag to close */
+            {
+                g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
+                            _("Element '%s' was closed but no element was opened"),
+                            tag);
+                return FALSE;
+            }
+            else
+            {
+                char *tagname;
+
+                if (item->tag == FM_XML_FILE_TAG_NOT_HANDLED)
+                    tagname = item->tag_name;
+                else
+                    tagname = file->tags[item->tag].name;
+                if (strcmp(tag, tagname)) /* closing tag doesn't match */
+                {
+                    /* FIXME: validate tag so be more verbose on error */
+                    g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
+                                _("Element '%s' was closed but the currently "
+                                  "open element is '%s'"), tag, tagname);
+                    return FALSE;
+                }
+                file->current_item = item->parent;
+_close_the_tag:
+                /* g_debug("XML parser: close the tag '%s'", tag); */
+                g_string_truncate(file->data, 0);
+                if (item->tag != FM_XML_FILE_TAG_NOT_HANDLED)
+                {
+                    if (!file->tags[item->tag].handler(item, item->children,
+                                                       item->attribute_names,
+                                                       item->attribute_values,
+                                                       item->attribute_names ? g_strv_length(item->attribute_names) : 0,
+                                                       file->line,
+                                                       file->pos,
+                                                       error, user_data))
+                        return FALSE;
+                }
+                file->pos++; /* '>' */
+                goto _restart;
+            }
+        }
+        else /* opening tag */
+        {
+            /* g_debug("XML parser: found opening tag '%s'", tag); */
+            /* parse and check tag name */
+            for (i = 1; i < file->n_tags; i++)
+                if (strcmp(file->tags[i].name, tag) == 0)
+                    break;
+            if (i == file->n_tags)
+                /* FIXME: do name validation */
+                i = FM_XML_FILE_TAG_NOT_HANDLED;
+            /* parse and check attributes */
+            attribs = 0;
+            attrib_names = attrib_values = NULL;
+            while (dst < end)
+            {
+                name = &dst[1]; /* skip this space */
+                while (name < end && _is_space(*name))
+                    name++;
+                value = name;
+                while (value < end && !_is_space(*value) && *value != '=')
+                    value++;
+                len = value - name;
+                _update_file_ptr_part(file, dst, value);
+                /* FIXME: skip spaces before =? */
+                if (value + 3 <= end && *value == '=') /* minimum is ="" */
+                {
+                    value++;
+                    file->pos++; /* '=' */
+                    /* FIXME: skip spaces after =? */
+                    quote = *value++;
+                    if (quote != '\'' && quote != '"')
+                    {
+                        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
+                                    _("Invalid char '%c' at start of attribute value"),
+                                    quote);
+                        goto _attr_error;
+                    }
+                    file->pos++; /* quote char */
+                    for (ptr = 0; &value[ptr] < end; ptr++)
+                        if (value[ptr] == quote)
+                            break;
+                    if (&value[ptr] == end)
+                    {
+                        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
+                                    _("Invalid char '%c' at end of attribute value,"
+                                      " expected '%c'"), value[ptr-1], quote);
+                        goto _attr_error;
+                    }
+                    buff = g_string_new_len(value, ptr);
+                    if (!unescape_gstring_inplace(buff, &file->line,
+                                                  &file->pos, TRUE, error))
+                    {
+                        g_string_free(buff, TRUE);
+_attr_error:
+                        for (i = 0; i < attribs; i++)
+                        {
+                            g_free(attrib_names[i]);
+                            g_free(attrib_values[i]);
+                        }
+                        g_free(attrib_names);
+                        g_free(attrib_values);
+                        return FALSE;
+                    }
+                    dst = &value[ptr+1];
+                    value = g_string_free(buff, FALSE);
+                    file->pos++; /* end quote char */
+                }
+                else
+                {
+                    dst = value;
+                    value = NULL;
+                    /* FIXME: isn't it error? */
+                }
+                attrib_names = g_renew(char *, attrib_names, attribs + 2);
+                attrib_values = g_renew(char *, attrib_values, attribs + 2);
+                attrib_names[attribs] = g_strndup(name, len);
+                attrib_values[attribs] = value;
+                attribs++;
+            }
+            if (attribs > 0)
+            {
+                attrib_names[attribs] = NULL;
+                attrib_values[attribs] = NULL;
+            }
+            /* create new item */
+            item = fm_xml_file_item_new(i);
+            item->attribute_names = attrib_names;
+            item->attribute_values = attrib_values;
+            if (i == FM_XML_FILE_TAG_NOT_HANDLED)
+                item->tag_name = g_strdup(tag);
+            /* insert new item into the container */
+            item->comment = file->comment_pre;
+            file->comment_pre = NULL;
+            if (file->current_item)
+                fm_xml_file_item_append_child(file->current_item, item);
+            else
+            {
+                item->file = file;
+                item->parent_list = &file->items;
+                file->items = g_list_append(file->items, item);
+            }
+            file->pos++; /* '>' or '/' */
+            if (selfdo) /* simple self-closing tag */
+                goto _close_the_tag;
+            file->current_item = item;
+            g_string_truncate(file->data, 0);
+            goto _restart;
+        }
+    }
+    /* otherwise we stopped at some data somewhere */
+    else
+    {
+        if (!file->data || file->data->len == 0) while (size > 0)
+        {
+            /* skip leading spaces */
+            if (*text == '\n')
+            {
+                file->line++;
+                file->pos = 0;
+            }
+            else if (*text == ' ' || *text == '\t' || *text == '\r')
+                file->pos++;
+            else
+                break;
+            text++;
+            size--;
+        }
+        for (ptr = 0; ptr < size; ptr++)
+            if (text[ptr] == '<')
+                break;
+        if (file->data == NULL)
+            file->data = g_string_new_len(text, ptr);
+        else if (ptr > 0)
+            g_string_append_len(file->data, text, ptr);
+        if (ptr == size) /* still no end of text */
+            return TRUE;
+        /* if(ptr>0) g_debug("XML parser: got text '%s'", file->data->str); */
+        if (ptr == 0) ; /* no text */
+        else if (file->current_item == NULL) /* text at top level! */
+        {
+            g_warning("FmXmlFile: line %u: junk data in XML file ignored",
+                      file->line);
+            _update_file_ptr(file, 0);
+        }
+        else if (unescape_gstring_inplace(file->data, &file->line,
+                                          &file->pos, FALSE, error))
+        {
+            item = fm_xml_file_item_new(FM_XML_FILE_TEXT);
+            item->text = g_strndup(file->data->str, file->data->len);
+            item->comment = file->comment_pre;
+            file->comment_pre = NULL;
+            fm_xml_file_item_append_child(file->current_item, item);
+            /* FIXME: truncate ending spaces from item->text */
+        }
+        else
+            return FALSE;
+        ptr++;
+        text += ptr;
+        size -= ptr;
+        g_string_assign(file->data, "<");
+        goto _restart;
+    }
+    /* error if reached */
+}
+
+/**
+ * fm_xml_file_finish_parse
+ * @file: the parser container
+ * @error: (allow-none) (out): location to save error
+ *
+ * Ends parsing of data and retrieves final status. If XML was invalid
+ * then returns %NULL and sets @error appropriately.
+ * This function can be called more than once.
+ *
+ * See also: fm_xml_file_parse_data().
+ * See also: fm_xml_file_item_get_children().
+ *
+ * Returns: (transfer container) (element-type FmXmlFileItem): contents of XML
+ *
+ * Since: 1.2.0
+ */
+GList *fm_xml_file_finish_parse(FmXmlFile *file, GError **error)
+{
+    g_return_val_if_fail(file != NULL && FM_IS_XML_FILE(file), NULL);
+    if (file->current_item)
+    {
+        if (file->current_item->tag == FM_XML_FILE_TEXT &&
+            file->current_item->parent == NULL)
+            g_warning("FmXmlFile: junk at end of XML");
+        else
+        {
+            g_set_error_literal(error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
+                                _("Document ended unexpectedly"));
+            /* FIXME: analize content of file->data to be more verbose */
+            return NULL;
+        }
+    }
+    else if (file->items == NULL)
+    {
+        g_set_error_literal(error, G_MARKUP_ERROR, G_MARKUP_ERROR_EMPTY,
+                            _("Document was empty or contained only whitespace"));
+        return NULL;
+    }
+    /* FIXME: check if file->comment_pre is NULL */
+    return g_list_copy(file->items);
+}
+
+/**
+ * fm_xml_file_get_current_line
+ * @file: the parser container
+ * @pos: (allow-none) (out): location to save line position
+ *
+ * Retrieves the line where parser has stopped.
+ *
+ * Returns: line num (starting from 1).
+ *
+ * Since: 1.2.0
+ */
+gint fm_xml_file_get_current_line(FmXmlFile *file, gint *pos)
+{
+    if (file == NULL || !FM_IS_XML_FILE(file))
+        return 0;
+    if (pos)
+        *pos = file->pos;
+    return file->line;
+}
+
+/**
+ * fm_xml_file_get_dtd
+ * @file: the parser container
+ *
+ * Retrieves DTD description for XML data in the container. Returned data
+ * are owned by @file and should not be modified by caller.
+ *
+ * Returns: (transfer none): DTD description.
+ *
+ * Since: 1.2.0
+ */
+const char *fm_xml_file_get_dtd(FmXmlFile *file)
+{
+    if(file == NULL)
+        return NULL;
+    return file->tags[0].name;
+}
+
+
+/* item manipulations */
+
+/**
+ * fm_xml_file_item_new
+ * @tag: tag id for new item
+ *
+ * Creates new unattached XML item.
+ *
+ * Returns: (transfer full): newly allocated #FmXmlFileItem.
+ *
+ * Since: 1.2.0
+ */
+FmXmlFileItem *fm_xml_file_item_new(FmXmlFileTag tag)
+{
+    FmXmlFileItem *item = g_slice_new0(FmXmlFileItem);
+
+    item->tag = tag;
+    return item;
+}
+
+/**
+ * fm_xml_file_item_append_text
+ * @item: item to append text
+ * @text: text to append
+ * @text_size: length of text in bytes, or -1 if the text is nul-terminated
+ * @cdata: %TRUE if @text should be saved as CDATA array
+ *
+ * Appends @text after last element contained in @item.
+ *
+ * Since: 1.2.0
+ */
+void fm_xml_file_item_append_text(FmXmlFileItem *item, const char *text,
+                                  gssize text_size, gboolean cdata)
+{
+    FmXmlFileItem *text_item;
+
+    g_return_if_fail(item != NULL);
+    if (text == NULL || text_size == 0)
+        return;
+    text_item = fm_xml_file_item_new(FM_XML_FILE_TEXT);
+    if (text_size > 0)
+        text_item->text = g_strndup(text, text_size);
+    else
+        text_item->text = g_strdup(text);
+    if (cdata)
+        text_item->comment = text_item->text;
+    fm_xml_file_item_append_child(item, text_item);
+}
+
+static inline gboolean _xml_item_is_busy(FmXmlFileItem *item)
+{
+    register FmXmlFileItem *test;
+
+    if (item->file)
+        for (test = item->file->current_item; test; test = test->parent)
+            if (test == item)
+            {
+                /* g_debug("*** item %p is busy", item); */
+                return TRUE;
+            }
+    return FALSE;
+}
+
+static void _reassign_xml_file(FmXmlFileItem *item, FmXmlFile *file)
+{
+    GList *chl;
+
+    /* do it recursively */
+    for (chl = item->children; chl; chl = chl->next)
+        _reassign_xml_file(chl->data, file);
+    item->file = file;
+}
+
+/**
+ * fm_xml_file_item_append_child
+ * @item: item to append child
+ * @child: the child item to append
+ *
+ * Appends @child after last element contained in @item. If the @child
+ * already was in the XML structure then it will be moved to the new
+ * place instead.
+ * Behavior after moving between different containers is undefined.
+ *
+ * Returns: %FALSE if @child is busy thus cannot be moved.
+ *
+ * Since: 1.2.0
+ */
+gboolean fm_xml_file_item_append_child(FmXmlFileItem *item, FmXmlFileItem *child)
+{
+    g_return_val_if_fail(item != NULL && child != NULL, FALSE);
+    if (_xml_item_is_busy(child))
+        return FALSE; /* cannot move item right now */
+    if (child->parent_list) /* remove from old list */
+    {
+        /* g_debug("moving item %p(%d) from parser %p into %p as child of %p", child, (int)child->tag, child->file, item->file, item); */
+        g_assert(child->file != NULL && g_list_find(*child->parent_list, child) != NULL);
+        *child->parent_list = g_list_remove(*child->parent_list, child);
+    }
+    /* else
+        g_debug("adding item %p(%d) into parser %p as child of %p", child, (int)child->tag, item->file, item); */
+    item->children = g_list_append(item->children, child);
+    child->parent_list = &item->children;
+    child->parent = item;
+    if (child->file != item->file)
+        _reassign_xml_file(child, item->file);
+    return TRUE;
+}
+
+/**
+ * fm_xml_file_item_set_comment
+ * @item: element to set
+ * @comment: (allow-none): new comment
+ *
+ * Changes comment that is prepended to @item.
+ *
+ * Since: 1.2.0
+ */
+void fm_xml_file_item_set_comment(FmXmlFileItem *item, const char *comment)
+{
+    g_return_if_fail(item != NULL);
+    g_free(item->comment);
+    item->comment = g_strdup(comment);
+}
+
+/**
+ * fm_xml_file_item_set_attribute
+ * @item: element to update
+ * @name: attribute name
+ * @value: (allow-none): attribute data
+ *
+ * Changes data for the attribute of some @item with new @value. If such
+ * attribute wasn't set then adds it for the @item. If @value is %NULL
+ * then the attribute will be unset from the @item.
+ *
+ * Returns: %TRUE if attribute was set successfully.
+ *
+ * Since: 1.2.0
+ */
+gboolean fm_xml_file_item_set_attribute(FmXmlFileItem *item,
+                                        const char *name, const char *value)
+{
+    int i, n_attr;
+
+    g_return_val_if_fail(item != NULL, FALSE);
+    g_return_val_if_fail(name != NULL, FALSE);
+    if (item->attribute_names == NULL && value == NULL)
+        return TRUE;
+    if (item->attribute_names == NULL)
+    {
+        item->attribute_names = g_new(char *, 2);
+        item->attribute_values = g_new(char *, 2);
+        item->attribute_names[0] = g_strdup(name);
+        item->attribute_values[0] = g_strdup(value);
+        item->attribute_names[1] = NULL;
+        item->attribute_values[1] = NULL;
+        return TRUE;
+    }
+    for (i = -1, n_attr = 0; item->attribute_names[n_attr] != NULL; n_attr++)
+        if (strcmp(item->attribute_names[n_attr], name) == 0)
+            i = n_attr;
+    if (i < 0)
+    {
+        if (value == NULL) /* already unset */
+            return TRUE;
+        item->attribute_names = g_renew(char *, item->attribute_names, n_attr + 2);
+        item->attribute_values = g_renew(char *, item->attribute_values, n_attr + 2);
+        item->attribute_names[n_attr] = g_strdup(name);
+        item->attribute_values[n_attr] = g_strdup(value);
+        item->attribute_names[n_attr+1] = NULL;
+        item->attribute_values[n_attr+1] = NULL;
+    }
+    else if (value != NULL) /* value changed */
+    {
+        g_free(item->attribute_values[i]);
+        item->attribute_values[i] = g_strdup(value);
+    }
+    else if (n_attr == 1) /* no more attributes left */
+    {
+        g_strfreev(item->attribute_names);
+        g_strfreev(item->attribute_values);
+        item->attribute_names = NULL;
+        item->attribute_values = NULL;
+    }
+    else /* replace removed attribute with last one if it wasn't last */
+    {
+        g_free(item->attribute_names[i]);
+        g_free(item->attribute_values[i]);
+        if (i < n_attr - 1)
+        {
+            item->attribute_names[i] = item->attribute_names[n_attr-1];
+            item->attribute_values[i] = item->attribute_values[n_attr-1];
+        }
+        item->attribute_names[n_attr-1] = NULL;
+        item->attribute_values[n_attr-1] = NULL;
+    }
+    return TRUE;
+}
+
+/**
+ * fm_xml_file_item_destroy
+ * @item: element to destroy
+ *
+ * Removes element and its children from its parent, and frees all
+ * data.
+ *
+ * Returns: %FALSE if @item is busy thus cannot be destroyed.
+ *
+ * Since: 1.2.0
+ */
+gboolean fm_xml_file_item_destroy(FmXmlFileItem *item)
+{
+    g_return_val_if_fail(item != NULL, FALSE);
+    if (_xml_item_is_busy(item))
+        return FALSE;
+    while (item->children)
+    {
+        g_assert(((FmXmlFileItem*)item->children->data)->file == item->file);
+        g_assert(((FmXmlFileItem*)item->children->data)->parent == item);
+        fm_xml_file_item_destroy(item->children->data);
+    }
+    if (item->parent_list)
+    {
+        /* g_debug("removing item %p from parser %p", item, item->file); */
+        g_assert(item->file != NULL && g_list_find(*item->parent_list, item) != NULL);
+        *item->parent_list = g_list_remove(*item->parent_list, item);
+    }
+    if (item->text != item->comment)
+        g_free(item->comment);
+    g_free(item->text);
+    g_strfreev(item->attribute_names);
+    g_strfreev(item->attribute_values);
+    g_slice_free(FmXmlFileItem, item);
+    return TRUE;
+}
+
+/**
+ * fm_xml_file_insert_before
+ * @item: item to insert before it
+ * @new_item: new item to insert
+ *
+ * Inserts @new_item before @item that is already in XML structure. If
+ * @new_item is already in the XML structure then it will be moved to
+ * the new place instead.
+ * Behavior after moving between defferent containers is undefined.
+ *
+ * Returns: %TRUE in case of success.
+ *
+ * Since: 1.2.0
+ */
+gboolean fm_xml_file_insert_before(FmXmlFileItem *item, FmXmlFileItem *new_item)
+{
+    GList *sibling;
+
+    g_return_val_if_fail(item != NULL && new_item != NULL, FALSE);
+    sibling = g_list_find(*item->parent_list, item);
+    if (sibling == NULL) /* no such item found */
+    {
+        /* g_critical("item %p not found in %p", item, item->parent); */
+        return FALSE;
+    }
+    if (_xml_item_is_busy(new_item))
+        return FALSE; /* cannot move item right now */
+    if (new_item->parent_list) /* remove from old list */
+    {
+        /* g_debug("moving item %p (parent=%p) from parser %p into %p", new_item, item, new_item->file, item->file); */
+        g_assert(new_item->file != NULL && g_list_find(*new_item->parent_list, new_item) != NULL);
+        *new_item->parent_list = g_list_remove(*new_item->parent_list, new_item);
+    }
+    /* else
+        g_debug("inserting item %p (parent=%p) into parser %p", item, new_item, item->file); */
+    *item->parent_list = g_list_insert_before(*item->parent_list, sibling, new_item);
+    new_item->parent_list = item->parent_list;
+    new_item->parent = item->parent;
+    if (new_item->file != item->file)
+        _reassign_xml_file(new_item, item->file);
+    return TRUE;
+}
+
+/**
+ * fm_xml_file_insert_first
+ * @file: the parser container
+ * @new_item: new item to insert
+ *
+ * Inserts @new_item as very first element of XML data in container.
+ *
+ * Returns: %TRUE in case of success.
+ *
+ * Since: 1.2.0
+ */
+gboolean fm_xml_file_insert_first(FmXmlFile *file, FmXmlFileItem *new_item)
+{
+    g_return_val_if_fail(file != NULL && FM_IS_XML_FILE(file), FALSE);
+    g_return_val_if_fail(new_item != NULL, FALSE);
+    if (_xml_item_is_busy(new_item))
+        return FALSE; /* cannot move item right now */
+    if (new_item->parent_list)
+    {
+        /* g_debug("moving item %p from parser %p into %p", new_item, new_item->file, file); */
+        g_assert(new_item->file != NULL && g_list_find(*new_item->parent_list, new_item) != NULL);
+        *new_item->parent_list = g_list_remove(*new_item->parent_list, new_item);
+    }
+    file->items = g_list_prepend(file->items, new_item);
+    new_item->parent_list = &file->items;
+    new_item->parent = NULL;
+    if (new_item->file != file)
+        _reassign_xml_file(new_item, file);
+    return TRUE;
+}
+
+
+/* save XML */
+
+/**
+ * fm_xml_file_set_dtd
+ * @file: the parser container
+ * @dtd: DTD description for XML data
+ * @error: (allow-none) (out): location to save error
+ *
+ * Changes DTD description for XML data in the container.
+ *
+ * Since: 1.2.0
+ */
+void fm_xml_file_set_dtd(FmXmlFile *file, const char *dtd, GError **error)
+{
+    if(file == NULL)
+        return;
+    /* FIXME: validate dtd */
+    g_free(file->tags[0].name);
+    file->tags[0].name = g_strdup(dtd);
+}
+
+static gboolean _parser_item_to_gstring(FmXmlFile *file, GString *string,
+                                        FmXmlFileItem *item, GString *prefix,
+                                        gboolean *has_nl, GError **error)
+{
+    const char *tag_name;
+    GList *l;
+
+    /* open the tag */
+    switch (item->tag)
+    {
+    case FM_XML_FILE_TAG_NOT_HANDLED:
+        if (item->tag_name == NULL)
+            goto _no_tag;
+        tag_name = item->tag_name;
+        goto _do_tag;
+    case FM_XML_FILE_TEXT:
+        if (item->text == item->comment) /* CDATA */
+            g_string_append_printf(string, "<![CDATA[%s]]>", item->text);
+        else if (item->text) /* just text */
+        {
+            char *escaped;
+
+            if (item->comment != NULL)
+                g_string_append_printf(string, "<!-- %s -->", item->comment);
+            escaped = g_markup_escape_text(item->text, -1);
+            g_string_append(string, escaped);
+            g_free(escaped);
+        }
+        else /* processing directive */
+        {
+            g_string_append_printf(string, "%s<?%s?>", prefix->str, item->comment);
+            *has_nl = TRUE;
+        }
+        return TRUE;
+    default:
+        if (item->tag >= file->n_tags)
+        {
+_no_tag:
+            g_set_error_literal(error, G_MARKUP_ERROR, G_MARKUP_ERROR_UNKNOWN_ELEMENT,
+                                _("fm_xml_file_to_data: XML data error"));
+            return FALSE;
+        }
+        tag_name = file->tags[item->tag].name;
+_do_tag:
+        /* do comment */
+        if (item->comment != NULL)
+            g_string_append_printf(string, "%s<!-- %s -->", prefix->str,
+                                   item->comment);
+        else if (item->attribute_names == NULL && item->children == NULL &&
+                 file->tags[item->tag].in_line)
+        {
+            /* don't add prefix if it is simple tag such as <br/> */
+            g_string_append_printf(string, "<%s/>", tag_name);
+            return TRUE;
+        }
+        /* start the tag */
+        g_string_append_printf(string, "%s<%s", prefix->str, tag_name);
+        /* do attributes */
+        if (item->attribute_names)
+        {
+            char **name = item->attribute_names;
+            char **value = item->attribute_values;
+            while (*name)
+            {
+                if (*value)
+                {
+                    char *escaped = g_markup_escape_text(*value, -1);
+                    g_string_append_printf(string, " %s='%s'", *name, escaped);
+                    g_free(escaped);
+                } /* else error? */
+                name++;
+                value++;
+            }
+        }
+        if (item->children == NULL)
+        {
+            /* handle empty tags such as <tag attr='value'/> */
+            g_string_append(string, "/>");
+            *has_nl = TRUE;
+            return TRUE;
+        }
+        g_string_append_c(string, '>');
+    }
+    /* do with children */
+    *has_nl = FALSE; /* to collect data from nested elements */
+    g_string_append(prefix, "    ");
+    for (l = item->children; l; l = l->next)
+        if (!_parser_item_to_gstring(file, string, l->data, prefix, has_nl, error))
+            break;
+    g_string_truncate(prefix, prefix->len - 4);
+    if (l != NULL) /* failed */
+        return FALSE;
+    /* close the tag */
+    g_string_append_printf(string, "%s</%s>", (*has_nl) ? prefix->str : "",
+                           tag_name);
+    *has_nl = TRUE; /* it was prefixed above */
+    return TRUE;
+}
+
+/**
+ * fm_xml_file_to_data
+ * @file: the parser container
+ * @text_size: (allow-none) (out): location to save size of returned data
+ * @error: (allow-none) (out): location to save error
+ *
+ * Prepares string representation (XML text) for the data that are in
+ * the container. Returned data should be freed with g_free() after
+ * usage.
+ *
+ * Returns: (transfer full): XML text representing data in @file.
+ *
+ * Since: 1.2.0
+ */
+char *fm_xml_file_to_data(FmXmlFile *file, gsize *text_size, GError **error)
+{
+    GString *string, *prefix;
+    GList *l;
+    gboolean has_nl = FALSE;
+
+    g_return_val_if_fail(file != NULL && FM_IS_XML_FILE(file), NULL);
+    string = g_string_sized_new(512);
+    prefix = g_string_new("\n");
+    if (G_LIKELY(file->tags[0].name))
+        g_string_printf(string, "<!DOCTYPE %s>", file->tags[0].name);
+    for (l = file->items; l; l = l->next)
+        if (!_parser_item_to_gstring(file, string, l->data, prefix, &has_nl, error))
+            break; /* if failed then l != NULL */
+    g_string_free(prefix, TRUE);
+    if (text_size)
+        *text_size = string->len;
+    return g_string_free(string, (l != NULL)); /* returns NULL if failed */
+}
+
+
+/* item data accessor functions */
+
+/**
+ * fm_xml_file_item_get_comment
+ * @item: the file element to inspect
+ *
+ * If an element @item has a comment ahead of it then retrieves that
+ * comment. The returned data are owned by @item and should not be freed
+ * nor otherwise altered by caller.
+ *
+ * Returns: (transfer none): comment or %NULL if no comment is set.
+ *
+ * Since: 1.2.0
+ */
+const char *fm_xml_file_item_get_comment(FmXmlFileItem *item)
+{
+    g_return_val_if_fail(item != NULL, NULL);
+    return item->comment;
+}
+
+/**
+ * fm_xml_file_item_get_children
+ * @item: the file element to inspect
+ *
+ * Retrieves list of children for @item that are known to the parser.
+ * Returned list should be freed by g_list_free() after usage.
+ *
+ * Note: any text between opening tag and closing tag such as
+ * |[ &lt;Tag&gt;Some text&lt;/Tag&gt; ]|
+ * is presented as a child of special type #FM_XML_FILE_TEXT and can be
+ * retrieved from that child, not from the item representing &lt;Tag&gt;.
+ *
+ * See also: fm_xml_file_item_get_data().
+ *
+ * Returns: (transfer container) (element-type FmXmlFileItem): children list.
+ *
+ * Since: 1.2.0
+ */
+GList *fm_xml_file_item_get_children(FmXmlFileItem *item)
+{
+    g_return_val_if_fail(item != NULL, NULL);
+    return g_list_copy(item->children);
+}
+
+/**
+ * fm_xml_file_item_find_child
+ * @item: the file element to inspect
+ * @tag: tag id to search among children
+ *
+ * Searches for first child of @item which have child with tag id @tag.
+ * Returned data are owned by file and should not be freed by caller.
+ *
+ * Returns: (transfer none): found child or %NULL if no such child was found.
+ *
+ * Since: 1.2.0
+ */
+FmXmlFileItem *fm_xml_file_item_find_child(FmXmlFileItem *item, FmXmlFileTag tag)
+{
+    GList *l;
+
+    for (l = item->children; l; l = l->next)
+        if (((FmXmlFileItem*)l->data)->tag == tag)
+            return (FmXmlFileItem*)l->data;
+    return NULL;
+}
+
+/**
+ * fm_xml_file_item_get_tag
+ * @item: the file element to inspect
+ *
+ * Retrieves tag id of @item.
+ *
+ * Returns: tag id.
+ *
+ * Since: 1.2.0
+ */
+FmXmlFileTag fm_xml_file_item_get_tag(FmXmlFileItem *item)
+{
+    g_return_val_if_fail(item != NULL, FM_XML_FILE_TAG_NOT_HANDLED);
+    return item->tag;
+}
+
+/**
+ * fm_xml_file_item_get_data
+ * @item: the file element to inspect
+ * @text_size: (allow-none) (out): location to save data size
+ *
+ * Retrieves text data from @item of type #FM_XML_FILE_TEXT. Returned
+ * data are owned by file and should not be freed nor altered.
+ *
+ * Returns: (transfer none): text data or %NULL if @item isn't text data.
+ *
+ * Since: 1.2.0
+ */
+const char *fm_xml_file_item_get_data(FmXmlFileItem *item, gsize *text_size)
+{
+    if (text_size)
+        *text_size = 0;
+    g_return_val_if_fail(item != NULL, NULL);
+    if (item->tag != FM_XML_FILE_TEXT)
+        return NULL;
+    if (text_size && item->text != NULL)
+        *text_size = strlen(item->text);
+    return item->text;
+}
+
+/**
+ * fm_xml_file_item_get_parent
+ * @item: the file element to inspect
+ *
+ * Retrieves parent element of @item if the @item has one. Returned data
+ * are owned by file and should not be freed by caller.
+ *
+ * Returns: (transfer none): parent element or %NULL if element has no parent.
+ *
+ * Since: 1.2.0
+ */
+FmXmlFileItem *fm_xml_file_item_get_parent(FmXmlFileItem *item)
+{
+    g_return_val_if_fail(item != NULL, NULL);
+    return item->parent;
+}
+
+/**
+ * fm_xml_file_get_tag_name
+ * @file: the parser container
+ * @tag: the tag id to inspect
+ *
+ * Retrieves tag for its id. Returned data are owned by @file and should
+ * not be modified by caller.
+ *
+ * Returns: (transfer none): tag string representation.
+ *
+ * Since: 1.2.0
+ */
+const char *fm_xml_file_get_tag_name(FmXmlFile *file, FmXmlFileTag tag)
+{
+    g_return_val_if_fail(file != NULL && FM_IS_XML_FILE(file), NULL);
+    g_return_val_if_fail(tag > 0 && tag < file->n_tags, NULL);
+    return file->tags[tag].name;
+}
+
+/**
+ * fm_xml_file_item_get_tag_name
+ * @item: the file element to inspect
+ *
+ * Retrieves tag for its id. Returned data are owned by @item and should
+ * not be modified by caller.
+ *
+ * Returns: (transfer none): tag string representation or %NULL if @item is text.
+ *
+ * Since: 1.2.0
+ */
+const char *fm_xml_file_item_get_tag_name(FmXmlFileItem *item)
+{
+    g_return_val_if_fail(item != NULL, NULL);
+    switch (item->tag)
+    {
+    case FM_XML_FILE_TEXT:
+        return NULL;
+    case FM_XML_FILE_TAG_NOT_HANDLED:
+        return item->tag_name;
+    default:
+        return item->file->tags[item->tag].name;
+    }
+}

--- a/libfm-qt/core/vfs/fm-xml-file.h
+++ b/libfm-qt/core/vfs/fm-xml-file.h
@@ -1,0 +1,122 @@
+/*
+ *      fm-xml-file.h
+ *
+ *      Copyright 2013 Andriy Grytsenko (LStranger) <andrej@rep.kiev.ua>
+ *
+ *      This file is a part of libfm-extra package.
+ *
+ *      This library is free software; you can redistribute it and/or
+ *      modify it under the terms of the GNU Lesser General Public
+ *      License as published by the Free Software Foundation; either
+ *      version 2.1 of the License, or (at your option) any later version.
+ *
+ *      This library is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *      Lesser General Public License for more details.
+ *
+ *      You should have received a copy of the GNU Lesser General Public
+ *      License along with this library; if not, write to the Free Software
+ *      Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef __FM_XML_FILE_H__
+#define __FM_XML_FILE_H__ 1
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define FM_XML_FILE_TYPE           (fm_xml_file_get_type())
+#define FM_IS_XML_FILE(obj)        (G_TYPE_CHECK_INSTANCE_TYPE((obj), FM_XML_FILE_TYPE))
+
+typedef struct _FmXmlFile           FmXmlFile;
+typedef struct _FmXmlFileClass      FmXmlFileClass;
+
+GType fm_xml_file_get_type(void);
+
+typedef struct _FmXmlFileItem       FmXmlFileItem;
+typedef guint                       FmXmlFileTag;
+
+/**
+ * FM_XML_FILE_TAG_NOT_HANDLED:
+ *
+ * Value of FmXmlFileTag which means this element has no handler installed.
+ */
+#define FM_XML_FILE_TAG_NOT_HANDLED 0
+
+/**
+ * FM_XML_FILE_TEXT:
+ *
+ * Value of FmXmlFileTag which means this element has parsed character data.
+ */
+#define FM_XML_FILE_TEXT (FmXmlFileTag)-1
+
+/**
+ * FmXmlFileHandler
+ * @item: XML element being parsed
+ * @children: (element-type FmXmlFileItem): elements found in @item
+ * @attribute_names: attributes names list for @item
+ * @attribute_values: attributes values list for @item
+ * @n_attributes: list length of @attribute_names and @attribute_values
+ * @line: current line number in the file (starting from 1)
+ * @pos: current pos number in the file (starting from 0)
+ * @error: (allow-none) (out): location to save error
+ * @user_data: data passed to fm_xml_file_parse_data()
+ *
+ * Callback for processing some element in XML file.
+ * It will be called at closing tag.
+ *
+ * Returns: %TRUE if no errors were found by handler.
+ *
+ * Since: 1.2.0
+ */
+typedef gboolean (*FmXmlFileHandler)(FmXmlFileItem *item, GList *children,
+                                     char * const *attribute_names,
+                                     char * const *attribute_values,
+                                     guint n_attributes, gint line, gint pos,
+                                     GError **error, gpointer user_data);
+
+/* setup */
+FmXmlFile *fm_xml_file_new(FmXmlFile *sibling);
+FmXmlFileTag fm_xml_file_set_handler(FmXmlFile *file, const char *tag,
+                                     FmXmlFileHandler handler, gboolean in_line,
+                                     GError **error);
+
+/* parse */
+gboolean fm_xml_file_parse_data(FmXmlFile *file, const char *text,
+                                gsize size, GError **error, gpointer user_data);
+GList *fm_xml_file_finish_parse(FmXmlFile *file, GError **error);
+gint fm_xml_file_get_current_line(FmXmlFile *file, gint *pos);
+const char *fm_xml_file_get_dtd(FmXmlFile *file);
+
+/* item manipulations */
+FmXmlFileItem *fm_xml_file_item_new(FmXmlFileTag tag);
+void fm_xml_file_item_append_text(FmXmlFileItem *item, const char *text,
+                                  gssize text_size, gboolean cdata);
+gboolean fm_xml_file_item_append_child(FmXmlFileItem *item, FmXmlFileItem *child);
+void fm_xml_file_item_set_comment(FmXmlFileItem *item, const char *comment);
+gboolean fm_xml_file_item_set_attribute(FmXmlFileItem *item,
+                                        const char *name, const char *value);
+gboolean fm_xml_file_item_destroy(FmXmlFileItem *item);
+
+gboolean fm_xml_file_insert_before(FmXmlFileItem *item, FmXmlFileItem *new_item);
+gboolean fm_xml_file_insert_first(FmXmlFile *file, FmXmlFileItem *new_item);
+
+/* save XML */
+void fm_xml_file_set_dtd(FmXmlFile *file, const char *dtd, GError **error);
+char *fm_xml_file_to_data(FmXmlFile *file, gsize *text_size, GError **error);
+
+/* item data accessor functions */
+const char *fm_xml_file_item_get_comment(FmXmlFileItem *item);
+GList *fm_xml_file_item_get_children(FmXmlFileItem *item);
+FmXmlFileItem *fm_xml_file_item_find_child(FmXmlFileItem *item, FmXmlFileTag tag);
+FmXmlFileTag fm_xml_file_item_get_tag(FmXmlFileItem *item);
+const char *fm_xml_file_item_get_data(FmXmlFileItem *item, gsize *text_size);
+FmXmlFileItem *fm_xml_file_item_get_parent(FmXmlFileItem *item);
+const char *fm_xml_file_item_get_tag_name(FmXmlFileItem *item);
+const char *fm_xml_file_get_tag_name(FmXmlFile *file, FmXmlFileTag tag);
+
+G_END_DECLS
+
+#endif /* __FM_XML_FILE_H__ */

--- a/libfm-qt/core/vfs/vfs-menu.c
+++ b/libfm-qt/core/vfs/vfs-menu.c
@@ -1,0 +1,3135 @@
+/*
+ *      fm-vfs-menu.c
+ *      VFS for "menu://applications/" path using menu-cache library.
+ *
+ *      Copyright 2012-2014 Andriy Grytsenko (LStranger) <andrej@rep.kiev.ua>
+ *
+ *      This library is free software; you can redistribute it and/or
+ *      modify it under the terms of the GNU Lesser General Public
+ *      License as published by the Free Software Foundation; either
+ *      version 2.1 of the License, or (at your option) any later version.
+ *
+ *      This library is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *      Lesser General Public License for more details.
+ *
+ *      You should have received a copy of the GNU Lesser General Public
+ *      License along with this library; if not, write to the Free Software
+ *      Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "fm-file.h"
+#include "glib-compat.h"
+#include "fm-xml-file.h"
+
+#include <glib/gi18n-lib.h>
+#include <menu-cache.h>
+
+/* support for libmenu-cache 0.4.x */
+#ifndef MENU_CACHE_CHECK_VERSION
+# ifdef HAVE_MENU_CACHE_DIR_LIST_CHILDREN
+#  define MENU_CACHE_CHECK_VERSION(_a,_b,_c) (_a == 0 && _b < 5) /* < 0.5.0 */
+# else
+#  define MENU_CACHE_CHECK_VERSION(_a,_b,_c) 0 /* not even 0.4.0 */
+# endif
+#endif
+
+/* libmenu-cache is multithreaded since 0.4.x */
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+# define RUN_WITH_MENU_CACHE(__func,__data) __func(__data)
+#else
+# define RUN_WITH_MENU_CACHE(__func,__data) fm_run_in_default_main_context(__func,__data)
+#endif
+
+/* beforehand declarations */
+GFile *_fm_vfs_menu_new_for_uri(const char *uri);
+
+
+/* ---- applications.menu manipulations ---- */
+typedef struct _FmMenuMenuTree          FmMenuMenuTree;
+
+struct _FmMenuMenuTree
+{
+    FmXmlFile *menu; /* composite tree to analyze */
+    char *file_path; /* current file */
+    GCancellable *cancellable;
+    gint line, pos; /* we remember position in deepest file */
+};
+
+G_LOCK_DEFINE_STATIC(menuTree); /* locks all .menu file access data below */
+static FmXmlFileTag menuTag_Menu = 0; /* tags that are supported */
+static FmXmlFileTag menuTag_Include = 0;
+static FmXmlFileTag menuTag_Exclude = 0;
+static FmXmlFileTag menuTag_Filename = 0;
+static FmXmlFileTag menuTag_Category = 0;
+static FmXmlFileTag menuTag_MergeFile = 0;
+static FmXmlFileTag menuTag_Directory = 0;
+static FmXmlFileTag menuTag_Name = 0;
+static FmXmlFileTag menuTag_Deleted = 0;
+static FmXmlFileTag menuTag_NotDeleted = 0;
+
+/* this handler does nothing, used just to remember its id */
+static gboolean _menu_xml_handler_pass(FmXmlFileItem *item, GList *children,
+                                       char * const *attribute_names,
+                                       char * const *attribute_values,
+                                       guint n_attributes, gint line, gint pos,
+                                       GError **error, gpointer user_data)
+{
+    FmMenuMenuTree *data = user_data;
+    return !g_cancellable_set_error_if_cancelled(data->cancellable, error);
+}
+
+/* FIXME: handle <Move><Old>...</Old><New>...</New></Move> */
+
+static inline const char *_get_menu_name(FmXmlFileItem *item)
+{
+    if (fm_xml_file_item_get_tag(item) != menuTag_Menu) /* skip not menu */
+        return NULL;
+    item = fm_xml_file_item_find_child(item, menuTag_Name);
+    if (item == NULL) /* no Name tag? */
+        return NULL;
+    item = fm_xml_file_item_find_child(item, FM_XML_FILE_TEXT);
+    if (item == NULL) /* empty Name tag? */
+        return NULL;
+    return fm_xml_file_item_get_data(item, NULL);
+}
+
+static FmXmlFileItem *_find_in_children(GList *list, const char *path)
+{
+    const char *ptr;
+    char *_ptr;
+
+    if (list == NULL)
+        return NULL;
+    g_debug("menu tree: searching for '%s'", path);
+    ptr = strchr(path, '/');
+    if (ptr == NULL)
+    {
+        ptr = path;
+        path = _ptr = NULL;
+    }
+    else
+    {
+        _ptr = g_strndup(path, ptr - path);
+        path = ptr + 1;
+        ptr = _ptr;
+    }
+    while (list)
+    {
+        const char *elem_name = _get_menu_name(list->data);
+        /* g_debug("got child %d: %s", fm_xml_file_item_get_tag(list->data), elem_name); */
+        if (g_strcmp0(elem_name, ptr) == 0)
+            break;
+        else
+            list = list->next;
+    }
+    g_free(_ptr);
+    if (list && path)
+    {
+        FmXmlFileItem *item;
+
+        list = fm_xml_file_item_get_children(list->data);
+        item = _find_in_children(list, path);
+        g_list_free(list);
+        return item;
+    }
+    return list ? list->data : NULL;
+}
+
+/* returns only <Menu> child */
+static FmXmlFileItem *_set_default_contents(FmXmlFile *file, const char *basename)
+{
+    FmXmlFileItem *item, *child;
+    char *path;
+
+    /* set DTD */
+    fm_xml_file_set_dtd(file,
+                        "Menu PUBLIC '-//freedesktop//DTD Menu 1.0//EN'\n"
+                        " 'http://www.freedesktop.org/standards/menu-spec/menu-1.0.dtd'",
+                        NULL);
+    /* set content:
+        <Menu>
+            <Name>Applications</Name>
+            <MergeFile type='parent'>/etc/xdg/menus/%s</MergeFile>
+        </Menu> */
+    item = fm_xml_file_item_new(menuTag_Menu);
+    fm_xml_file_insert_first(file, item);
+    child = fm_xml_file_item_new(menuTag_Name);
+    fm_xml_file_item_append_text(child, "Applications", -1, FALSE);
+    fm_xml_file_item_append_child(item, child);
+    child = fm_xml_file_item_new(menuTag_MergeFile);
+    fm_xml_file_item_set_attribute(child, "type", "parent");
+    /* FIXME: what is correct way to handle this? is it required at all? */
+    path = g_strdup_printf("/etc/xdg/menus/%s", basename);
+    fm_xml_file_item_append_text(child, path, -1, FALSE);
+    g_free(path);
+    fm_xml_file_item_append_child(item, child);
+    return item;
+    /* FIXME: can errors happen above? */
+}
+
+/* tries to create <Menu>... path in children list and returns <Menu> for it */
+static FmXmlFileItem *_create_path_in_tree(FmXmlFileItem *parent, const char *path)
+{
+    const char *ptr;
+    char *_ptr;
+    GList *list, *l;
+    FmXmlFileItem *item, *name;
+
+    if (path == NULL)
+        return NULL;
+    list = fm_xml_file_item_get_children(parent);
+    /* g_debug("menu tree: creating '%s'", path); */
+    ptr = strchr(path, '/');
+    if (ptr == NULL)
+    {
+        ptr = path;
+        path = _ptr = NULL;
+    }
+    else
+    {
+        _ptr = g_strndup(path, ptr - path);
+        path = ptr + 1;
+        ptr = _ptr;
+    }
+    for (l = list; l; l = l->next)
+    {
+        const char *elem_name = _get_menu_name(l->data);
+        /* g_debug("got child %d: %s", fm_xml_file_item_get_tag(list->data), elem_name); */
+        if (g_strcmp0(elem_name, ptr) == 0)
+            break;
+    }
+    if (l) /* subpath already exists */
+    {
+        item = l->data;
+        g_list_free(list);
+        g_free(_ptr);
+        return _create_path_in_tree(item, path);
+    }
+    g_list_free(list);
+    /* create subtag <Name> */
+    name = fm_xml_file_item_new(menuTag_Name);
+    fm_xml_file_item_append_text(name, ptr, -1, FALSE);
+    g_free(_ptr);
+    /* create <Menu> and insert it */
+    item = fm_xml_file_item_new(menuTag_Menu);
+    if (!fm_xml_file_item_append_child(parent, item) ||
+        !fm_xml_file_item_append_child(item, name))
+    {
+        /* FIXME: it cannot fail on newly created items! */
+        fm_xml_file_item_destroy(name);
+        fm_xml_file_item_destroy(item);
+        return NULL;
+    }
+    /* path is NULL if it is a final subpath */
+    return path ? _create_path_in_tree(item, path) : item;
+}
+
+/* locks menuTree, sets fields in data, sets gf
+   returns "Applications" menu on success and NULL on failure */
+static FmXmlFileItem *_prepare_contents(FmMenuMenuTree *data, GCancellable *cancellable,
+                                        GError **error, GFile **gf)
+{
+    const char *xdg_menu_prefix;
+    char *contents;
+    gsize len;
+    GList *xml = NULL;
+    FmXmlFileItem *apps;
+    gboolean ok;
+
+    /* do it in compatibility with lxpanel */
+    xdg_menu_prefix = g_getenv("XDG_MENU_PREFIX");
+    contents = g_strdup_printf("%sapplications.menu",
+                               xdg_menu_prefix ? xdg_menu_prefix : "lxde-");
+    data->file_path = g_build_filename(g_get_user_config_dir(), "menus",
+                                       contents, NULL);
+    *gf = g_file_new_for_path(data->file_path);
+    data->menu = fm_xml_file_new(NULL);
+    data->line = data->pos = -1;
+    data->cancellable = cancellable;
+    G_LOCK(menuTree);
+    /* set tags, ignore errors */
+    menuTag_Menu = fm_xml_file_set_handler(data->menu, "Menu",
+                                           &_menu_xml_handler_pass, FALSE, NULL);
+    menuTag_Name = fm_xml_file_set_handler(data->menu, "Name",
+                                           &_menu_xml_handler_pass, FALSE, NULL);
+    menuTag_Deleted = fm_xml_file_set_handler(data->menu, "Deleted",
+                                              &_menu_xml_handler_pass, FALSE, NULL);
+    menuTag_NotDeleted = fm_xml_file_set_handler(data->menu, "NotDeleted",
+                                                 &_menu_xml_handler_pass, FALSE, NULL);
+    menuTag_Directory = fm_xml_file_set_handler(data->menu, "Directory",
+                                                &_menu_xml_handler_pass, FALSE, NULL);
+    menuTag_Include = fm_xml_file_set_handler(data->menu, "Include",
+                                              &_menu_xml_handler_pass, FALSE, NULL);
+    menuTag_Exclude = fm_xml_file_set_handler(data->menu, "Exclude",
+                                              &_menu_xml_handler_pass, FALSE, NULL);
+    menuTag_Filename = fm_xml_file_set_handler(data->menu, "Filename",
+                                               &_menu_xml_handler_pass, FALSE, NULL);
+    menuTag_MergeFile = fm_xml_file_set_handler(data->menu, "MergeFile",
+                                                &_menu_xml_handler_pass, FALSE, NULL);
+    menuTag_Category = fm_xml_file_set_handler(data->menu, "Category",
+                                               &_menu_xml_handler_pass, FALSE, NULL);
+    if (!g_file_query_exists(*gf, cancellable))
+    {
+        /* if file doesn't exist then it should be created with default contents */
+        apps = _set_default_contents(data->menu, contents);
+        g_free(contents);
+        return apps;
+    }
+    g_free(contents); /* we used it temporarily */
+    contents = NULL;
+    ok = g_file_load_contents(*gf, cancellable, &contents, &len, NULL, error);
+    if (!ok)
+        return NULL;
+    ok = fm_xml_file_parse_data(data->menu, contents, len, error, data);
+    g_free(contents);
+    if (ok)
+        xml = fm_xml_file_finish_parse(data->menu, error);
+    if (xml == NULL) /* error is set by failed function */
+    {
+        if (data->line == -1)
+            data->line = fm_xml_file_get_current_line(data->menu, &data->pos);
+        g_prefix_error(error, _("XML file '%s' error (%d:%d): "), data->file_path,
+                       data->line, data->pos);
+    }
+    else
+    {
+        apps = _find_in_children(xml, "Applications");
+        g_list_free(xml);
+        if (apps)
+            return apps;
+        g_set_error_literal(error, G_FILE_ERROR, G_FILE_ERROR_NOENT,
+                            _("XML file doesn't contain Applications root"));
+    }
+    return NULL;
+}
+
+/* replaces invalid chars in path with minus sign */
+static inline char *_get_pathtag_for_path(const char *path)
+{
+    char *pathtag, *c;
+
+    pathtag = g_strdup(path);
+    for (c = pathtag; *c; c++)
+        if (*c == '/' || *c == '\t' || *c == '\n' || *c == '\r' || *c == ' ')
+            *c = '-';
+    return pathtag;
+}
+
+static gboolean _save_new_menu_file(GFile *gf, FmXmlFile *file,
+                                    GCancellable *cancellable,
+                                    GError **error)
+{
+    gsize len;
+    char *contents = fm_xml_file_to_data(file, &len, error);
+    gboolean result = FALSE;
+
+    if (contents == NULL)
+        return FALSE;
+    /* g_debug("new menu file: %s", contents); */
+    result = g_file_replace_contents(gf, contents, len, NULL, FALSE,
+                                     G_FILE_CREATE_REPLACE_DESTINATION, NULL,
+                                     cancellable, error);
+    g_free(contents);
+    return result;
+}
+
+#if MENU_CACHE_CHECK_VERSION(0, 5, 0)
+/* changes .menu XML file */
+static gboolean _remove_directory(const char *path, GCancellable *cancellable,
+                                  GError **error)
+{
+    GList *xml = NULL, *it;
+    GFile *gf;
+    FmXmlFileItem *apps, *item;
+    FmMenuMenuTree data;
+    gboolean ok = TRUE;
+
+    /* g_debug("deleting menu folder '%s'", path); */
+    /* FIXME: check if there is that path in the XML tree before doing anything */
+    apps = _prepare_contents(&data, cancellable, error, &gf);
+    if (apps == NULL)
+    {
+        /* either failed to load contents or cancelled */
+        ok = FALSE;
+    }
+    else if ((xml = fm_xml_file_item_get_children(apps)) != NULL &&
+             (item = _find_in_children(xml, path)) != NULL)
+    {
+        /* if path is found and has <NotDeleted/> then replace it with <Deleted/> */
+        g_list_free(xml);
+        xml = fm_xml_file_item_get_children(item);
+        for (it = xml; it; it = it->next)
+        {
+            FmXmlFileTag tag = fm_xml_file_item_get_tag(it->data);
+            if (tag == menuTag_Deleted || tag == menuTag_NotDeleted)
+                fm_xml_file_item_destroy(it->data);
+        }
+        goto _add_deleted_tag;
+    }
+    else
+    {
+        /* else create path and add <Deleted/> to it */
+        item = _create_path_in_tree(apps, path);
+        if (item == NULL)
+        {
+            g_set_error(error, G_FILE_ERROR, G_FILE_ERROR_FAILED,
+                        _("Cannot create XML definition for '%s'"), path);
+            ok = FALSE;
+        }
+        else
+        {
+            FmXmlFileItem *item2;
+
+_add_deleted_tag:
+            item2 = fm_xml_file_item_new(menuTag_Deleted);
+            fm_xml_file_item_set_comment(item2, "deleted by LibFM");
+            fm_xml_file_item_append_child(item, item2); /* NOTE: it cannot fail */
+        }
+    }
+    if (ok)
+        ok = _save_new_menu_file(gf, data.menu, cancellable, error);
+    G_UNLOCK(menuTree);
+    g_object_unref(gf);
+    g_object_unref(data.menu);
+    g_free(data.file_path);
+    g_list_free(xml);
+    return ok;
+}
+
+/* changes .menu XML file */
+static gboolean _add_directory(const char *path, GCancellable *cancellable,
+                               GError **error)
+{
+    GList *xml = NULL, *it;
+    GFile *gf;
+    FmXmlFileItem *apps, *item, *child;
+    FmMenuMenuTree data;
+    gboolean ok = TRUE;
+
+    /* g_debug("adding menu folder '%s'", path); */
+    /* FIXME: fail if such Menu Name already not deleted in XML tree */
+    apps = _prepare_contents(&data, cancellable, error, &gf);
+    if (apps == NULL)
+    {
+        /* either failed to load contents or cancelled */
+        ok = FALSE;
+    }
+    else if ((xml = fm_xml_file_item_get_children(apps)) != NULL &&
+             (item = _find_in_children(xml, path)) != NULL)
+    {
+        /* "undelete" the directory: */
+        /* if path is found and has <Deleted/> then replace it with <NotDeleted/> */
+        g_list_free(xml);
+        xml = fm_xml_file_item_get_children(item);
+        ok = FALSE; /* it should be Deleted, otherwise error, see FIXME above */
+        for (it = xml; it; it = it->next)
+        {
+            FmXmlFileTag tag = fm_xml_file_item_get_tag(it->data);
+            if (tag == menuTag_Deleted)
+            {
+                fm_xml_file_item_destroy(it->data);
+                ok = TRUE; /* see FIXME above */
+            }
+            else if (tag == menuTag_NotDeleted)
+            {
+                fm_xml_file_item_destroy(it->data);
+                ok = FALSE; /* see FIXME above */
+            }
+        }
+        if (!ok) /* see FIXME above */
+            g_set_error(error, G_IO_ERROR, G_IO_ERROR_EXISTS,
+                        _("Menu path '%s' already exists"), path);
+        else
+        {
+            child = fm_xml_file_item_new(menuTag_NotDeleted);
+            fm_xml_file_item_set_comment(child, "undeleted by LibFM");
+            fm_xml_file_item_append_child(item, child); /* NOTE: it cannot fail */
+        }
+    }
+    else
+    {
+        /* else create path and add content to it */
+        item = _create_path_in_tree(apps, path);
+        if (item == NULL)
+        {
+            g_set_error(error, G_IO_ERROR, G_IO_ERROR_EXISTS,
+                        _("Cannot create XML definition for '%s'"), path);
+            ok = FALSE;
+        }
+        else
+        {
+            char *pathtag, *dir, *contents;
+            GString *str;
+
+            /* add <NotDeleted/> */
+            child = fm_xml_file_item_new(menuTag_NotDeleted);
+            fm_xml_file_item_append_child(item, child);
+            /* touch .directory file, ignore errors */
+            dir = strrchr(path, '/'); /* use it as a storage for basename */
+            if (dir)
+                dir++;
+            else
+                dir = (char *)path;
+            contents = g_strdup_printf("[" G_KEY_FILE_DESKTOP_GROUP "]\n"
+                                       G_KEY_FILE_DESKTOP_KEY_TYPE "=" G_KEY_FILE_DESKTOP_TYPE_DIRECTORY "\n"
+                                       G_KEY_FILE_DESKTOP_KEY_NAME "=%s", dir);
+            pathtag = _get_pathtag_for_path(path);
+            dir = g_build_filename(g_get_user_data_dir(), "desktop-directories",
+                                   pathtag, NULL);
+            str = g_string_new(dir);
+            g_free(dir);
+            g_string_append(str, ".directory");
+            g_file_set_contents(str->str, contents, -1, NULL);
+            /* FIXME: report errors */
+            g_free(contents);
+            /* add <Directory>.....</Directory> */
+            child = fm_xml_file_item_new(menuTag_Directory);
+            g_string_printf(str, "%s.directory", pathtag);
+            fm_xml_file_item_append_text(child, str->str, str->len, FALSE);
+            fm_xml_file_item_append_child(item, child);
+            /* add <Include><Category>......</Category></Include> */
+            child = fm_xml_file_item_new(menuTag_Include);
+            fm_xml_file_item_append_child(item, child);
+            g_string_printf(str, "X-%s", pathtag);
+            g_free(pathtag);
+            item = fm_xml_file_item_new(menuTag_Category); /* reuse item var. */
+            fm_xml_file_item_append_text(item, str->str, str->len, FALSE);
+            fm_xml_file_item_append_child(child, item);
+            g_string_free(str, TRUE);
+            /* ignoring errors since new created items cannot fail on append */
+        }
+    }
+    if (ok)
+        ok = _save_new_menu_file(gf, data.menu, cancellable, error);
+    G_UNLOCK(menuTree);
+    g_object_unref(gf);
+    g_object_unref(data.menu);
+    g_free(data.file_path);
+    g_list_free(xml);
+    return ok;
+}
+#endif
+
+/* changes .menu XML file */
+static gboolean _add_application(const char *path, GCancellable *cancellable,
+                                 GError **error)
+{
+    const char *id;
+    char *dir;
+    GList *xml = NULL, *it;
+    GFile *gf;
+    FmXmlFileItem *apps, *item, *child;
+    FmMenuMenuTree data;
+    gboolean ok = TRUE;
+
+    id = strrchr(path, '/');
+    if (id == NULL)
+    {
+        dir = NULL;
+        id = path;
+    }
+    else
+    {
+        dir = g_strndup(path, id - path);
+        id++;
+    }
+    apps = _prepare_contents(&data, cancellable, error, &gf);
+    if (apps == NULL)
+    {
+        /* either failed to load contents or cancelled */
+        ok = FALSE;
+    }
+    else if (dir == NULL) /* adding to root, use apps as target */
+    {
+        item = apps;
+        goto _set;
+    }
+    else if ((xml = fm_xml_file_item_get_children(apps)) != NULL &&
+             (item = _find_in_children(xml, dir)) != NULL)
+    {
+        /* already found that path */
+        goto _set;
+    }
+    else
+    {
+        /* else create path and add content to it */
+        item = _create_path_in_tree(apps, dir);
+        if (item == NULL)
+        {
+            g_set_error(error, G_IO_ERROR, G_IO_ERROR_EXISTS,
+                        _("Cannot create XML definition for '%s'"), path);
+            ok = FALSE;
+        }
+        else
+        {
+_set:
+            g_list_free(xml);
+            xml = fm_xml_file_item_get_children(item);
+            ok = FALSE; /* check if Include is already there */
+            /* remove <Exclude><Filename>id</Filename></Exclude> */
+            for (it = xml; it; it = it->next)
+            {
+                FmXmlFileTag tag = fm_xml_file_item_get_tag(it->data);
+                if (tag == menuTag_Exclude)
+                {
+                    /* get Filename tag */
+                    child = fm_xml_file_item_find_child(it->data, menuTag_Filename);
+                    if (child == NULL)
+                        continue;
+                    /* get contents of the tag */
+                    child = fm_xml_file_item_find_child(child, FM_XML_FILE_TEXT);
+                    if (child == NULL)
+                        continue;
+                    if (strcmp(fm_xml_file_item_get_data(child, NULL), id) != 0)
+                        continue;
+                    fm_xml_file_item_destroy(it->data);
+                    /* it was excluded before so removing exclude will add it */
+                    ok = TRUE;
+                }
+                else if (!ok && tag == menuTag_Include)
+                {
+                    /* get Filename tag */
+                    child = fm_xml_file_item_find_child(it->data, menuTag_Filename);
+                    if (child == NULL)
+                        continue;
+                    /* get contents of the tag */
+                    child = fm_xml_file_item_find_child(child, FM_XML_FILE_TEXT);
+                    if (child == NULL)
+                        continue;
+                    if (strcmp(fm_xml_file_item_get_data(child, NULL), id) == 0)
+                        ok = TRUE; /* found! */
+                }
+            }
+            if (!ok)
+            {
+                /* add <Include><Filename>id</Filename></Include> */
+                child = fm_xml_file_item_new(menuTag_Include);
+                fm_xml_file_item_set_comment(child, "added by LibFM");
+                fm_xml_file_item_append_child(item, child);
+                item = fm_xml_file_item_new(menuTag_Filename);
+                fm_xml_file_item_append_text(item, id, -1, FALSE);
+                fm_xml_file_item_append_child(child, item);
+                ok = TRUE;
+            }
+        }
+    }
+    if (ok)
+        ok = _save_new_menu_file(gf, data.menu, cancellable, error);
+    G_UNLOCK(menuTree);
+    g_object_unref(gf);
+    g_object_unref(data.menu);
+    g_free(data.file_path);
+    g_list_free(xml);
+    g_free(dir);
+    return ok;
+}
+
+/* changes .menu XML file */
+static gboolean _remove_application(const char *path, GCancellable *cancellable,
+                                    GError **error)
+{
+    const char *id;
+    char *dir;
+    GList *xml = NULL, *it;
+    GFile *gf;
+    FmXmlFileItem *apps, *item, *child;
+    FmMenuMenuTree data;
+    gboolean ok = TRUE;
+
+    id = strrchr(path, '/');
+    if (id == NULL)
+    {
+        dir = NULL;
+        id = path;
+    }
+    else
+    {
+        dir = g_strndup(path, id - path);
+        id++;
+    }
+    apps = _prepare_contents(&data, cancellable, error, &gf);
+    if (apps == NULL)
+    {
+        /* either failed to load contents or cancelled */
+        ok = FALSE;
+    }
+    else if (dir == NULL) /* removing from root, use apps as target */
+    {
+        item = apps;
+        goto _set;
+    }
+    else if ((xml = fm_xml_file_item_get_children(apps)) != NULL &&
+             (item = _find_in_children(xml, dir)) != NULL)
+    {
+        /* already found that path */
+        goto _set;
+    }
+    else
+    {
+        /* else create path and add content to it */
+        item = _create_path_in_tree(apps, dir);
+        if (item == NULL)
+        {
+            g_set_error(error, G_IO_ERROR, G_IO_ERROR_EXISTS,
+                        _("Cannot create XML definition for '%s'"), path);
+            ok = FALSE;
+        }
+        else
+        {
+_set:
+            g_list_free(xml);
+            xml = fm_xml_file_item_get_children(item);
+            ok = FALSE; /* check if Include is already there */
+            /* remove <Include><Filename>id</Filename></Include> */
+            for (it = xml; it; it = it->next)
+            {
+                FmXmlFileTag tag = fm_xml_file_item_get_tag(it->data);
+                if (tag == menuTag_Include)
+                {
+                    /* get Filename tag */
+                    child = fm_xml_file_item_find_child(it->data, menuTag_Filename);
+                    if (child == NULL)
+                        continue;
+                    /* get contents of the tag */
+                    child = fm_xml_file_item_find_child(child, FM_XML_FILE_TEXT);
+                    if (child == NULL)
+                        continue;
+                    if (strcmp(fm_xml_file_item_get_data(child, NULL), id) != 0)
+                        continue;
+                    fm_xml_file_item_destroy(it->data);
+                    /* it was included before so removing include will remove it */
+                    ok = TRUE;
+                }
+                else if (!ok && tag == menuTag_Exclude)
+                {
+                    /* get Filename tag */
+                    child = fm_xml_file_item_find_child(it->data, menuTag_Filename);
+                    if (child == NULL)
+                        continue;
+                    /* get contents of the tag */
+                    child = fm_xml_file_item_find_child(child, FM_XML_FILE_TEXT);
+                    if (child == NULL)
+                        continue;
+                    if (strcmp(fm_xml_file_item_get_data(child, NULL), id) == 0)
+                        ok = TRUE; /* found! */
+                }
+            }
+            if (!ok)
+            {
+                /* add <Exclude><Filename>id</Filename></Exclude> */
+                child = fm_xml_file_item_new(menuTag_Exclude);
+                fm_xml_file_item_set_comment(child, "deleted by LibFM");
+                fm_xml_file_item_append_child(item, child);
+                item = fm_xml_file_item_new(menuTag_Filename);
+                fm_xml_file_item_append_text(item, id, -1, FALSE);
+                fm_xml_file_item_append_child(child, item);
+                ok = TRUE;
+            }
+        }
+    }
+    if (ok)
+        ok = _save_new_menu_file(gf, data.menu, cancellable, error);
+    G_UNLOCK(menuTree);
+    g_object_unref(gf);
+    g_object_unref(data.menu);
+    g_free(data.file_path);
+    g_list_free(xml);
+    g_free(dir);
+    return ok;
+}
+
+
+/* ---- FmMenuVFile class ---- */
+#define FM_TYPE_MENU_VFILE             (fm_vfs_menu_file_get_type())
+#define FM_MENU_VFILE(o)               (G_TYPE_CHECK_INSTANCE_CAST((o), \
+                                        FM_TYPE_MENU_VFILE, FmMenuVFile))
+
+typedef struct _FmMenuVFile             FmMenuVFile;
+typedef struct _FmMenuVFileClass        FmMenuVFileClass;
+
+static GType fm_vfs_menu_file_get_type  (void);
+
+struct _FmMenuVFile
+{
+    GObject parent_object;
+
+    char *path;
+};
+
+struct _FmMenuVFileClass
+{
+  GObjectClass parent_class;
+};
+
+static void fm_menu_g_file_init(GFileIface *iface);
+static void fm_menu_fm_file_init(FmFileInterface *iface);
+
+G_DEFINE_TYPE_WITH_CODE(FmMenuVFile, fm_vfs_menu_file, G_TYPE_OBJECT,
+                        G_IMPLEMENT_INTERFACE(G_TYPE_FILE, fm_menu_g_file_init)
+                        G_IMPLEMENT_INTERFACE(FM_TYPE_FILE, fm_menu_fm_file_init))
+
+static void fm_vfs_menu_file_finalize(GObject *object)
+{
+    FmMenuVFile *item = FM_MENU_VFILE(object);
+
+    g_free(item->path);
+
+    G_OBJECT_CLASS(fm_vfs_menu_file_parent_class)->finalize(object);
+}
+
+static void fm_vfs_menu_file_class_init(FmMenuVFileClass *klass)
+{
+    GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+
+    gobject_class->finalize = fm_vfs_menu_file_finalize;
+}
+
+static void fm_vfs_menu_file_init(FmMenuVFile *item)
+{
+    /* nothing */
+}
+
+static FmMenuVFile *_fm_menu_vfile_new(void)
+{
+    return (FmMenuVFile*)g_object_new(FM_TYPE_MENU_VFILE, NULL);
+}
+
+
+/* ---- menu enumerator class ---- */
+#define FM_TYPE_VFS_MENU_ENUMERATOR        (fm_vfs_menu_enumerator_get_type())
+#define FM_VFS_MENU_ENUMERATOR(o)          (G_TYPE_CHECK_INSTANCE_CAST((o), \
+                            FM_TYPE_VFS_MENU_ENUMERATOR, FmVfsMenuEnumerator))
+
+typedef struct _FmVfsMenuEnumerator         FmVfsMenuEnumerator;
+typedef struct _FmVfsMenuEnumeratorClass    FmVfsMenuEnumeratorClass;
+
+struct _FmVfsMenuEnumerator
+{
+    GFileEnumerator parent;
+
+    MenuCache *mc;
+    GSList *child;
+    guint32 de_flag;
+};
+
+struct _FmVfsMenuEnumeratorClass
+{
+    GFileEnumeratorClass parent_class;
+};
+
+static GType fm_vfs_menu_enumerator_get_type   (void);
+
+G_DEFINE_TYPE(FmVfsMenuEnumerator, fm_vfs_menu_enumerator, G_TYPE_FILE_ENUMERATOR)
+
+static void _fm_vfs_menu_enumerator_dispose(GObject *object)
+{
+    FmVfsMenuEnumerator *enu = FM_VFS_MENU_ENUMERATOR(object);
+
+    if(enu->mc)
+    {
+        menu_cache_unref(enu->mc);
+        enu->mc = NULL;
+    }
+
+    G_OBJECT_CLASS(fm_vfs_menu_enumerator_parent_class)->dispose(object);
+}
+
+GIcon* _fm_icon_from_name(const char* name); /* defined in core/iconinfo.cpp */
+
+static GFileInfo *_g_file_info_from_menu_cache_item(MenuCacheItem *item,
+                                                    /* GFileAttributeMatcher *attribute_matcher, */
+                                                    guint32 de_flag)
+{
+    GFileInfo *fileinfo = g_file_info_new();
+    const char *icon_name;
+    GIcon* icon;
+
+    /* FIXME: use g_uri_escape_string() for item name */
+    g_file_info_set_name(fileinfo, menu_cache_item_get_id(item));
+    if(menu_cache_item_get_name(item) != NULL)
+        g_file_info_set_display_name(fileinfo, menu_cache_item_get_name(item));
+
+    /* the setup below was in fm_file_info_set_from_menu_cache_item()
+       so this setup makes latter API deprecated */
+    icon_name = menu_cache_item_get_icon(item);
+    if(icon_name)
+    {
+        icon = _fm_icon_from_name(icon_name);
+        if(G_LIKELY(icon))
+        {
+            g_file_info_set_icon(fileinfo, icon);
+            g_object_unref(icon);
+        }
+    }
+    if(menu_cache_item_get_type(item) == MENU_CACHE_TYPE_DIR)
+    {
+        g_file_info_set_file_type(fileinfo, G_FILE_TYPE_DIRECTORY);
+#if MENU_CACHE_CHECK_VERSION(0, 5, 0)
+        g_file_info_set_is_hidden(fileinfo,
+                                  !menu_cache_dir_is_visible(MENU_CACHE_DIR(item)));
+#else
+        g_file_info_set_is_hidden(fileinfo, FALSE);
+#endif
+    }
+    else /* MENU_CACHE_TYPE_APP */
+    {
+        char *path = menu_cache_item_get_file_path(item);
+        g_file_info_set_file_type(fileinfo, G_FILE_TYPE_SHORTCUT);
+        g_file_info_set_attribute_string(fileinfo,
+                                         G_FILE_ATTRIBUTE_STANDARD_TARGET_URI,
+                                         path);
+        g_free(path);
+        g_file_info_set_content_type(fileinfo, "application/x-desktop");
+        g_file_info_set_is_hidden(fileinfo,
+                                  !menu_cache_app_get_is_visible(MENU_CACHE_APP(item),
+                                                                 de_flag));
+    }
+// FIXME: use attribute_matcher and set G_FILE_ATTRIBUTE_ACCESS_CAN_{WRITE,READ,EXECUTE,DELETE}
+    g_file_info_set_attribute_string(fileinfo, G_FILE_ATTRIBUTE_ID_FILESYSTEM,
+                                     "menu-Applications");
+    g_file_info_set_attribute_boolean(fileinfo,
+                                      G_FILE_ATTRIBUTE_ACCESS_CAN_RENAME, TRUE);
+    g_file_info_set_attribute_boolean(fileinfo,
+                                      G_FILE_ATTRIBUTE_ACCESS_CAN_TRASH, FALSE);
+    return fileinfo;
+}
+
+typedef struct
+{
+    union
+    {
+        FmVfsMenuEnumerator *enumerator;
+        const char *path_str;
+    };
+    union
+    {
+        FmMenuVFile *destination;
+//        const char *attributes;
+        const char *display_name;
+        GFileInfo *info;
+    };
+//    GFileQueryInfoFlags flags;
+    union
+    {
+        GCancellable *cancellable;
+        GFile *file;
+    };
+    GError **error;
+    gpointer result;
+} FmVfsMenuMainThreadData;
+
+static gboolean _fm_vfs_menu_enumerator_next_file_real(gpointer data)
+{
+    FmVfsMenuMainThreadData *init = data;
+    FmVfsMenuEnumerator *enu = init->enumerator;
+    GSList *child = enu->child;
+    MenuCacheItem *item;
+
+    init->result = NULL;
+
+    if(child == NULL)
+        goto done;
+
+    for(; child; child = child->next)
+    {
+        if(g_cancellable_set_error_if_cancelled(init->cancellable, init->error))
+            break;
+        item = MENU_CACHE_ITEM(child->data);
+        if(!item || menu_cache_item_get_type(item) == MENU_CACHE_TYPE_SEP ||
+           menu_cache_item_get_type(item) == MENU_CACHE_TYPE_NONE)
+            continue;
+#if 0
+        /* also hide menu items which should be hidden in current DE. */
+        if(menu_cache_item_get_type(item) == MENU_CACHE_TYPE_APP
+           && !menu_cache_app_get_is_visible(MENU_CACHE_APP(item), enu->de_flag))
+            continue;
+#endif
+
+        init->result = _g_file_info_from_menu_cache_item(item, enu->de_flag);
+        child = child->next;
+        break;
+    }
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+    while(enu->child != child) /* free skipped/used elements */
+    {
+        GSList *ch = enu->child;
+        enu->child = ch->next;
+        menu_cache_item_unref(ch->data);
+        g_slist_free_1(ch);
+    }
+#else
+    enu->child = child;
+#endif
+
+done:
+    return FALSE;
+}
+
+static GFileInfo *_fm_vfs_menu_enumerator_next_file(GFileEnumerator *enumerator,
+                                                    GCancellable *cancellable,
+                                                    GError **error)
+{
+    FmVfsMenuMainThreadData init;
+
+    init.enumerator = FM_VFS_MENU_ENUMERATOR(enumerator);
+    init.cancellable = cancellable;
+    init.error = error;
+    RUN_WITH_MENU_CACHE(_fm_vfs_menu_enumerator_next_file_real, &init);
+    return init.result;
+}
+
+static gboolean _fm_vfs_menu_enumerator_close(GFileEnumerator *enumerator,
+                                              GCancellable *cancellable,
+                                              GError **error)
+{
+    FmVfsMenuEnumerator *enu = FM_VFS_MENU_ENUMERATOR(enumerator);
+
+    if(enu->mc)
+    {
+        menu_cache_unref(enu->mc);
+        enu->mc = NULL;
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+        g_slist_free_full(enu->child, (GDestroyNotify)menu_cache_item_unref);
+#endif
+        enu->child = NULL;
+    }
+    return TRUE;
+}
+
+static void fm_vfs_menu_enumerator_class_init(FmVfsMenuEnumeratorClass *klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS(klass);
+  GFileEnumeratorClass *enumerator_class = G_FILE_ENUMERATOR_CLASS(klass);
+
+  gobject_class->dispose = _fm_vfs_menu_enumerator_dispose;
+
+  enumerator_class->next_file = _fm_vfs_menu_enumerator_next_file;
+  enumerator_class->close_fn = _fm_vfs_menu_enumerator_close;
+}
+
+static void fm_vfs_menu_enumerator_init(FmVfsMenuEnumerator *enumerator)
+{
+    /* nothing */
+}
+
+static MenuCacheItem *_vfile_path_to_menu_cache_item(MenuCache* mc, const char *path)
+{
+    MenuCacheItem *dir;
+    char *unescaped, *tmp = NULL;
+
+    unescaped = g_uri_unescape_string(path, NULL);
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+    dir = MENU_CACHE_ITEM(menu_cache_dup_root_dir(mc));
+#else
+    dir = MENU_CACHE_ITEM(menu_cache_get_root_dir(mc));
+#endif
+    if(dir)
+    {
+#if !MENU_CACHE_CHECK_VERSION(0, 5, 0)
+        char *id;
+#if !MENU_CACHE_CHECK_VERSION(0, 4, 0)
+        GSList *child;
+#endif
+#endif
+        tmp = g_strconcat("/", menu_cache_item_get_id(dir), "/", unescaped, NULL);
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+        menu_cache_item_unref(dir);
+        dir = menu_cache_item_from_path(mc, tmp);
+#else
+        /* access not dir is a bit tricky */
+        id = strrchr(tmp, '/');
+        *id++ = '\0';
+        dir = MENU_CACHE_ITEM(menu_cache_get_dir_from_path(mc, tmp));
+        child = menu_cache_dir_get_children(MENU_CACHE_DIR(dir));
+        dir = NULL;
+        while (child)
+        {
+            if (g_strcmp0(id, menu_cache_item_get_id(child->data)) == 0)
+            {
+                dir = child->data;
+                break;
+            }
+            child = child->next;
+        }
+#endif
+#if !MENU_CACHE_CHECK_VERSION(0, 5, 0)
+        /* The menu-cache is buggy and returns parent for invalid path
+           instead of failure so we check what we got here.
+           Unfortunately we cannot detect if requested name is the same
+           as its parent and menu-cache returned the parent. */
+        id = strrchr(unescaped, '/');
+        if(id)
+            id++;
+        else
+            id = unescaped;
+        if(dir != NULL && strcmp(id, menu_cache_item_get_id(dir)) != 0)
+            dir = NULL;
+#endif
+    }
+    g_free(unescaped);
+    g_free(tmp);
+    /* NOTE: returned value is referenced for >= 0.4.0 only */
+    return dir;
+}
+
+static MenuCache *_get_menu_cache(GError **error)
+{
+    MenuCache *mc;
+    static gboolean environment_tested = FALSE;
+    static gboolean requires_prefix = FALSE;
+
+    /* do it in compatibility with lxpanel */
+    if(!environment_tested)
+    {
+        requires_prefix = (g_getenv("XDG_MENU_PREFIX") == NULL);
+        environment_tested = TRUE;
+    }
+#if MENU_CACHE_CHECK_VERSION(0, 5, 0)
+    mc = menu_cache_lookup_sync(requires_prefix ? "lxde-applications.menu+hidden" : "applications.menu+hidden");
+#else
+    mc = menu_cache_lookup_sync(requires_prefix ? "lxde-applications.menu" : "applications.menu");
+#endif
+    /* FIXME: may be it is reasonable to set XDG_MENU_PREFIX ? */
+
+    if(mc == NULL) /* initialization failed */
+        g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                            _("Menu cache error"));
+    return mc;
+}
+
+static gboolean _fm_vfs_menu_enumerator_new_real(gpointer data)
+{
+    FmVfsMenuMainThreadData *init = data;
+    FmVfsMenuEnumerator *enumerator;
+    MenuCache* mc;
+    const char *de_name;
+    MenuCacheItem *dir;
+
+    mc = _get_menu_cache(init->error);
+
+    if(mc == NULL) /* initialization failed */
+        return FALSE;
+
+    enumerator = g_object_new(FM_TYPE_VFS_MENU_ENUMERATOR, "container",
+                              init->file, NULL);
+    enumerator->mc = mc;
+    de_name = g_getenv("XDG_CURRENT_DESKTOP");
+
+    if(de_name)
+        enumerator->de_flag = menu_cache_get_desktop_env_flag(mc, de_name);
+    else
+        enumerator->de_flag = (guint32)-1;
+
+    /* the menu should be loaded now */
+    if(init->path_str)
+        dir = _vfile_path_to_menu_cache_item(mc, init->path_str);
+    else
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+        dir = MENU_CACHE_ITEM(menu_cache_dup_root_dir(mc));
+#else
+        dir = MENU_CACHE_ITEM(menu_cache_get_root_dir(mc));
+#endif
+    if(dir)
+    {
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+        enumerator->child = menu_cache_dir_list_children(MENU_CACHE_DIR(dir));
+        menu_cache_item_unref(dir);
+#else
+        enumerator->child = menu_cache_dir_get_children(MENU_CACHE_DIR(dir));
+#endif
+    }
+    /* FIXME: do something with attributes and flags */
+
+    init->result = enumerator;
+    return FALSE;
+}
+
+static GFileEnumerator *_fm_vfs_menu_enumerator_new(GFile *file,
+                                                    const char *path_str,
+                                                    const char *attributes,
+                                                    GFileQueryInfoFlags flags,
+                                                    GError **error)
+{
+    FmVfsMenuMainThreadData enu;
+
+    enu.path_str = path_str;
+//    enu.attributes = attributes;
+//    enu.flags = flags;
+    enu.file = file;
+    enu.error = error;
+    enu.result = NULL;
+    RUN_WITH_MENU_CACHE(_fm_vfs_menu_enumerator_new_real, &enu);
+    return enu.result;
+}
+
+
+/* ---- GFile implementation ---- */
+static GFileAttributeInfoList *_fm_vfs_menu_settable_attributes = NULL;
+
+#define ERROR_UNSUPPORTED(err) g_set_error_literal(err, G_IO_ERROR, \
+                        G_IO_ERROR_NOT_SUPPORTED, _("Operation not supported"))
+
+static GFile *_fm_vfs_menu_dup(GFile *file)
+{
+    FmMenuVFile *item, *new_item;
+
+    item = FM_MENU_VFILE(file);
+    new_item = _fm_menu_vfile_new();
+    if(item->path)
+        new_item->path = g_strdup(item->path);
+    return (GFile*)new_item;
+}
+
+static guint _fm_vfs_menu_hash(GFile *file)
+{
+    return g_str_hash(FM_MENU_VFILE(file)->path ? FM_MENU_VFILE(file)->path : "/");
+}
+
+static gboolean _fm_vfs_menu_equal(GFile *file1, GFile *file2)
+{
+    char *path1 = FM_MENU_VFILE(file1)->path;
+    char *path2 = FM_MENU_VFILE(file2)->path;
+
+    return g_strcmp0(path1, path2) == 0;
+}
+
+static gboolean _fm_vfs_menu_is_native(GFile *file)
+{
+    return FALSE;
+}
+
+static gboolean _fm_vfs_menu_has_uri_scheme(GFile *file, const char *uri_scheme)
+{
+    return g_ascii_strcasecmp(uri_scheme, "menu") == 0;
+}
+
+static char *_fm_vfs_menu_get_uri_scheme(GFile *file)
+{
+    return g_strdup("menu");
+}
+
+static char *_fm_vfs_menu_get_basename(GFile *file)
+{
+    /* g_debug("_fm_vfs_menu_get_basename %s", FM_MENU_VFILE(file)->path); */
+    if(FM_MENU_VFILE(file)->path == NULL)
+        return g_strdup("/");
+    return g_path_get_basename(FM_MENU_VFILE(file)->path);
+}
+
+static char *_fm_vfs_menu_get_path(GFile *file)
+{
+    return NULL;
+}
+
+static char *_fm_vfs_menu_get_uri(GFile *file)
+{
+    return g_strconcat("menu://applications/", FM_MENU_VFILE(file)->path, NULL);
+}
+
+static char *_fm_vfs_menu_get_parse_name(GFile *file)
+{
+    char *unescaped, *path;
+
+    /* g_debug("_fm_vfs_menu_get_parse_name %s", FM_MENU_VFILE(file)->path); */
+    unescaped = g_uri_unescape_string(FM_MENU_VFILE(file)->path, NULL);
+    path = g_strconcat("menu://applications/", unescaped, NULL);
+    g_free(unescaped);
+    return path;
+}
+
+static GFile *_fm_vfs_menu_get_parent(GFile *file)
+{
+    char *path = FM_MENU_VFILE(file)->path;
+    char *dirname;
+    GFile *parent;
+
+    /* g_debug("_fm_vfs_menu_get_parent %s", path); */
+    if(path)
+    {
+        dirname = g_path_get_dirname(path);
+        if(strcmp(dirname, ".") == 0)
+        {
+            g_free(dirname);
+            path = NULL;
+        }
+        else
+            path = dirname;
+    }
+    parent = _fm_vfs_menu_new_for_uri(path);
+    if(path)
+        g_free(path);
+    return parent;
+}
+
+/* this function is taken from GLocalFile implementation */
+static const char *match_prefix (const char *path, const char *prefix)
+{
+  int prefix_len;
+
+  prefix_len = strlen (prefix);
+  if (strncmp (path, prefix, prefix_len) != 0)
+    return NULL;
+
+  if (prefix_len > 0 && (prefix[prefix_len-1]) == '/')
+    prefix_len--;
+
+  return path + prefix_len;
+}
+
+static gboolean _fm_vfs_menu_prefix_matches(GFile *prefix, GFile *file)
+{
+    const char *path = FM_MENU_VFILE(file)->path;
+    const char *pp = FM_MENU_VFILE(prefix)->path;
+    const char *remainder;
+
+    if(pp == NULL)
+        return TRUE;
+    if(path == NULL)
+        return FALSE;
+    remainder = match_prefix(path, pp);
+    if(remainder != NULL && *remainder == '/')
+        return TRUE;
+    return FALSE;
+}
+
+static char *_fm_vfs_menu_get_relative_path(GFile *parent, GFile *descendant)
+{
+    const char *path = FM_MENU_VFILE(descendant)->path;
+    const char *pp = FM_MENU_VFILE(parent)->path;
+    const char *remainder;
+
+    if(pp == NULL)
+        return g_strdup(path);
+    if(path == NULL)
+        return NULL;
+    remainder = match_prefix(path, pp);
+    if(remainder != NULL && *remainder == '/')
+        return g_uri_unescape_string(&remainder[1], NULL);
+    return NULL;
+}
+
+static GFile *_fm_vfs_menu_resolve_relative_path(GFile *file, const char *relative_path)
+{
+    const char *path = FM_MENU_VFILE(file)->path;
+    FmMenuVFile *new_item = _fm_menu_vfile_new();
+
+    /* g_debug("_fm_vfs_menu_resolve_relative_path %s %s", path, relative_path); */
+    /* FIXME: handle if relative_path is invalid */
+    if(relative_path == NULL || *relative_path == '\0')
+        new_item->path = g_strdup(path);
+    else if(path == NULL)
+        new_item->path = g_strdup(relative_path);
+    else
+    {
+        /* relative_path is the most probably unescaped string (at least GFVS
+           works such way) so we have to escape invalid chars here. */
+        char *escaped = g_uri_escape_string(relative_path,
+                                            G_URI_RESERVED_CHARS_ALLOWED_IN_PATH,
+                                            TRUE);
+        new_item->path = g_strconcat(path, "/", relative_path, NULL);
+        g_free(escaped);
+    }
+    return (GFile*)new_item;
+}
+
+static gboolean _fm_vfs_menu_get_child_for_display_name_real(gpointer data)
+{
+    FmVfsMenuMainThreadData *init = data;
+    MenuCache *mc;
+    MenuCacheItem *dir;
+    gboolean is_invalid = FALSE;
+
+    init->result = NULL;
+    mc = _get_menu_cache(init->error);
+    if(mc == NULL)
+        goto _mc_failed;
+
+    if(init->path_str)
+    {
+        dir = _vfile_path_to_menu_cache_item(mc, init->path_str);
+        if(dir == NULL || menu_cache_item_get_type(dir) != MENU_CACHE_TYPE_DIR)
+            is_invalid = TRUE;
+    }
+    else
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+        dir = MENU_CACHE_ITEM(menu_cache_dup_root_dir(mc));
+#else
+        dir = MENU_CACHE_ITEM(menu_cache_get_root_dir(mc));
+#endif
+    if(is_invalid)
+        g_set_error_literal(init->error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                            _("Invalid menu directory"));
+    else if(dir)
+    {
+#if MENU_CACHE_CHECK_VERSION(0, 5, 0)
+        MenuCacheItem *item = menu_cache_find_child_by_name(MENU_CACHE_DIR(dir),
+                                                            init->display_name);
+        g_debug("searched for child '%s' found '%s'", init->display_name,
+                item ? menu_cache_item_get_id(item) : "(nil)");
+        if (item == NULL)
+            init->result = _fm_vfs_menu_resolve_relative_path(init->file,
+                                                              init->display_name);
+        else
+        {
+            init->result = _fm_vfs_menu_resolve_relative_path(init->file,
+                                                menu_cache_item_get_id(item));
+            menu_cache_item_unref(item);
+        }
+#else /* < 0.5.0 */
+        GSList *l;
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+        GSList *children = menu_cache_dir_list_children(MENU_CACHE_DIR(dir));
+#else
+        GSList *children = menu_cache_dir_get_children(MENU_CACHE_DIR(dir));
+#endif
+        for (l = children; l; l = l->next)
+            if (g_strcmp0(init->display_name, menu_cache_item_get_name(l->data)) == 0)
+                break;
+        if (l == NULL) /* not found */
+            init->result = _fm_vfs_menu_resolve_relative_path(init->file,
+                                                              init->display_name);
+        else
+            init->result = _fm_vfs_menu_resolve_relative_path(init->file,
+                                                menu_cache_item_get_id(l->data));
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+        g_slist_free_full(children, (GDestroyNotify)menu_cache_item_unref);
+#endif
+#endif /* < 0.5.0 */
+    }
+    else /* menu_cache_get_root_dir failed */
+        g_set_error_literal(init->error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                            _("Menu cache error"));
+
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+    if(dir)
+        menu_cache_item_unref(dir);
+#endif
+    menu_cache_unref(mc);
+
+_mc_failed:
+    return FALSE;
+}
+
+static GFile *_fm_vfs_menu_get_child_for_display_name(GFile *file,
+                                                      const char *display_name,
+                                                      GError **error)
+{
+    FmMenuVFile *item = FM_MENU_VFILE(file);
+    FmVfsMenuMainThreadData enu;
+
+    /* g_debug("_fm_vfs_menu_get_child_for_display_name: '%s' '%s'", item->path, display_name); */
+    if (display_name == NULL || *display_name == '\0')
+    {
+        g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                            _("Menu item name cannot be empty"));
+        return NULL;
+    }
+    /* NOTE: this violates GFile requirement that this API should not do I/O but
+       there is no way to do this without dirty tricks which may lead to failure */
+    enu.path_str = item->path;
+    enu.error = error;
+    enu.display_name = display_name;
+    enu.file = file;
+    RUN_WITH_MENU_CACHE(_fm_vfs_menu_get_child_for_display_name_real, &enu);
+    return enu.result;
+}
+
+static GFileEnumerator *_fm_vfs_menu_enumerate_children(GFile *file,
+                                                        const char *attributes,
+                                                        GFileQueryInfoFlags flags,
+                                                        GCancellable *cancellable,
+                                                        GError **error)
+{
+    const char *path = FM_MENU_VFILE(file)->path;
+
+    return _fm_vfs_menu_enumerator_new(file, path, attributes, flags, error);
+}
+
+static gboolean _fm_vfs_menu_query_info_real(gpointer data)
+{
+    FmVfsMenuMainThreadData *init = data;
+    MenuCache *mc;
+    MenuCacheItem *dir;
+    gboolean is_invalid = FALSE;
+
+    init->result = NULL;
+    mc = _get_menu_cache(init->error);
+    if(mc == NULL)
+        goto _mc_failed;
+
+    if(init->path_str)
+    {
+        dir = _vfile_path_to_menu_cache_item(mc, init->path_str);
+        if(dir == NULL)
+            is_invalid = TRUE;
+    }
+    else
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+        dir = MENU_CACHE_ITEM(menu_cache_dup_root_dir(mc));
+#else
+        dir = MENU_CACHE_ITEM(menu_cache_get_root_dir(mc));
+#endif
+    if(is_invalid)
+        g_set_error(init->error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                    _("Invalid menu directory '%s'"), init->path_str);
+    else if(dir)
+    {
+        const char *de_name = g_getenv("XDG_CURRENT_DESKTOP");
+
+        if(de_name)
+            init->result = _g_file_info_from_menu_cache_item(dir,
+                                menu_cache_get_desktop_env_flag(mc, de_name));
+        else
+            init->result = _g_file_info_from_menu_cache_item(dir, (guint32)-1);
+    }
+    else /* menu_cache_get_root_dir failed */
+        g_set_error_literal(init->error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                            _("Menu cache error"));
+
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+    if(dir)
+        menu_cache_item_unref(dir);
+#endif
+    menu_cache_unref(mc);
+
+_mc_failed:
+    return FALSE;
+}
+
+static GFileInfo *_fm_vfs_menu_query_info(GFile *file,
+                                          const char *attributes,
+                                          GFileQueryInfoFlags flags,
+                                          GCancellable *cancellable,
+                                          GError **error)
+{
+    FmMenuVFile *item = FM_MENU_VFILE(file);
+    GFileInfo *info;
+    GFileAttributeMatcher *matcher;
+    char *basename, *id;
+    FmVfsMenuMainThreadData enu;
+
+    matcher = g_file_attribute_matcher_new(attributes);
+
+    if(item->path == NULL) /* menu root */
+    {
+        info = g_file_info_new();
+        if(g_file_attribute_matcher_matches(matcher, G_FILE_ATTRIBUTE_STANDARD_NAME))
+            g_file_info_set_name(info, "/");
+        if(g_file_attribute_matcher_matches(matcher, G_FILE_ATTRIBUTE_ID_FILESYSTEM))
+            g_file_info_set_attribute_string(info, G_FILE_ATTRIBUTE_ID_FILESYSTEM,
+                                             "menu-Applications");
+        if(g_file_attribute_matcher_matches(matcher, G_FILE_ATTRIBUTE_STANDARD_TYPE))
+            g_file_info_set_file_type(info, G_FILE_TYPE_DIRECTORY);
+        if(g_file_attribute_matcher_matches(matcher, G_FILE_ATTRIBUTE_STANDARD_ICON))
+        {
+            GIcon *icon = g_themed_icon_new("system-software-install");
+            g_file_info_set_icon(info, icon);
+            g_object_unref(icon);
+        }
+        if(g_file_attribute_matcher_matches(matcher, G_FILE_ATTRIBUTE_STANDARD_IS_HIDDEN))
+            g_file_info_set_is_hidden(info, FALSE);
+        if(g_file_attribute_matcher_matches(matcher, G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME))
+            g_file_info_set_display_name(info, _("Applications"));
+        if(g_file_attribute_matcher_matches(matcher, G_FILE_ATTRIBUTE_ACCESS_CAN_RENAME))
+            g_file_info_set_attribute_boolean(info, G_FILE_ATTRIBUTE_ACCESS_CAN_RENAME, FALSE);
+        if(g_file_attribute_matcher_matches(matcher, G_FILE_ATTRIBUTE_ACCESS_CAN_TRASH))
+            g_file_info_set_attribute_boolean(info, G_FILE_ATTRIBUTE_ACCESS_CAN_TRASH, FALSE);
+#if 0
+        /* FIXME: is this ever needed? */
+        if(g_file_attribute_matcher_matches(matcher, G_FILE_ATTRIBUTE_ACCESS_CAN_WRITE))
+            g_file_info_set_attribute_boolean(info, G_FILE_ATTRIBUTE_ACCESS_CAN_WRITE, TRUE);
+        if(g_file_attribute_matcher_matches(matcher, G_FILE_ATTRIBUTE_ACCESS_CAN_READ))
+            g_file_info_set_attribute_boolean(info, G_FILE_ATTRIBUTE_ACCESS_CAN_READ, TRUE);
+        if(g_file_attribute_matcher_matches(matcher, G_FILE_ATTRIBUTE_ACCESS_CAN_EXECUTE))
+            g_file_info_set_attribute_boolean(info, G_FILE_ATTRIBUTE_ACCESS_CAN_EXECUTE, FALSE);
+        if(g_file_attribute_matcher_matches(matcher, G_FILE_ATTRIBUTE_ACCESS_CAN_DELETE))
+            g_file_info_set_attribute_boolean(info, G_FILE_ATTRIBUTE_ACCESS_CAN_DELETE, FALSE);
+#endif
+    }
+    else if(g_file_attribute_matcher_matches(matcher, G_FILE_ATTRIBUTE_STANDARD_TYPE) ||
+            g_file_attribute_matcher_matches(matcher, G_FILE_ATTRIBUTE_STANDARD_ICON) ||
+            g_file_attribute_matcher_matches(matcher, G_FILE_ATTRIBUTE_STANDARD_TARGET_URI) ||
+            g_file_attribute_matcher_matches(matcher, G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE) ||
+            g_file_attribute_matcher_matches(matcher, G_FILE_ATTRIBUTE_STANDARD_IS_HIDDEN) ||
+            g_file_attribute_matcher_matches(matcher, G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME))
+    {
+        /* retrieve matching attributes from menu-cache */
+        enu.path_str = item->path;
+//        enu.attributes = attributes;
+//        enu.flags = flags;
+        enu.cancellable = cancellable;
+        enu.error = error;
+        RUN_WITH_MENU_CACHE(_fm_vfs_menu_query_info_real, &enu);
+        info = enu.result;
+    }
+    else
+    {
+        info = g_file_info_new();
+        if(g_file_attribute_matcher_matches(matcher, G_FILE_ATTRIBUTE_STANDARD_NAME))
+        {
+            basename = g_path_get_basename(item->path);
+            id = g_uri_unescape_string(basename, NULL);
+            g_free(basename);
+            g_file_info_set_name(info, id);
+            g_free(id);
+        }
+        if(g_file_attribute_matcher_matches(matcher, G_FILE_ATTRIBUTE_ID_FILESYSTEM))
+            g_file_info_set_attribute_string(info, G_FILE_ATTRIBUTE_ID_FILESYSTEM,
+                                             "menu-Applications");
+    }
+
+    g_file_attribute_matcher_unref(matcher);
+
+    return info;
+}
+
+static GFileInfo *_fm_vfs_menu_query_filesystem_info(GFile *file,
+                                                     const char *attributes,
+                                                     GCancellable *cancellable,
+                                                     GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return NULL;
+}
+
+static GMount *_fm_vfs_menu_find_enclosing_mount(GFile *file,
+                                                 GCancellable *cancellable,
+                                                 GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return NULL;
+}
+
+static gboolean _fm_vfs_menu_set_display_name_real(gpointer data)
+{
+    FmVfsMenuMainThreadData *init = data;
+    MenuCache *mc;
+    MenuCacheItem *dir;
+    gboolean ok = FALSE;
+
+    mc = _get_menu_cache(init->error);
+    if(mc == NULL)
+        goto _mc_failed;
+
+    dir = _vfile_path_to_menu_cache_item(mc, init->path_str);
+    if(dir == NULL)
+        g_set_error_literal(init->error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                            _("Invalid menu item"));
+    else if (menu_cache_item_get_file_basename(dir) == NULL ||
+             menu_cache_item_get_file_dirname(dir) == NULL)
+        g_set_error(init->error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
+                    _("The menu item '%s' doesn't have appropriate entry file"),
+                    menu_cache_item_get_id(dir));
+    else if (!g_cancellable_set_error_if_cancelled(init->cancellable, init->error))
+    {
+        char *path = menu_cache_item_get_file_path(dir);
+        GKeyFile *kf = g_key_file_new();
+
+        ok = g_key_file_load_from_file(kf, path, G_KEY_FILE_KEEP_COMMENTS | G_KEY_FILE_KEEP_TRANSLATIONS,
+                                       init->error);
+        g_free(path);
+        if (ok)
+        {
+            /* get locale name */
+            const gchar * const *langs = g_get_language_names();
+            char *contents;
+            gsize length;
+
+            if (strcmp(langs[0], "C") != 0)
+            {
+                char *lang;
+                /* remove encoding from locale name */
+                char *sep = strchr(langs[0], '.');
+
+                if (sep)
+                    lang = g_strndup(langs[0], sep - langs[0]);
+                else
+                    lang = g_strdup(langs[0]);
+                g_key_file_set_locale_string(kf, G_KEY_FILE_DESKTOP_GROUP,
+                                             G_KEY_FILE_DESKTOP_KEY_NAME, lang,
+                                             init->display_name);
+                g_free(lang);
+            }
+            else
+                g_key_file_set_string(kf, G_KEY_FILE_DESKTOP_GROUP,
+                                      G_KEY_FILE_DESKTOP_KEY_NAME, init->display_name);
+            contents = g_key_file_to_data(kf, &length, init->error);
+            if (contents == NULL)
+                ok = FALSE;
+            else
+            {
+                path = g_build_filename(g_get_user_data_dir(),
+                                        (menu_cache_item_get_type(dir) == MENU_CACHE_TYPE_DIR) ? "desktop-directories" : "applications",
+                                        menu_cache_item_get_file_basename(dir), NULL);
+                ok = g_file_set_contents(path, contents, length, init->error);
+                /* FIXME: handle case if directory doesn't exist */
+                g_free(contents);
+                g_free(path);
+            }
+        }
+        g_key_file_free(kf);
+    }
+
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+    if(dir)
+        menu_cache_item_unref(dir);
+#endif
+    menu_cache_unref(mc);
+
+_mc_failed:
+    return ok;
+}
+
+static GFile *_fm_vfs_menu_set_display_name(GFile *file,
+                                            const char *display_name,
+                                            GCancellable *cancellable,
+                                            GError **error)
+{
+    FmMenuVFile *item = FM_MENU_VFILE(file);
+    FmVfsMenuMainThreadData enu;
+
+    /* g_debug("_fm_vfs_menu_set_display_name: %s -> %s", item->path, display_name); */
+    if (item->path == NULL)
+    {
+        ERROR_UNSUPPORTED(error);
+        return NULL;
+    }
+    if (display_name == NULL || *display_name == '\0')
+    {
+        g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                            _("Menu item name cannot be empty"));
+        return NULL;
+    }
+    enu.path_str = item->path;
+    enu.display_name = display_name;
+    enu.cancellable = cancellable;
+    enu.error = error;
+    if (RUN_WITH_MENU_CACHE(_fm_vfs_menu_set_display_name_real, &enu))
+        return g_object_ref(file);
+    return NULL;
+}
+
+static GFileAttributeInfoList *_fm_vfs_menu_query_settable_attributes(GFile *file,
+                                                                      GCancellable *cancellable,
+                                                                      GError **error)
+{
+    return g_file_attribute_info_list_ref(_fm_vfs_menu_settable_attributes);
+}
+
+static GFileAttributeInfoList *_fm_vfs_menu_query_writable_namespaces(GFile *file,
+                                                                      GCancellable *cancellable,
+                                                                      GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return NULL;
+}
+
+static gboolean _fm_vfs_menu_set_attributes_from_info_real(gpointer data)
+{
+    FmVfsMenuMainThreadData *init = data;
+    MenuCache *mc;
+    MenuCacheItem *item;
+    gpointer value;
+    const char *display_name = NULL;
+    GIcon *icon = NULL;
+    gint set_hidden = -1;
+    gboolean ok = FALSE;
+
+    /* check attributes first */
+    if (g_file_info_get_attribute_data(init->info, G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME,
+                                       NULL, &value, NULL))
+        display_name = value;
+    if (g_file_info_get_attribute_data(init->info, G_FILE_ATTRIBUTE_STANDARD_ICON,
+                                       NULL, &value, NULL))
+        icon = value;
+    if (g_file_info_get_attribute_data(init->info, G_FILE_ATTRIBUTE_STANDARD_IS_HIDDEN,
+                                       NULL, &value, NULL))
+        set_hidden = (*(gboolean *)value) ? 1 : 0;
+    if (display_name == NULL && icon == NULL && set_hidden < 0)
+        return TRUE; /* nothing to do */
+    /* now try access item */
+    mc = _get_menu_cache(init->error);
+    if(mc == NULL)
+        goto _mc_failed;
+
+    item = _vfile_path_to_menu_cache_item(mc, init->path_str);
+    if(item == NULL)
+        g_set_error_literal(init->error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                            _("Invalid menu item"));
+    else if (menu_cache_item_get_file_basename(item) == NULL ||
+             menu_cache_item_get_file_dirname(item) == NULL)
+        g_set_error(init->error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
+                    _("The menu item '%s' doesn't have appropriate entry file"),
+                    menu_cache_item_get_id(item));
+    else if (!g_cancellable_set_error_if_cancelled(init->cancellable, init->error))
+    {
+        char *path;
+        GKeyFile *kf;
+        GError *err = NULL;
+        gboolean no_error = TRUE;
+
+        /* for hidden on directory: use _add_directory() or _remove_directory() */
+        if (set_hidden >= 0 && menu_cache_item_get_type(item) == MENU_CACHE_TYPE_DIR)
+        {
+#if MENU_CACHE_CHECK_VERSION(0, 5, 0)
+            char *unescaped = g_uri_unescape_string(init->path_str, NULL);
+            if (set_hidden > 0)
+                no_error = _remove_directory(unescaped, init->cancellable, init->error);
+            else
+                no_error = _add_directory(unescaped, init->cancellable, init->error);
+            g_free(unescaped);
+            ok = no_error;
+#else
+            g_set_error_literal(init->error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
+                                _("Change hidden status isn't supported for menu directory"));
+            no_error = FALSE;
+#endif
+            if (display_name == NULL && icon == NULL) /* nothing else to update */
+                goto _done;
+            set_hidden = -1; /* don't set NoDisplay for a directory */
+        }
+        /* in all other cases - update Name, Icon or NoDisplay and save keyfile */
+        path = menu_cache_item_get_file_path(item);
+        kf = g_key_file_new();
+        ok = g_key_file_load_from_file(kf, path, G_KEY_FILE_KEEP_COMMENTS | G_KEY_FILE_KEEP_TRANSLATIONS,
+                                       &err);
+        g_free(path);
+        if (ok) /* otherwise there is no reason to continue */
+        {
+            char *contents;
+            gsize length;
+
+            if (display_name)
+            {
+                /* get locale name */
+                const gchar * const *langs = g_get_language_names();
+
+                if (strcmp(langs[0], "C") != 0)
+                {
+                    char *lang;
+                    /* remove encoding from locale name */
+                    char *sep = strchr(langs[0], '.');
+
+                    if (sep)
+                        lang = g_strndup(langs[0], sep - langs[0]);
+                    else
+                        lang = g_strdup(langs[0]);
+                    g_key_file_set_locale_string(kf, G_KEY_FILE_DESKTOP_GROUP,
+                                                 G_KEY_FILE_DESKTOP_KEY_NAME, lang,
+                                                 display_name);
+                    g_free(lang);
+                }
+                else
+                    g_key_file_set_string(kf, G_KEY_FILE_DESKTOP_GROUP,
+                                          G_KEY_FILE_DESKTOP_KEY_NAME, display_name);
+            }
+            if (icon)
+            {
+                char *icon_str = g_icon_to_string(icon);
+                /* FIXME: need to change encoding in some cases? */
+                g_key_file_set_string(kf, G_KEY_FILE_DESKTOP_GROUP,
+                                      G_KEY_FILE_DESKTOP_KEY_ICON, icon_str);
+                g_free(icon_str);
+            }
+            if (set_hidden >= 0)
+            {
+                g_key_file_set_boolean(kf, G_KEY_FILE_DESKTOP_GROUP,
+                                       G_KEY_FILE_DESKTOP_KEY_NO_DISPLAY,
+                                       (set_hidden > 0));
+            }
+            contents = g_key_file_to_data(kf, &length, &err);
+            if (contents == NULL)
+                ok = FALSE;
+            else
+            {
+                path = g_build_filename(g_get_user_data_dir(),
+                                        (menu_cache_item_get_type(item) == MENU_CACHE_TYPE_DIR) ? "desktop-directories" : "applications",
+                                        menu_cache_item_get_file_basename(item), NULL);
+                ok = g_file_set_contents(path, contents, length, &err);
+                /* FIXME: handle case if directory doesn't exist */
+                g_free(contents);
+                g_free(path);
+            }
+        }
+        g_key_file_free(kf);
+        if (no_error && !ok) /* we got error in err */
+            g_propagate_error(init->error, err);
+        else if (!ok) /* both init->error and err contain error */
+            g_error_free(err);
+        else if (!no_error) /* we got error in init->error */
+            ok = FALSE;
+    }
+
+_done:
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+    if(item)
+        menu_cache_item_unref(item);
+#endif
+    menu_cache_unref(mc);
+
+_mc_failed:
+    return ok;
+}
+
+static gboolean _fm_vfs_menu_set_attributes_from_info(GFile *file,
+                                                      GFileInfo *info,
+                                                      GFileQueryInfoFlags flags,
+                                                      GCancellable *cancellable,
+                                                      GError **error)
+{
+    FmMenuVFile *item = FM_MENU_VFILE(file);
+    FmVfsMenuMainThreadData enu;
+
+    if (item->path == NULL)
+    {
+        ERROR_UNSUPPORTED(error);
+        return FALSE;
+    }
+    enu.path_str = item->path;
+    enu.info = info;
+//    enu.flags = flags;
+    enu.cancellable = cancellable;
+    enu.error = error;
+    return (RUN_WITH_MENU_CACHE(_fm_vfs_menu_set_attributes_from_info_real, &enu));
+}
+
+static gboolean _fm_vfs_menu_set_attribute(GFile *file,
+                                           const char *attribute,
+                                           GFileAttributeType type,
+                                           gpointer value_p,
+                                           GFileQueryInfoFlags flags,
+                                           GCancellable *cancellable,
+                                           GError **error)
+{
+    FmMenuVFile *item = FM_MENU_VFILE(file);
+    GFileInfo *info;
+    gboolean result;
+
+    g_debug("_fm_vfs_menu_set_attribute: %s on %s", attribute, item->path);
+    if (item->path == NULL)
+    {
+        ERROR_UNSUPPORTED(error);
+        return FALSE;
+    }
+    if (value_p == NULL)
+        goto _invalid_arg;
+    if (strcmp(attribute, G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME) == 0)
+    {
+        if (type != G_FILE_ATTRIBUTE_TYPE_STRING)
+            goto _invalid_arg;
+        info = g_file_info_new();
+        g_file_info_set_display_name(info, value_p);
+    }
+    else if (strcmp(attribute, G_FILE_ATTRIBUTE_STANDARD_ICON) == 0)
+    {
+        if (type != G_FILE_ATTRIBUTE_TYPE_OBJECT)
+            goto _invalid_arg;
+        if (!G_IS_ICON(value_p))
+            goto _invalid_arg;
+        info = g_file_info_new();
+        g_file_info_set_icon(info, value_p);
+    }
+    else if (strcmp(attribute, G_FILE_ATTRIBUTE_STANDARD_IS_HIDDEN) == 0)
+    {
+        if (type != G_FILE_ATTRIBUTE_TYPE_BOOLEAN)
+            goto _invalid_arg;
+        info = g_file_info_new();
+        g_file_info_set_is_hidden(info, *(gboolean *)value_p);
+    }
+    else
+    {
+        g_set_error(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
+                    _("Setting attribute '%s' not supported"), attribute);
+        return FALSE;
+    }
+    result = _fm_vfs_menu_set_attributes_from_info(file, info, flags,
+                                                   cancellable, error);
+    g_object_unref(info);
+    return result;
+
+_invalid_arg:
+    g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+                _("Invalid value for attribute '%s'"), attribute);
+    return FALSE;
+}
+
+static inline GFile *_g_file_new_for_id(const char *id)
+{
+    char *file_path;
+    GFile *file;
+
+    file_path = g_build_filename(g_get_user_data_dir(), "applications", id, NULL);
+    /* we can try to guess file path and make directories but it
+       hardly worth the efforts so it's easier to just make new file
+       by its ID since ID is unique thru all the menu */
+    if (file_path == NULL)
+        return NULL;
+    file = g_file_new_for_path(file_path);
+    g_free(file_path);
+    return file;
+}
+
+static gboolean _fm_vfs_menu_read_fn_real(gpointer data)
+{
+    FmVfsMenuMainThreadData *init = data;
+    MenuCache *mc;
+    MenuCacheItem *item = NULL;
+
+    init->result = NULL;
+    mc = _get_menu_cache(init->error);
+    if(mc == NULL)
+        goto _mc_failed;
+
+    if(init->path_str)
+        item = _vfile_path_to_menu_cache_item(mc, init->path_str);
+
+        /* If item wasn't found or isn't a file then we cannot read it. */
+    if(item != NULL && menu_cache_item_get_type(item) == MENU_CACHE_TYPE_DIR)
+        g_set_error(init->error, G_IO_ERROR, G_IO_ERROR_IS_DIRECTORY,
+                    _("The '%s' is a menu directory"), init->path_str);
+    else if(item == NULL || menu_cache_item_get_type(item) != MENU_CACHE_TYPE_APP)
+        g_set_error(init->error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                    _("The '%s' isn't a menu item"),
+                    init->path_str ? init->path_str : "/");
+    else
+    {
+        char *file_path;
+        GFile *gf;
+        GError *err = NULL;
+
+        file_path = menu_cache_item_get_file_path(item);
+        if (file_path)
+        {
+            gf = g_file_new_for_path(file_path);
+            g_free(file_path);
+            if (gf)
+            {
+                init->result = g_file_read(gf, init->cancellable, &err);
+                if (init->result == NULL)
+                {
+                    /* never return G_IO_ERROR_IS_DIRECTORY */
+                    if (err->domain == G_IO_ERROR &&
+                        err->code == G_IO_ERROR_IS_DIRECTORY)
+                    {
+                        g_error_free(err);
+                        g_set_error(init->error, G_IO_ERROR, G_IO_ERROR_NOT_REGULAR_FILE,
+                                    _("The '%s' entry file is broken"), init->path_str);
+                    }
+                    else
+                        g_propagate_error(init->error, err);
+                }
+                g_object_unref(gf);
+            }
+        }
+    }
+
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+    if(item)
+        menu_cache_item_unref(item);
+#endif
+    menu_cache_unref(mc);
+
+_mc_failed:
+    return FALSE;
+}
+
+static GFileInputStream *_fm_vfs_menu_read_fn(GFile *file,
+                                              GCancellable *cancellable,
+                                              GError **error)
+{
+    FmMenuVFile *item = FM_MENU_VFILE(file);
+    FmVfsMenuMainThreadData enu;
+
+    /* g_debug("_fm_vfs_menu_read_fn %s", item->path); */
+    enu.path_str = item->path;
+    enu.cancellable = cancellable;
+    enu.error = error;
+    RUN_WITH_MENU_CACHE(_fm_vfs_menu_read_fn_real, &enu);
+    return enu.result;
+}
+
+static GFileOutputStream *_fm_vfs_menu_append_to(GFile *file,
+                                                 GFileCreateFlags flags,
+                                                 GCancellable *cancellable,
+                                                 GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return NULL;
+}
+
+
+/* ---- FmMenuVFileOutputStream class ---- */
+#define FM_TYPE_MENU_VFILE_OUTPUT_STREAM  (fm_vfs_menu_file_output_stream_get_type())
+#define FM_MENU_VFILE_OUTPUT_STREAM(o)    (G_TYPE_CHECK_INSTANCE_CAST((o), \
+                                           FM_TYPE_MENU_VFILE_OUTPUT_STREAM, \
+                                           FmMenuVFileOutputStream))
+
+typedef struct _FmMenuVFileOutputStream      FmMenuVFileOutputStream;
+typedef struct _FmMenuVFileOutputStreamClass FmMenuVFileOutputStreamClass;
+
+struct _FmMenuVFileOutputStream
+{
+    GFileOutputStream parent;
+    GOutputStream *real_stream;
+    gchar *path; /* "Dir/App.desktop" */
+    GString *content;
+    gboolean do_close;
+};
+
+struct _FmMenuVFileOutputStreamClass
+{
+    GFileOutputStreamClass parent_class;
+};
+
+static GType fm_vfs_menu_file_output_stream_get_type  (void);
+
+G_DEFINE_TYPE(FmMenuVFileOutputStream, fm_vfs_menu_file_output_stream, G_TYPE_FILE_OUTPUT_STREAM);
+
+static void fm_vfs_menu_file_output_stream_finalize(GObject *object)
+{
+    FmMenuVFileOutputStream *stream = FM_MENU_VFILE_OUTPUT_STREAM(object);
+    if(stream->real_stream)
+        g_object_unref(stream->real_stream);
+    g_free(stream->path);
+    g_string_free(stream->content, TRUE);
+    G_OBJECT_CLASS(fm_vfs_menu_file_output_stream_parent_class)->finalize(object);
+}
+
+static gssize fm_vfs_menu_file_output_stream_write(GOutputStream *stream,
+                                                   const void *buffer, gsize count,
+                                                   GCancellable *cancellable,
+                                                   GError **error)
+{
+    if (g_cancellable_set_error_if_cancelled(cancellable, error))
+        return -1;
+    g_string_append_len(FM_MENU_VFILE_OUTPUT_STREAM(stream)->content, buffer, count);
+    return (gssize)count;
+}
+
+static gboolean fm_vfs_menu_file_output_stream_close(GOutputStream *gos,
+                                                     GCancellable *cancellable,
+                                                     GError **error)
+{
+    FmMenuVFileOutputStream *stream = FM_MENU_VFILE_OUTPUT_STREAM(gos);
+    GKeyFile *kf;
+    gsize len = 0;
+    gchar *content;
+    gboolean ok;
+
+    if (g_cancellable_set_error_if_cancelled(cancellable, error))
+        return FALSE;
+    if (!stream->do_close)
+        return TRUE;
+    kf = g_key_file_new();
+    /* parse entered file content first */
+    if (stream->content->len > 0)
+        g_key_file_load_from_data(kf, stream->content->str, stream->content->len,
+                                  G_KEY_FILE_KEEP_COMMENTS | G_KEY_FILE_KEEP_TRANSLATIONS,
+                                  NULL); /* FIXME: don't ignore some errors? */
+    /* correct invalid data in desktop entry file: Name and Exec are mandatory,
+       Type must be Application, and Category should include requested one */
+    if(!g_key_file_has_key(kf, G_KEY_FILE_DESKTOP_GROUP,
+                           G_KEY_FILE_DESKTOP_KEY_NAME, NULL))
+        g_key_file_set_string(kf, G_KEY_FILE_DESKTOP_GROUP,
+                              G_KEY_FILE_DESKTOP_KEY_NAME, "");
+    if(!g_key_file_has_key(kf, G_KEY_FILE_DESKTOP_GROUP,
+                           G_KEY_FILE_DESKTOP_KEY_EXEC, NULL))
+        g_key_file_set_string(kf, G_KEY_FILE_DESKTOP_GROUP,
+                              G_KEY_FILE_DESKTOP_KEY_EXEC, "");
+    g_key_file_set_string(kf, G_KEY_FILE_DESKTOP_GROUP, G_KEY_FILE_DESKTOP_KEY_TYPE,
+                          G_KEY_FILE_DESKTOP_TYPE_APPLICATION);
+    content = g_key_file_to_data(kf, &len, error);
+    g_key_file_free(kf);
+    if (!content)
+        return FALSE;
+    ok = g_output_stream_write_all(stream->real_stream, content, len, &len,
+                                   cancellable, error);
+    g_free(content);
+    if (!ok || !g_output_stream_close(stream->real_stream, cancellable, error))
+        return FALSE;
+    stream->do_close = FALSE;
+    if (stream->path && !_add_application(stream->path, cancellable, error))
+        return FALSE;
+    return TRUE;
+}
+
+static void fm_vfs_menu_file_output_stream_class_init(FmMenuVFileOutputStreamClass *klass)
+{
+    GObjectClass *gobject_class = G_OBJECT_CLASS(klass);
+    GOutputStreamClass *stream_class = G_OUTPUT_STREAM_CLASS(klass);
+
+    gobject_class->finalize = fm_vfs_menu_file_output_stream_finalize;
+    stream_class->write_fn = fm_vfs_menu_file_output_stream_write;
+    stream_class->close_fn = fm_vfs_menu_file_output_stream_close;
+    /* we don't implement seek/truncate/etag/query so no GFileOutputStream funcs */
+}
+
+static void fm_vfs_menu_file_output_stream_init(FmMenuVFileOutputStream *stream)
+{
+    stream->content = g_string_sized_new(1024);
+    stream->do_close = TRUE;
+}
+
+static FmMenuVFileOutputStream *_fm_vfs_menu_file_output_stream_new(const gchar *path)
+{
+    FmMenuVFileOutputStream *stream;
+
+    stream = g_object_new(FM_TYPE_MENU_VFILE_OUTPUT_STREAM, NULL);
+    if (path)
+        stream->path = g_strdup(path);
+    return stream;
+}
+
+static GFileOutputStream *_vfile_menu_create(GFile *file,
+                                             GFileCreateFlags flags,
+                                             GCancellable *cancellable,
+                                             GError **error,
+                                             const gchar *path)
+{
+    FmMenuVFileOutputStream *stream;
+    GFileOutputStream *ostream;
+    GError *err = NULL;
+    GFile *parent;
+
+    if (g_cancellable_set_error_if_cancelled(cancellable, error))
+        return NULL;
+//    g_file_delete(file, cancellable, NULL); /* remove old if there is any */
+    ostream = g_file_create(file, flags, cancellable, &err);
+    if (ostream == NULL)
+    {
+        if (g_cancellable_is_cancelled(cancellable) ||
+            err->domain != G_IO_ERROR || err->code != G_IO_ERROR_NOT_FOUND)
+        {
+            g_propagate_error(error, err);
+            return NULL;
+        }
+        /* .local/share/applications/ isn't found? make it! */
+        g_clear_error(&err);
+        parent = g_file_get_parent(file);
+        if (!g_file_make_directory_with_parents(parent, cancellable, error))
+        {
+            g_object_unref(parent);
+            return NULL;
+        }
+        g_object_unref(parent);
+        ostream = g_file_create(file, flags, cancellable, error);
+        if (ostream == NULL)
+            return ostream;
+    }
+    stream = _fm_vfs_menu_file_output_stream_new(path);
+    stream->real_stream = G_OUTPUT_STREAM(ostream);
+    return (GFileOutputStream*)stream;
+}
+
+static GFileOutputStream *_vfile_menu_replace(GFile *file,
+                                              const char *etag,
+                                              gboolean make_backup,
+                                              GFileCreateFlags flags,
+                                              GCancellable *cancellable,
+                                              GError **error,
+                                              const gchar *path)
+{
+    FmMenuVFileOutputStream *stream;
+    GFileOutputStream *ostream;
+
+    if (g_cancellable_set_error_if_cancelled(cancellable, error))
+        return NULL;
+    stream = _fm_vfs_menu_file_output_stream_new(path);
+    ostream = g_file_replace(file, etag, make_backup, flags, cancellable, error);
+    if (ostream == NULL)
+    {
+        g_object_unref(stream);
+        return NULL;
+    }
+    stream->real_stream = G_OUTPUT_STREAM(ostream);
+    return (GFileOutputStream*)stream;
+}
+
+static gboolean _fm_vfs_menu_create_real(gpointer data)
+{
+    FmVfsMenuMainThreadData *init = data;
+    MenuCache *mc;
+    char *unescaped = NULL, *id;
+    gboolean is_invalid = TRUE;
+
+    init->result = NULL;
+    if(init->path_str)
+    {
+        MenuCacheItem *item;
+#if !MENU_CACHE_CHECK_VERSION(0, 5, 0)
+        GSList *list, *l;
+#endif
+
+        mc = _get_menu_cache(init->error);
+        if(mc == NULL)
+            goto _mc_failed;
+        unescaped = g_uri_unescape_string(init->path_str, NULL);
+        /* ensure new menu item has suffix .desktop */
+        if (!g_str_has_suffix(unescaped, ".desktop"))
+        {
+            id = unescaped;
+            unescaped = g_strconcat(unescaped, ".desktop", NULL);
+            g_free(id);
+        }
+        id = strrchr(unescaped, '/');
+        if (id)
+            id++;
+        else
+            id = unescaped;
+#if MENU_CACHE_CHECK_VERSION(0, 5, 0)
+        item = menu_cache_find_item_by_id(mc, id);
+        if (item)
+            menu_cache_item_unref(item); /* use item simply as marker */
+#else
+        list = menu_cache_list_all_apps(mc);
+        for (l = list; l; l = l->next)
+            if (strcmp(menu_cache_item_get_id(l->data), id) == 0)
+                break;
+        if (l)
+            item = l->data;
+        else
+            item = NULL;
+        g_slist_free_full(list, (GDestroyNotify)menu_cache_item_unref);
+#endif
+        if(item == NULL)
+            is_invalid = FALSE;
+        /* g_debug("create id %s, category %s", id, category); */
+        menu_cache_unref(mc);
+    }
+
+    if(is_invalid)
+        g_set_error(init->error, G_IO_ERROR, G_IO_ERROR_EXISTS,
+                    _("Cannot create menu item '%s'"),
+                    init->path_str ? init->path_str : "/");
+    else
+    {
+        GFile *gf = _g_file_new_for_id(id);
+
+        if (gf)
+        {
+            init->result = _vfile_menu_create(gf, G_FILE_CREATE_NONE,
+                                              init->cancellable, init->error,
+                                              unescaped);
+            g_object_unref(gf);
+        }
+    }
+    g_free(unescaped);
+
+_mc_failed:
+    return FALSE;
+}
+
+static GFileOutputStream *_fm_vfs_menu_create(GFile *file,
+                                              GFileCreateFlags flags,
+                                              GCancellable *cancellable,
+                                              GError **error)
+{
+    FmMenuVFile *item = FM_MENU_VFILE(file);
+    FmVfsMenuMainThreadData enu;
+
+    /* g_debug("_fm_vfs_menu_create %s", item->path); */
+    enu.path_str = item->path;
+    enu.cancellable = cancellable;
+    enu.error = error;
+    // enu.flags = flags;
+    RUN_WITH_MENU_CACHE(_fm_vfs_menu_create_real, &enu);
+    return enu.result;
+}
+
+static gboolean _fm_vfs_menu_replace_real(gpointer data)
+{
+    FmVfsMenuMainThreadData *init = data;
+    MenuCache *mc;
+    char *unescaped = NULL, *id;
+    gboolean is_invalid = TRUE;
+
+    init->result = NULL;
+    if(init->path_str)
+    {
+        MenuCacheItem *item, *item2;
+
+        mc = _get_menu_cache(init->error);
+        if(mc == NULL)
+            goto _mc_failed;
+        /* prepare id first */
+        unescaped = g_uri_unescape_string(init->path_str, NULL);
+        id = strrchr(unescaped, '/');
+        if (id != NULL)
+            id++;
+        else
+            id = unescaped;
+        /* get existing item */
+        item = _vfile_path_to_menu_cache_item(mc, init->path_str);
+        if (item != NULL) /* item is there, OK, we'll replace it then */
+            is_invalid = FALSE;
+        /* if not found then check item by id to exclude conflicts */
+        else
+        {
+#if MENU_CACHE_CHECK_VERSION(0, 5, 0)
+            item2 = menu_cache_find_item_by_id(mc, id);
+#else
+            GSList *list = menu_cache_list_all_apps(mc), *l;
+            for (l = list; l; l = l->next)
+                if (strcmp(menu_cache_item_get_id(l->data), id) == 0)
+                    break;
+            if (l)
+                item2 = menu_cache_item_ref(l->data);
+            else
+                item2 = NULL;
+            g_slist_free_full(list, (GDestroyNotify)menu_cache_item_unref);
+#endif
+            if(item2 == NULL)
+                is_invalid = FALSE;
+            else /* item was found in another category */
+                menu_cache_item_unref(item2);
+        }
+        menu_cache_unref(mc);
+    }
+
+    if(is_invalid)
+        g_set_error(init->error, G_IO_ERROR, G_IO_ERROR_EXISTS,
+                    _("Cannot create menu item '%s'"),
+                    init->path_str ? init->path_str : "/");
+    else
+    {
+        GFile *gf = _g_file_new_for_id(id);
+
+        if (gf)
+        {
+            /* FIXME: use flags and make_backup */
+            init->result = _vfile_menu_replace(gf, NULL, FALSE,
+                                               G_FILE_CREATE_REPLACE_DESTINATION,
+                                               init->cancellable, init->error,
+                                               /* don't insert it into XML */
+                                               NULL);
+            g_object_unref(gf);
+        }
+    }
+    g_free(unescaped);
+
+_mc_failed:
+    return FALSE;
+}
+
+static GFileOutputStream *_fm_vfs_menu_replace(GFile *file,
+                                               const char *etag,
+                                               gboolean make_backup,
+                                               GFileCreateFlags flags,
+                                               GCancellable *cancellable,
+                                               GError **error)
+{
+    FmMenuVFile *item = FM_MENU_VFILE(file);
+    FmVfsMenuMainThreadData enu;
+
+    /* g_debug("_fm_vfs_menu_replace %s", item->path); */
+    enu.path_str = item->path;
+    enu.cancellable = cancellable;
+    enu.error = error;
+    // enu.flags = flags;
+    // enu.make_backup = make_backup;
+    RUN_WITH_MENU_CACHE(_fm_vfs_menu_replace_real, &enu);
+    return enu.result;
+}
+
+/* not in main thread; returns NULL on failure */
+static GKeyFile *_g_key_file_from_item(GFile *file, GCancellable *cancellable,
+                                       GError **error)
+{
+    char *contents;
+    gsize length;
+    GKeyFile *kf;
+
+    if (!g_file_load_contents(file, cancellable, &contents, &length, NULL, error))
+        return NULL;
+    kf = g_key_file_new();
+    if (!g_key_file_load_from_data(kf, contents, length,
+                                   G_KEY_FILE_KEEP_COMMENTS | G_KEY_FILE_KEEP_TRANSLATIONS,
+                                   error))
+    {
+        g_key_file_free(kf);
+        kf = NULL;
+    }
+    g_free(contents);
+    return kf;
+}
+
+/* not in main thread; returns FALSE on failure, consumes key file */
+static gboolean _g_key_file_into_item(GFile *file, GKeyFile *kf,
+                                      GCancellable *cancellable, GError **error)
+{
+    char *contents;
+    gsize length;
+    gboolean result = FALSE;
+
+    contents = g_key_file_to_data(kf, &length, error);
+    g_key_file_free(kf);
+    if (contents == NULL)
+        return FALSE;
+    result = g_file_replace_contents(file, contents, length, NULL, FALSE,
+                                     G_FILE_CREATE_REPLACE_DESTINATION, NULL,
+                                     cancellable, error);
+    g_free(contents);
+    return result;
+}
+
+static gboolean _fm_vfs_menu_delete_file(GFile *file,
+                                         GCancellable *cancellable,
+                                         GError **error)
+{
+    FmMenuVFile *item = FM_MENU_VFILE(file);
+    GKeyFile *kf;
+    GError *err = NULL;
+
+    g_debug("_fm_vfs_menu_delete_file %s", item->path);
+    /* load contents */
+    kf = _g_key_file_from_item(file, cancellable, &err);
+    if (kf == NULL)
+    {
+#if MENU_CACHE_CHECK_VERSION(0, 5, 0)
+        /* it might be just a directory */
+        if (err->domain == G_IO_ERROR && err->code == G_IO_ERROR_IS_DIRECTORY)
+        {
+            char *unescaped = g_uri_unescape_string(item->path, NULL);
+            gboolean ok = _remove_directory(unescaped, cancellable, error);
+            g_error_free(err);
+            g_free(unescaped);
+            return ok;
+        }
+        /* else it just failed */
+#endif
+        g_propagate_error(error, err);
+        return FALSE;
+    }
+    /* set NoDisplay=true and save */
+    g_key_file_set_boolean(kf, G_KEY_FILE_DESKTOP_GROUP,
+                           G_KEY_FILE_DESKTOP_KEY_NO_DISPLAY, TRUE);
+    return _g_key_file_into_item(file, kf, cancellable, error);
+}
+
+static gboolean _fm_vfs_menu_trash(GFile *file,
+                                   GCancellable *cancellable,
+                                   GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return FALSE;
+}
+
+static gboolean _fm_vfs_menu_make_directory(GFile *file,
+                                            GCancellable *cancellable,
+                                            GError **error)
+{
+#if !MENU_CACHE_CHECK_VERSION(0, 5, 0)
+    /* creating a directory with libmenu-cache < 0.5.0 will lead to invisible
+       directory; inexperienced user will be confused; therefore we disable
+       such operation in such conditions */
+    ERROR_UNSUPPORTED(error);
+    return FALSE;
+#else
+    FmMenuVFile *item = FM_MENU_VFILE(file);
+    char *unescaped;
+    gboolean ok;
+
+    /* XDG desktop menu specification: desktop-entry-id should be *.desktop */
+    if (g_str_has_suffix(item->path, ".desktop"))
+    {
+        g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_FILENAME,
+                            _("Name of menu directory should not end with"
+                              " \".desktop\""));
+        return FALSE;
+    }
+    unescaped = g_uri_unescape_string(item->path, NULL);
+    ok = _add_directory(unescaped, cancellable, error);
+    g_free(unescaped);
+    return ok;
+#endif
+}
+
+static gboolean _fm_vfs_menu_make_symbolic_link(GFile *file,
+                                                const char *symlink_value,
+                                                GCancellable *cancellable,
+                                                GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return FALSE;
+}
+
+static gboolean _fm_vfs_menu_copy(GFile *source,
+                                  GFile *destination,
+                                  GFileCopyFlags flags,
+                                  GCancellable *cancellable,
+                                  GFileProgressCallback progress_callback,
+                                  gpointer progress_callback_data,
+                                  GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return FALSE;
+}
+
+static gboolean _fm_vfs_menu_move_real(gpointer data)
+{
+    FmVfsMenuMainThreadData *init = data;
+    MenuCache *mc = NULL;
+    MenuCacheItem *item = NULL, *item2;
+    char *src_path, *dst_path;
+    char *src_id, *dst_id;
+    gboolean result = FALSE;
+
+    dst_path = init->destination->path;
+    if (init->path_str == NULL || dst_path == NULL)
+    {
+        g_set_error_literal(init->error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                            _("Invalid operation with menu root"));
+        return FALSE;
+    }
+    /* make path strings */
+    src_path = g_uri_unescape_string(init->path_str, NULL);
+    dst_path = g_uri_unescape_string(dst_path, NULL);
+    src_id = strrchr(src_path, '/');
+    if (src_id)
+        src_id++;
+    else
+        src_id = src_path;
+    dst_id = strrchr(dst_path, '/');
+    if (dst_id)
+        dst_id++;
+    else
+        dst_id = dst_path;
+    if (strcmp(src_id, dst_id))
+    {
+        /* ID change isn't supported now */
+        ERROR_UNSUPPORTED(init->error);
+        goto _failed;
+    }
+    if (strcmp(src_path, dst_path) == 0)
+    {
+        g_warning("menu: tried to move '%s' into itself", src_path);
+        g_free(src_path);
+        g_free(dst_path);
+        return TRUE; /* nothing was changed */
+    }
+    /* do actual move */
+    mc = _get_menu_cache(init->error);
+    if(mc == NULL)
+        goto _failed;
+    item = _vfile_path_to_menu_cache_item(mc, init->path_str);
+    /* TODO: if id changed then check for ID conflicts */
+    /* TODO: save updated desktop entry for old ID (if different) */
+    if(item == NULL || menu_cache_item_get_type(item) != MENU_CACHE_TYPE_APP)
+    {
+        /* FIXME: implement directories movement */
+        g_set_error(init->error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                    _("The '%s' isn't a menu item"), init->path_str);
+        goto _failed;
+    }
+    item2 = _vfile_path_to_menu_cache_item(mc, init->destination->path);
+    if (item2)
+    {
+        g_set_error(init->error, G_IO_ERROR, G_IO_ERROR_EXISTS,
+                    _("Menu path '%s' already exists"), dst_path);
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+        menu_cache_item_unref(item2);
+#endif
+        goto _failed;
+    }
+    /* do actual move */
+    if (_add_application(dst_path, init->cancellable, init->error))
+    {
+        if (_remove_application(src_path, init->cancellable, init->error))
+            result = TRUE;
+        else /* failed, rollback */
+            _remove_application(dst_path, init->cancellable, NULL);
+    }
+
+_failed:
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+    if(item)
+        menu_cache_item_unref(item);
+#endif
+    if(mc)
+        menu_cache_unref(mc);
+    g_free(src_path);
+    g_free(dst_path);
+    return result;
+}
+
+static gboolean _fm_vfs_menu_move(GFile *source,
+                                  GFile *destination,
+                                  GFileCopyFlags flags,
+                                  GCancellable *cancellable,
+                                  GFileProgressCallback progress_callback,
+                                  gpointer progress_callback_data,
+                                  GError **error)
+{
+    FmMenuVFile *item = FM_MENU_VFILE(source);
+    FmVfsMenuMainThreadData enu;
+
+    /* g_debug("_fm_vfs_menu_move"); */
+    if(!FM_IS_FILE(destination))
+    {
+        g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+                            _("Invalid destination"));
+        return FALSE;
+    }
+    enu.path_str = item->path;
+    enu.cancellable = cancellable;
+    enu.error = error;
+    // enu.flags = flags;
+    enu.destination = FM_MENU_VFILE(destination);
+    /* FIXME: use progress_callback */
+    return RUN_WITH_MENU_CACHE(_fm_vfs_menu_move_real, &enu);
+}
+
+/* ---- FmMenuVFileMonitor class ---- */
+#define FM_TYPE_MENU_VFILE_MONITOR     (fm_vfs_menu_file_monitor_get_type())
+#define FM_MENU_VFILE_MONITOR(o)       (G_TYPE_CHECK_INSTANCE_CAST((o), \
+                                        FM_TYPE_MENU_VFILE_MONITOR, FmMenuVFileMonitor))
+
+typedef struct _FmMenuVFileMonitor      FmMenuVFileMonitor;
+typedef struct _FmMenuVFileMonitorClass FmMenuVFileMonitorClass;
+
+static GType fm_vfs_menu_file_monitor_get_type  (void);
+
+struct _FmMenuVFileMonitor
+{
+    GFileMonitor parent_object;
+
+    FmMenuVFile *file;
+    MenuCache *cache;
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+    MenuCacheItem *item;
+    MenuCacheNotifyId notifier;
+#else
+    GSList *items;
+    gboolean stopped;
+    gpointer notifier;
+#endif
+};
+
+struct _FmMenuVFileMonitorClass
+{
+    GFileMonitorClass parent_class;
+};
+
+G_DEFINE_TYPE(FmMenuVFileMonitor, fm_vfs_menu_file_monitor, G_TYPE_FILE_MONITOR);
+
+static void fm_vfs_menu_file_monitor_finalize(GObject *object)
+{
+    FmMenuVFileMonitor *mon = FM_MENU_VFILE_MONITOR(object);
+
+    if(mon->cache)
+    {
+        if(mon->notifier)
+            menu_cache_remove_reload_notify(mon->cache, mon->notifier);
+        menu_cache_unref(mon->cache);
+    }
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+    if(mon->item)
+        menu_cache_item_unref(mon->item);
+#else
+    g_slist_free_full(mon->items, (GDestroyNotify)menu_cache_item_unref);
+#endif
+    g_object_unref(mon->file);
+
+    G_OBJECT_CLASS(fm_vfs_menu_file_monitor_parent_class)->finalize(object);
+}
+
+static gboolean fm_vfs_menu_file_monitor_cancel(GFileMonitor *monitor)
+{
+    FmMenuVFileMonitor *mon = FM_MENU_VFILE_MONITOR(monitor);
+
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+    if(mon->item)
+        menu_cache_item_unref(mon->item); /* rest will be done in finalizer */
+    mon->item = NULL;
+#else
+    mon->stopped = TRUE;
+#endif
+    return TRUE;
+}
+
+static void fm_vfs_menu_file_monitor_class_init(FmMenuVFileMonitorClass *klass)
+{
+    GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+    GFileMonitorClass *gfilemon_class = G_FILE_MONITOR_CLASS (klass);
+
+    gobject_class->finalize = fm_vfs_menu_file_monitor_finalize;
+    gfilemon_class->cancel = fm_vfs_menu_file_monitor_cancel;
+}
+
+static void fm_vfs_menu_file_monitor_init(FmMenuVFileMonitor *item)
+{
+    /* nothing */
+}
+
+static FmMenuVFileMonitor *_fm_menu_vfile_monitor_new(void)
+{
+    return (FmMenuVFileMonitor*)g_object_new(FM_TYPE_MENU_VFILE_MONITOR, NULL);
+}
+
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+static void _reload_notify_handler(MenuCache* cache, gpointer user_data)
+#else
+static void _reload_notify_handler(gpointer cache, gpointer user_data)
+#endif
+{
+    FmMenuVFileMonitor *mon = FM_MENU_VFILE_MONITOR(user_data);
+    GSList *items, *new_items, *ol, *nl;
+    MenuCacheItem *dir;
+    GFile *file;
+    const char *de_name;
+    guint32 de_flag;
+
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+    if(mon->item == NULL) /* menu folder was destroyed or monitor cancelled */
+        return;
+    dir = mon->item;
+    if(mon->file->path)
+        mon->item = _vfile_path_to_menu_cache_item(cache, mon->file->path);
+    else
+        mon->item = MENU_CACHE_ITEM(menu_cache_dup_root_dir(cache));
+    if(mon->item && menu_cache_item_get_type(mon->item) != MENU_CACHE_TYPE_DIR)
+    {
+        menu_cache_item_unref(mon->item);
+        mon->item = NULL;
+    }
+    if(mon->item == NULL) /* folder was destroyed - emit event and exit */
+    {
+        menu_cache_item_unref(dir);
+        g_file_monitor_emit_event(G_FILE_MONITOR(mon), G_FILE(mon->file), NULL,
+                                  G_FILE_MONITOR_EVENT_DELETED);
+        return;
+    }
+    items = menu_cache_dir_list_children(MENU_CACHE_DIR(dir));
+    menu_cache_item_unref(dir);
+    new_items = menu_cache_dir_list_children(MENU_CACHE_DIR(mon->item));
+#else
+    if(mon->stopped) /* menu folder was destroyed or monitor cancelled */
+        return;
+    if(mon->file->path)
+        dir = _vfile_path_to_menu_cache_item(cache, mon->file->path);
+    else
+        dir = MENU_CACHE_ITEM(menu_cache_get_root_dir(cache));
+    if(dir == NULL) /* folder was destroyed - emit event and exit */
+    {
+        mon->stopped = TRUE;
+        g_file_monitor_emit_event(G_FILE_MONITOR(mon), G_FILE(mon->file), NULL,
+                                  G_FILE_MONITOR_EVENT_DELETED);
+        return;
+    }
+    /* emit change on the folder in any case */
+    g_file_monitor_emit_event(G_FILE_MONITOR(mon), G_FILE(mon->file), NULL,
+                              G_FILE_MONITOR_EVENT_CHANGED);
+    items = mon->items;
+    mon->items = g_slist_copy_deep(menu_cache_dir_get_children(MENU_CACHE_DIR(dir)),
+                                   (GCopyFunc)menu_cache_item_ref, NULL);
+    new_items = g_slist_copy_deep(mon->items, (GCopyFunc)menu_cache_item_ref, NULL);
+#endif
+    for (ol = items; ol; ) /* remove all separatorts first */
+    {
+        nl = ol->next;
+        if (menu_cache_item_get_id(ol->data) == NULL)
+        {
+            menu_cache_item_unref(ol->data);
+            items = g_slist_delete_link(items, ol);
+        }
+        ol = nl;
+    }
+    for (ol = new_items; ol; )
+    {
+        nl = ol->next;
+        if (menu_cache_item_get_id(ol->data) == NULL)
+        {
+            menu_cache_item_unref(ol->data);
+            new_items = g_slist_delete_link(new_items, ol);
+        }
+        ol = nl;
+    }
+    /* we have two copies of lists now, compare them and emit events */
+    ol = items;
+    de_name = g_getenv("XDG_CURRENT_DESKTOP");
+    if(de_name)
+        de_flag = menu_cache_get_desktop_env_flag(cache, de_name);
+    else
+        de_flag = (guint32)-1;
+    while (ol)
+    {
+        for (nl = new_items; nl; nl = nl->next)
+            if (strcmp(menu_cache_item_get_id(ol->data),
+                       menu_cache_item_get_id(nl->data)) == 0)
+                break; /* the same id found */
+        if (nl)
+        {
+            /* check if any visible attribute of it was changed */
+            if (g_strcmp0(menu_cache_item_get_name(ol->data),
+                          menu_cache_item_get_name(nl->data)) == 0 ||
+                g_strcmp0(menu_cache_item_get_icon(ol->data),
+                          menu_cache_item_get_icon(nl->data)) == 0 ||
+                menu_cache_app_get_is_visible(ol->data, de_flag) !=
+                                menu_cache_app_get_is_visible(nl->data, de_flag))
+            {
+                file = _fm_vfs_menu_resolve_relative_path(G_FILE(mon->file),
+                                             menu_cache_item_get_id(nl->data));
+                g_file_monitor_emit_event(G_FILE_MONITOR(mon), file, NULL,
+                                          G_FILE_MONITOR_EVENT_ATTRIBUTE_CHANGED);
+                g_object_unref(file);
+            }
+            /* free both new and old from the list */
+            menu_cache_item_unref(nl->data);
+            new_items = g_slist_delete_link(new_items, nl);
+            nl = ol->next; /* use 'nl' as storage */
+            menu_cache_item_unref(ol->data);
+            items = g_slist_delete_link(items, ol);
+            ol = nl;
+        }
+        else /* id not found (removed), go to next */
+            ol = ol->next;
+    }
+    /* emit events for removed files */
+    while (items)
+    {
+        file = _fm_vfs_menu_resolve_relative_path(G_FILE(mon->file),
+                                             menu_cache_item_get_id(items->data));
+        g_file_monitor_emit_event(G_FILE_MONITOR(mon), file, NULL,
+                                  G_FILE_MONITOR_EVENT_DELETED);
+        g_object_unref(file);
+        menu_cache_item_unref(items->data);
+        items = g_slist_delete_link(items, items);
+    }
+    /* emit events for added files */
+    while (new_items)
+    {
+        file = _fm_vfs_menu_resolve_relative_path(G_FILE(mon->file),
+                                     menu_cache_item_get_id(new_items->data));
+        g_file_monitor_emit_event(G_FILE_MONITOR(mon), file, NULL,
+                                  G_FILE_MONITOR_EVENT_CREATED);
+        g_object_unref(file);
+        menu_cache_item_unref(new_items->data);
+        new_items = g_slist_delete_link(new_items, new_items);
+    }
+}
+
+static gboolean _fm_vfs_menu_monitor_dir_real(gpointer data)
+{
+    FmVfsMenuMainThreadData *init = data;
+    FmMenuVFileMonitor *mon;
+#if !MENU_CACHE_CHECK_VERSION(0, 4, 0)
+    MenuCacheItem *dir;
+#endif
+
+    init->result = NULL;
+    if(g_cancellable_set_error_if_cancelled(init->cancellable, init->error))
+        return FALSE;
+    /* open menu cache instance */
+    mon = _fm_menu_vfile_monitor_new();
+    if(mon == NULL) /* out of memory! */
+        return FALSE;
+    mon->file = FM_MENU_VFILE(g_object_ref(init->destination));
+    mon->cache = _get_menu_cache(init->error);
+    if(mon->cache == NULL)
+        goto _fail;
+    /* check if requested path exists within cache */
+#if MENU_CACHE_CHECK_VERSION(0, 4, 0)
+    if(mon->file->path)
+        mon->item = _vfile_path_to_menu_cache_item(mon->cache, mon->file->path);
+    else
+        mon->item = MENU_CACHE_ITEM(menu_cache_dup_root_dir(mon->cache));
+    if(mon->item == NULL || menu_cache_item_get_type(mon->item) != MENU_CACHE_TYPE_DIR)
+#else
+    if(mon->file->path)
+        dir = _vfile_path_to_menu_cache_item(mon->cache, mon->file->path);
+    else
+        dir = MENU_CACHE_ITEM(menu_cache_get_root_dir(mon->cache));
+    if(dir == NULL)
+#endif
+    {
+        g_set_error(init->error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                    _("FmMenuVFileMonitor: folder '%s' not found in menu cache"),
+                    mon->file->path);
+        goto _fail;
+    }
+#if !MENU_CACHE_CHECK_VERSION(0, 4, 0)
+    /* for old libmenu-cache we have no choice but copy all the data right now */
+    mon->items = g_slist_copy_deep(menu_cache_dir_get_children(MENU_CACHE_DIR(dir)),
+                                   (GCopyFunc)menu_cache_item_ref, NULL);
+#endif
+    if(g_cancellable_set_error_if_cancelled(init->cancellable, init->error))
+        goto _fail;
+    /* current directory contents belong to mon->item now */
+    /* attach reload notify handler */
+    mon->notifier = menu_cache_add_reload_notify(mon->cache,
+                                                 &_reload_notify_handler, mon);
+    init->result = mon;
+    return TRUE;
+
+_fail:
+    g_object_unref(mon);
+    return FALSE;
+}
+
+static GFileMonitor *_fm_vfs_menu_monitor_dir(GFile *file,
+                                              GFileMonitorFlags flags,
+                                              GCancellable *cancellable,
+                                              GError **error)
+{
+    FmVfsMenuMainThreadData enu;
+
+    /* g_debug("_fm_vfs_menu_monitor_dir %s", FM_MENU_VFILE(file)->path); */
+    enu.cancellable = cancellable;
+    enu.error = error;
+    // enu.flags = flags;
+    enu.destination = FM_MENU_VFILE(file);
+    RUN_WITH_MENU_CACHE(_fm_vfs_menu_monitor_dir_real, &enu);
+    return (GFileMonitor*)enu.result;
+}
+
+static GFileMonitor *_fm_vfs_menu_monitor_file(GFile *file,
+                                               GFileMonitorFlags flags,
+                                               GCancellable *cancellable,
+                                               GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return NULL;
+}
+
+#if GLIB_CHECK_VERSION(2, 22, 0)
+static GFileIOStream *_fm_vfs_menu_open_readwrite(GFile *file,
+                                                  GCancellable *cancellable,
+                                                  GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return NULL;
+}
+
+static GFileIOStream *_fm_vfs_menu_create_readwrite(GFile *file,
+                                                    GFileCreateFlags flags,
+                                                    GCancellable *cancellable,
+                                                    GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return NULL;
+}
+
+static GFileIOStream *_fm_vfs_menu_replace_readwrite(GFile *file,
+                                                     const char *etag,
+                                                     gboolean make_backup,
+                                                     GFileCreateFlags flags,
+                                                     GCancellable *cancellable,
+                                                     GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return NULL;
+}
+#endif /* Glib >= 2.22 */
+
+static void fm_menu_g_file_init(GFileIface *iface)
+{
+    GFileAttributeInfoList *list;
+
+    iface->dup = _fm_vfs_menu_dup;
+    iface->hash = _fm_vfs_menu_hash;
+    iface->equal = _fm_vfs_menu_equal;
+    iface->is_native = _fm_vfs_menu_is_native;
+    iface->has_uri_scheme = _fm_vfs_menu_has_uri_scheme;
+    iface->get_uri_scheme = _fm_vfs_menu_get_uri_scheme;
+    iface->get_basename = _fm_vfs_menu_get_basename;
+    iface->get_path = _fm_vfs_menu_get_path;
+    iface->get_uri = _fm_vfs_menu_get_uri;
+    iface->get_parse_name = _fm_vfs_menu_get_parse_name;
+    iface->get_parent = _fm_vfs_menu_get_parent;
+    iface->prefix_matches = _fm_vfs_menu_prefix_matches;
+    iface->get_relative_path = _fm_vfs_menu_get_relative_path;
+    iface->resolve_relative_path = _fm_vfs_menu_resolve_relative_path;
+    iface->get_child_for_display_name = _fm_vfs_menu_get_child_for_display_name;
+    iface->enumerate_children = _fm_vfs_menu_enumerate_children;
+    iface->query_info = _fm_vfs_menu_query_info;
+    iface->query_filesystem_info = _fm_vfs_menu_query_filesystem_info;
+    iface->find_enclosing_mount = _fm_vfs_menu_find_enclosing_mount;
+    iface->set_display_name = _fm_vfs_menu_set_display_name;
+    iface->query_settable_attributes = _fm_vfs_menu_query_settable_attributes;
+    iface->query_writable_namespaces = _fm_vfs_menu_query_writable_namespaces;
+    iface->set_attribute = _fm_vfs_menu_set_attribute;
+    iface->set_attributes_from_info = _fm_vfs_menu_set_attributes_from_info;
+    iface->read_fn = _fm_vfs_menu_read_fn;
+    iface->append_to = _fm_vfs_menu_append_to;
+    iface->create = _fm_vfs_menu_create;
+    iface->replace = _fm_vfs_menu_replace;
+    iface->delete_file = _fm_vfs_menu_delete_file;
+    iface->trash = _fm_vfs_menu_trash;
+    iface->make_directory = _fm_vfs_menu_make_directory;
+    iface->make_symbolic_link = _fm_vfs_menu_make_symbolic_link;
+    iface->copy = _fm_vfs_menu_copy;
+    iface->move = _fm_vfs_menu_move;
+    iface->monitor_dir = _fm_vfs_menu_monitor_dir;
+    iface->monitor_file = _fm_vfs_menu_monitor_file;
+#if GLIB_CHECK_VERSION(2, 22, 0)
+    iface->open_readwrite = _fm_vfs_menu_open_readwrite;
+    iface->create_readwrite = _fm_vfs_menu_create_readwrite;
+    iface->replace_readwrite = _fm_vfs_menu_replace_readwrite;
+    iface->supports_thread_contexts = TRUE;
+#endif /* Glib >= 2.22 */
+
+    list = g_file_attribute_info_list_new();
+    g_file_attribute_info_list_add(list, G_FILE_ATTRIBUTE_STANDARD_IS_HIDDEN,
+                                   G_FILE_ATTRIBUTE_TYPE_BOOLEAN,
+                                   G_FILE_ATTRIBUTE_INFO_COPY_WHEN_MOVED);
+    g_file_attribute_info_list_add(list, G_FILE_ATTRIBUTE_STANDARD_ICON,
+                                   G_FILE_ATTRIBUTE_TYPE_OBJECT,
+                                   G_FILE_ATTRIBUTE_INFO_COPY_WHEN_MOVED);
+    _fm_vfs_menu_settable_attributes = list;
+}
+
+
+/* ---- FmFile implementation ---- */
+static gboolean _fm_vfs_menu_wants_incremental(GFile* file)
+{
+    return FALSE;
+}
+
+static void fm_menu_fm_file_init(FmFileInterface *iface)
+{
+    iface->wants_incremental = _fm_vfs_menu_wants_incremental;
+}
+
+
+/* ---- interface for loading ---- */
+GFile *_fm_vfs_menu_new_for_uri(const char *uri)
+{
+    FmMenuVFile *item = _fm_menu_vfile_new();
+
+    if(uri == NULL)
+        uri = "";
+    /* skip menu:/ */
+    if(g_ascii_strncasecmp(uri, "menu:", 5) == 0)
+        uri += 5;
+    while(*uri == '/')
+        uri++;
+    /* skip "applications/" or "applications.menu/" */
+    if(g_ascii_strncasecmp(uri, "applications", 12) == 0)
+    {
+        uri += 12;
+        if(g_ascii_strncasecmp(uri, ".menu", 5) == 0)
+            uri += 5;
+    }
+    while(*uri == '/') /* skip starting slashes */
+        uri++;
+    /* save the rest of path, NULL means the root path */
+    if(*uri)
+    {
+        char *end;
+
+        item->path = g_strdup(uri);
+        for(end = item->path + strlen(item->path); end > item->path; end--)
+            if(end[-1] == '/') /* skip trailing slashes */
+                end[-1] = '\0';
+            else
+                break;
+    }
+    /* g_debug("_fm_vfs_menu_new_for_uri %s -> %s", uri, item->path); */
+    return (GFile*)item;
+}

--- a/libfm-qt/core/vfs/vfs-search.c
+++ b/libfm-qt/core/vfs/vfs-search.c
@@ -1,0 +1,1356 @@
+/*
+ *      fm-vfs-search.c
+ * 
+ *      Copyright 2012 Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *      Copyright 2010 Shae Smittle <starfall87@gmail.com>
+ *
+ *      This library is free software; you can redistribute it and/or
+ *      modify it under the terms of the GNU Lesser General Public
+ *      License as published by the Free Software Foundation; either
+ *      version 2.1 of the License, or (at your option) any later version.
+ *
+ *      This library is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *      Lesser General Public License for more details.
+ *
+ *      You should have received a copy of the GNU Lesser General Public
+ *      License along with this library; if not, write to the Free Software
+ *      Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "fm-file.h"
+
+#include <glib/gi18n-lib.h>
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <time.h>
+
+#define _GNU_SOURCE /* for FNM_CASEFOLD in fnmatch.h, a GNU extension */
+#include <fnmatch.h>
+
+#if __GNUC__ >= 4
+#pragma GCC diagnostic ignored "-Wcomment" /* for comments below */
+#endif
+
+/* ---- Classes structures ---- */
+typedef struct _FmSearchIntIter FmSearchIntIter;
+
+struct _FmSearchIntIter
+{
+    FmSearchIntIter *parent; /* recursion path */
+    GFile *folder_path; /* path to folder */
+    GFileEnumerator *enu; /* children enumerator */
+};
+
+#define FM_TYPE_VFS_SEACRH_ENUMERATOR      (fm_vfs_search_enumerator_get_type())
+#define FM_VFS_SEACRH_ENUMERATOR(o)        (G_TYPE_CHECK_INSTANCE_CAST((o),\
+                            FM_TYPE_VFS_SEACRH_ENUMERATOR, FmVfsSearchEnumerator))
+
+typedef struct _FmVfsSearchEnumerator         FmVfsSearchEnumerator;
+typedef struct _FmVfsSearchEnumeratorClass    FmVfsSearchEnumeratorClass;
+
+struct _FmVfsSearchEnumerator
+{
+    GFileEnumerator parent;
+
+    FmSearchIntIter* iter;
+    char* attributes;
+    GFileQueryInfoFlags flags;
+    GSList* target_folders; /* GFile */
+    char** name_patterns;
+    GRegex* name_regex;
+    char* content_pattern;
+    GRegex* content_regex;
+    char** mime_types;
+    guint64 min_mtime;
+    guint64 max_mtime;
+    guint64 min_size;
+    guint64 max_size;
+    gboolean name_case_insensitive : 1;
+    gboolean content_case_insensitive : 1;
+    gboolean recursive : 1;
+    gboolean show_hidden : 1;
+};
+
+struct _FmVfsSearchEnumeratorClass
+{
+    GFileEnumeratorClass parent_class;
+};
+
+
+#define FM_TYPE_SEARCH_VFILE           (fm_vfs_search_file_get_type())
+#define FM_SEARCH_VFILE(o)             (G_TYPE_CHECK_INSTANCE_CAST((o), \
+                                        FM_TYPE_SEARCH_VFILE, FmSearchVFile))
+
+typedef struct _FmSearchVFile           FmSearchVFile;
+typedef struct _FmSearchVFileClass      FmSearchVFileClass;
+
+static GType fm_vfs_search_file_get_type (void);
+
+struct _FmSearchVFile
+{
+    GObject parent_object;
+
+    char *path; /* full search path */
+    GFile *current; /* last scanned directory */
+};
+
+struct _FmSearchVFileClass
+{
+  GObjectClass parent_class;
+};
+
+
+/* beforehand declarations */
+static gboolean fm_search_job_match_file(FmVfsSearchEnumerator * priv,
+                                         GFileInfo * info, GFile * parent,
+                                         GCancellable *cancellable,
+                                         GError **error);
+static void fm_search_job_match_folder(FmVfsSearchEnumerator * priv,
+                                       GFile * folder_path,
+                                       GCancellable *cancellable,
+                                       GError **error);
+static void parse_search_uri(FmVfsSearchEnumerator* priv, const char* uri_str);
+
+
+/* ---- Directory iterator ---- */
+/* caller should g_object_ref(folder_path) if success */
+static inline FmSearchIntIter *_search_iter_new(FmSearchIntIter *parent,
+                                                const char *attributes,
+                                                GFileQueryInfoFlags flags,
+                                                GFile *folder_path,
+                                                GCancellable *cancellable,
+                                                GError **error)
+{
+    GFileEnumerator *enu;
+    FmSearchIntIter *iter;
+
+    enu = g_file_enumerate_children(folder_path, attributes, flags,
+                                    cancellable, error);
+    if(enu == NULL)
+        return NULL;
+    iter = g_slice_new(FmSearchIntIter);
+    iter->parent = parent;
+    iter->folder_path = folder_path;
+    iter->enu = enu;
+    return iter;
+}
+
+static inline void _search_iter_free(FmSearchIntIter *iter, GCancellable *cancellable)
+{
+    g_file_enumerator_close(iter->enu, cancellable, NULL);
+    g_object_unref(iter->enu);
+    g_object_unref(iter->folder_path);
+    g_slice_free(FmSearchIntIter, iter);
+}
+
+
+/* ---- search enumerator class ---- */
+static GType fm_vfs_search_enumerator_get_type   (void);
+
+G_DEFINE_TYPE(FmVfsSearchEnumerator, fm_vfs_search_enumerator, G_TYPE_FILE_ENUMERATOR)
+
+static void _fm_vfs_search_enumerator_dispose(GObject *object)
+{
+    FmVfsSearchEnumerator *priv = FM_VFS_SEACRH_ENUMERATOR(object);
+    FmSearchIntIter *iter;
+
+    while((iter = priv->iter))
+    {
+        priv->iter = iter->parent;
+        _search_iter_free(iter, NULL);
+    }
+
+    if(priv->attributes)
+    {
+        g_free(priv->attributes);
+        priv->attributes = NULL;
+    }
+
+    if(priv->target_folders)
+    {
+        g_slist_foreach(priv->target_folders, (GFunc)g_object_unref, NULL);
+        g_slist_free(priv->target_folders);
+        priv->target_folders = NULL;
+    }
+
+    if(priv->name_patterns)
+    {
+        g_strfreev(priv->name_patterns);
+        priv->name_patterns = NULL;
+    }
+
+    if(priv->name_regex)
+    {
+        g_regex_unref(priv->name_regex);
+        priv->name_regex = NULL;
+    }
+
+    if(priv->content_pattern)
+    {
+        g_free(priv->content_pattern);
+        priv->content_pattern = NULL;
+    }
+
+    if(priv->content_regex)
+    {
+        g_regex_unref(priv->content_regex);
+        priv->content_regex = NULL;
+    }
+
+    if(priv->mime_types)
+    {
+        g_strfreev(priv->mime_types);
+        priv->mime_types = NULL;
+    }
+
+    G_OBJECT_CLASS(fm_vfs_search_enumerator_parent_class)->dispose(object);
+}
+
+/* The next directory that is a match with the recursive search: */
+static GFileInfo *recur_dir_match = NULL;
+
+static GFileInfo *_fm_vfs_search_enumerator_next_file(GFileEnumerator *enumerator,
+                                                      GCancellable *cancellable,
+                                                      GError **error)
+{
+    FmVfsSearchEnumerator *enu = FM_VFS_SEACRH_ENUMERATOR(enumerator);
+    FmSearchIntIter *iter;
+    GFileInfo * file_info;
+    GError *err = NULL;
+    FmSearchVFile *container;
+
+    /* g_debug("_fm_vfs_search_enumerator_next_file"); */
+    while(!g_cancellable_set_error_if_cancelled(cancellable, error))
+    {
+        iter = enu->iter;
+        if(iter == NULL) /* ended with folder */
+        {
+            if(enu->target_folders == NULL)
+                break;
+            iter = _search_iter_new(NULL, enu->attributes, enu->flags,
+                                    enu->target_folders->data,
+                                    cancellable, error);
+            if(iter == NULL)
+                break;
+            /* data is moved into iter now so free link itself */
+            enu->target_folders = g_slist_delete_link(enu->target_folders,
+                                                      enu->target_folders);
+            container = FM_SEARCH_VFILE(g_file_enumerator_get_container(enumerator));
+            if(container->current)
+                g_object_unref(container->current);
+            container->current = g_object_ref(iter->folder_path);
+            enu->iter = iter;
+        }
+
+        gboolean had_recur_dir_match = (recur_dir_match != NULL);
+        file_info = had_recur_dir_match ? recur_dir_match : g_file_enumerator_next_file(iter->enu, cancellable, &err);
+        if(file_info && g_file_info_get_name(file_info))
+        {
+            gboolean is_recursive = (enu->recursive &&
+                                    /* SF bug #969: very possibly we get multiple instances of the
+                                       same file if we follow symlink to a directory
+                                       FIXME: make it optional? */
+                                    !g_file_info_get_is_symlink(file_info) &&
+                                    g_file_info_get_file_type(file_info) == G_FILE_TYPE_DIRECTORY);
+            /* check if directory itself matches criteria */
+            if(fm_search_job_match_file(enu, file_info, iter->folder_path,
+                                        cancellable, &err))
+            {
+                g_debug("found matched: %s", g_file_info_get_name(file_info));
+                if(err == NULL && is_recursive)
+                {
+                    if(recur_dir_match)
+                    {
+                        /* directory match was found last time;
+                           search inside it recursively below */
+                        recur_dir_match = NULL;
+                    }
+                    else
+                    {
+                        /* directory match is found; remember it for the
+                           next recursive search before returning it */
+                        recur_dir_match = file_info;
+                        return file_info;
+                    }
+                }
+                else
+                    return file_info;
+            }
+
+            /* recurse upon each directory */
+            if(err == NULL && is_recursive)
+            {
+                if(enu->show_hidden || !g_file_info_get_is_hidden(file_info))
+                {
+                    const char * name = g_file_info_get_name(file_info);
+                    GFile * file = g_file_get_child(iter->folder_path, name);
+                    /* go into directory and iterate it now */
+                    fm_search_job_match_folder(enu, file, cancellable, &err);
+                    g_object_unref(file);
+                }
+            }
+
+            if(!had_recur_dir_match)
+                g_object_unref(file_info);
+            if(err == NULL)
+                continue;
+        }
+
+        if(err != NULL) /* file_info == NULL */
+        {
+            if(err->domain == G_IO_ERROR && err->code == G_IO_ERROR_PERMISSION_DENIED)
+            {
+                g_error_free(err); /* ignore this error */
+                err = NULL;
+                continue;
+            }
+            g_propagate_error(error, err);
+            break;
+        }
+        /* else end of file list - go up */
+        enu->iter = iter->parent;
+        container = FM_SEARCH_VFILE(g_file_enumerator_get_container(enumerator));
+        if(container->current)
+            g_object_unref(container->current);
+        if(enu->iter)
+            container->current = g_object_ref(enu->iter->folder_path);
+        else
+            container->current = NULL;
+        _search_iter_free(iter, cancellable);
+    }
+    return NULL;
+}
+
+static gboolean _fm_vfs_search_enumerator_close(GFileEnumerator *enumerator,
+                                              GCancellable *cancellable,
+                                              GError **error)
+{
+    recur_dir_match = NULL;
+    FmVfsSearchEnumerator *enu = FM_VFS_SEACRH_ENUMERATOR(enumerator);
+    FmSearchIntIter *iter;
+
+    while((iter = enu->iter))
+    {
+        enu->iter = iter->parent;
+        _search_iter_free(iter, cancellable);
+    }
+    return TRUE;
+}
+
+static void fm_vfs_search_enumerator_class_init(FmVfsSearchEnumeratorClass *klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS(klass);
+  GFileEnumeratorClass *enumerator_class = G_FILE_ENUMERATOR_CLASS(klass);
+
+  gobject_class->dispose = _fm_vfs_search_enumerator_dispose;
+
+  enumerator_class->next_file = _fm_vfs_search_enumerator_next_file;
+  enumerator_class->close_fn = _fm_vfs_search_enumerator_close;
+  
+}
+
+static void fm_vfs_search_enumerator_init(FmVfsSearchEnumerator *enumerator)
+{
+    /* nothing */
+}
+
+static GFileEnumerator *_fm_vfs_search_enumerator_new(GFile *file,
+                                                      const char *path_str,
+                                                      const char *attributes,
+                                                      GFileQueryInfoFlags flags,
+                                                      GError **error)
+{
+    FmVfsSearchEnumerator *enumerator;
+
+    enumerator = g_object_new(FM_TYPE_VFS_SEACRH_ENUMERATOR, "container", file, NULL);
+
+    enumerator->attributes = g_strdup(attributes);
+    enumerator->flags = flags;
+    parse_search_uri(enumerator, path_str);
+    /* FIXME: don't ignore flags */
+
+    return G_FILE_ENUMERATOR(enumerator);
+}
+
+
+/* ---- The search engine ---- */
+
+/*
+ * name: parse_date_str
+ * @str: a string in YYYY-MM-DD format
+ * Return: a time_t value
+ */
+static time_t parse_date_str(const char* str)
+{
+    int len = strlen(str);
+    if(G_LIKELY(len >= 8))
+    {
+        struct tm timeinfo = {0};
+        if(sscanf(str, "%04d-%02d-%02d", &timeinfo.tm_year, &timeinfo.tm_mon, &timeinfo.tm_mday) == 3)
+        {
+            timeinfo.tm_year -= 1900; /* should be years since 1900 */
+            --timeinfo.tm_mon; /* month should be 0-11 */
+            return mktime(&timeinfo);
+        }
+    }
+    return 0;
+}
+
+/*
+ * parse_search_uri
+ * @job
+ * @uri: a search uri
+ * 
+ * Format of a search URI is similar to that of an http URI:
+ * 
+ * search://<folder1>,<folder2>,<folder...>?<parameter1=value1>&<parameter2=value2>&...
+ * The optional parameter key/value pairs are:
+ * show_hidden=<0 or 1>: whether to search for hidden files
+ * recursive=<0 or 1>: whether to search sub folders recursively
+ * name=<patterns>: patterns of filenames, separated by comma
+ * name_regex=<regular expression>: regular expression
+ * name_case_sensitive=<0 or 1>
+ * content=<content pattern>: search for files containing the pattern
+ * content_regex=<regular expression>: regular expression
+ * content_case_sensitive=<0 or 1>
+ * mime_types=<mime-types>: mime-types to search for, can use /* (ex: image/*), separated by ';'
+ * min_size=<bytes>
+ * max_size=<bytes>
+ * min_mtime=YYYY-MM-DD
+ * max_mtime=YYYY-MM-DD
+ * 
+ * An example to search all *.desktop files in /usr/share and /usr/local/share
+ * can be written like this:
+ * 
+ * search:///usr/share,/usr/local/share?recursive=1&show_hidden=0&name=*.desktop&name_ci=0
+ * 
+ * If the folder paths and parameters contain invalid characters for a
+ * URI, they should be escaped.
+ * 
+ */
+static void parse_search_uri(FmVfsSearchEnumerator* priv, const char* uri_str)
+{
+    const char scheme[] = "search://"; /* NOTE: sizeof(scheme) includes '\0' */
+    if(g_ascii_strncasecmp(uri_str, scheme, sizeof(scheme)-1) == 0)
+    {
+        const char* p = uri_str + sizeof(scheme)-1; /* skip scheme part */
+        char* params = strchr(p, '?');
+        char* name_regex = NULL;
+        char* content_regex = NULL;
+
+        /* add folder paths */
+        while (p)
+        {
+            char* sep = strchr(p, ','); /* use , to separate multiple paths */
+            char *path;
+
+            if (sep && (params == NULL || sep < params))
+                path = g_uri_unescape_segment(p, sep, NULL);
+            else if (params != NULL)
+            {
+                path = g_uri_unescape_segment(p, params, NULL);
+                sep = NULL;
+            }
+            else
+                path = g_uri_unescape_string(p, NULL);
+            /* g_debug("target folder path: %s", path); */
+            /* add the path to target folders */
+            priv->target_folders = g_slist_prepend(priv->target_folders,
+                                                   g_file_new_for_commandline_arg(path));
+            g_free(path);
+
+            p = sep;
+            if (p) /* it's on ':' now */
+                p++;
+        }
+
+        /* priv->target_folders = g_slist_reverse(priv->target_folders); */
+
+        /* decode parameters */
+        if(params)
+        {
+            params++; /* skip '?' */
+            while(*params)
+            {
+                /* parameters are in name=value pairs */
+                char *name;
+                char* value = strchr(params, '=');
+                char* sep = strchr(params, '&');
+
+                if (value && (sep == NULL || value < sep))
+                {
+                    name = g_strndup(params, value - params);
+                    if (sep)
+                        value = g_uri_unescape_segment(value+1, sep, NULL);
+                    else
+                        value = g_uri_unescape_string(value+1, NULL);
+                }
+                else if (sep)
+                {
+                    name = g_strndup(params, sep - params);
+                    value = NULL;
+                }
+                else /* value == NULL && sep == NULL */
+                    name = g_strdup(params);
+
+                /* g_printf("parameter name/value: %s = %s\n", name, value); */
+
+                if(strcmp(name, "show_hidden") == 0)
+                    priv->show_hidden = (value[0] == '1') ? TRUE : FALSE;
+                else if(strcmp(name, "recursive") == 0)
+                    priv->recursive = (value[0] == '1') ? TRUE : FALSE;
+                else if(strcmp(name, "name") == 0)
+                    priv->name_patterns = g_strsplit(value, ",", 0);
+                else if(strcmp(name, "name_regex") == 0)
+                {
+                    g_free(name_regex);
+                    name_regex = value;
+                    value = NULL;
+                }
+                else if(strcmp(name, "name_ci") == 0)
+                    priv->name_case_insensitive = (value[0] == '1') ? TRUE : FALSE;
+                else if(strcmp(name, "content") == 0)
+                {
+                    g_free(priv->content_pattern);
+                    priv->content_pattern = value;
+                    value = NULL;
+                }
+                else if(strcmp(name, "content_regex") == 0)
+                {
+                    g_free(content_regex);
+                    content_regex = value;
+                    value = NULL;
+                }
+                else if(strcmp(name, "content_ci") == 0)
+                    priv->content_case_insensitive = (value[0] == '1') ? TRUE : FALSE;
+                else if(strcmp(name, "mime_types") == 0)
+                {
+                    priv->mime_types = g_strsplit(value, ";", -1);
+
+                    /* For mime_type patterns such as image/* and audio/*,
+                     * we move the trailing '*' to begining of the string
+                     * as a measure of optimization. Later we can detect if it's a
+                     * pattern or a full type name by checking the first char. */
+                    if(priv->mime_types)
+                    {
+                        char** pmime_type;
+                        for(pmime_type = priv->mime_types; *pmime_type; ++pmime_type)
+                        {
+                            char* mime_type = *pmime_type;
+                            int len = strlen(mime_type);
+                            /* if the mime_type is end with "/*" */
+                            if(len > 2 && /*mime_type[len - 2] == '/' &&*/ mime_type[len - 1] == '*')
+                            {
+                                /* move the trailing * to first char */
+                                memmove(mime_type + 1, mime_type, len - 1);
+                                mime_type[0] = '*';
+                            }
+                        }
+
+                        if (!g_strstr_len(priv->attributes, -1, G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE))
+                        {
+                            gchar * attributes = g_strconcat(priv->attributes, ",", G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE, NULL);
+                            g_free(priv->attributes);
+                            priv->attributes = attributes;
+                        }
+
+                    }
+                }
+                else if(strcmp(name, "min_size") == 0)
+                    priv->min_size = atoll(value);
+                else if(strcmp(name, "max_size") == 0)
+                    priv->max_size = atoll(value);
+                else if(strcmp(name, "min_mtime") == 0)
+                    priv->min_mtime = (guint64)parse_date_str(value);
+                else if(strcmp(name, "max_mtime") == 0)
+                    priv->max_mtime = (guint64)parse_date_str(value);
+
+                g_free(name);
+                g_free(value);
+
+                /* continue with the next param=value pair */
+                if(sep)
+                    params = sep + 1;
+                else
+                    break;
+            }
+
+            if(name_regex)
+            {
+                /* we set G_REGEX_RAW because GLib might cause a crash
+                   if a search is done in a non-utf8 string */
+                GRegexCompileFlags flags = G_REGEX_RAW;
+                if(priv->name_case_insensitive)
+                    flags |= G_REGEX_CASELESS;
+                priv->name_regex = g_regex_new(name_regex, flags, 0, NULL);
+                g_free(name_regex);
+            }
+
+            if(content_regex)
+            {
+                GRegexCompileFlags flags = G_REGEX_RAW; /* like above */
+                if(priv->content_case_insensitive)
+                    flags |= G_REGEX_CASELESS;
+                priv->content_regex = g_regex_new(content_regex, flags, 0, NULL);
+                g_free(content_regex);
+            }
+
+            if(priv->content_case_insensitive) /* case insensitive */
+            {
+                if(priv->content_pattern) /* make sure the pattern is lower case */
+                {
+                    char* down = g_utf8_strdown(priv->content_pattern, -1);
+                    g_free(priv->content_pattern);
+                    priv->content_pattern = down;
+                }
+            }
+        }
+    }
+}
+
+static void fm_search_job_match_folder(FmVfsSearchEnumerator * priv,
+                                       GFile * folder_path,
+                                       GCancellable *cancellable,
+                                       GError **error)
+{
+    FmSearchIntIter *iter;
+    FmSearchVFile *container;
+
+    /* FIXME: make error if NULL */
+    iter = _search_iter_new(priv->iter, priv->attributes, priv->flags, folder_path,
+                            cancellable, error);
+    if(iter == NULL) /* error */
+        return;
+    g_object_ref(folder_path); /* it's copied into iter */
+    priv->iter = iter;
+    container = FM_SEARCH_VFILE(g_file_enumerator_get_container(G_FILE_ENUMERATOR(priv)));
+    if(container->current)
+        g_object_unref(container->current);
+    container->current = g_object_ref(folder_path);
+}
+
+static gboolean fm_search_job_match_filename(FmVfsSearchEnumerator* priv, GFileInfo* info)
+{
+    gboolean ret;
+
+    /* g_debug("fm_search_job_match_filename: %s", g_file_info_get_name(info)); */
+    if(priv->name_regex)
+    {
+        const char* name = g_file_info_get_name(info);
+        ret = g_regex_match(priv->name_regex, name, 0, NULL);
+    }
+    else if(priv->name_patterns)
+    {
+        ret = FALSE;
+        const char* name = g_file_info_get_name(info);
+        char** ppattern;
+        for(ppattern = priv->name_patterns; *ppattern; ++ppattern)
+        {
+            const char* pattern = *ppattern;
+            /* FIXME: FNM_CASEFOLD is a GNU extension */
+            int flags = FNM_PERIOD;
+            if(priv->name_case_insensitive)
+                flags |= FNM_CASEFOLD;
+            if(fnmatch(pattern, name, flags) == 0)
+                ret = TRUE;
+        }
+    }
+    else
+        ret = TRUE;
+    return ret;
+}
+
+static gboolean fm_search_job_match_content_line_based(FmVfsSearchEnumerator* priv,
+                                                       GFileInfo* info,
+                                                       GInputStream* stream,
+                                                       GCancellable* cancellable,
+                                                       GError** error)
+{
+    gboolean ret = FALSE;
+    /* create a buffered data input stream for line-based I/O */
+    GDataInputStream *input_stream = g_data_input_stream_new(stream);
+    do
+    {
+        gsize line_len;
+        char* line = g_data_input_stream_read_line(input_stream, &line_len, cancellable, error);
+        if(line == NULL) /* error or EOF */
+            break;
+        if(priv->content_regex)
+        {
+            /* match using regexp */
+            ret = g_regex_match(priv->content_regex, line, 0, NULL);
+        }
+        else if(priv->content_pattern && priv->content_case_insensitive)
+        {
+            /* case insensitive search is line-based because we need to
+             * do utf8 validation + case conversion and it's easier to
+             * do with lines than with raw streams. */
+            if(g_utf8_validate(line, -1, NULL))
+            {
+                /* this whole line contains valid UTF-8 */
+                char* down = g_utf8_strdown(line, -1);
+                g_free(line);
+                line = down;
+            }
+            else /* non-UTF8, treat as ASCII */
+            {
+                char* p;
+                for(p = line; *p; ++p)
+                    *p = g_ascii_tolower(*p);
+            }
+
+            if(strstr(line, priv->content_pattern))
+                ret = TRUE;
+        }
+        g_free(line);
+    }while(ret == FALSE);
+    g_object_unref(input_stream);
+    return ret;
+}
+
+static gboolean fm_search_job_match_content_exact(FmVfsSearchEnumerator* priv,
+                                                  GFileInfo* info,
+                                                  GInputStream* stream,
+                                                  GCancellable* cancellable,
+                                                  GError** error)
+{
+    gboolean ret = FALSE;
+    char *buf, *pbuf;
+    gssize size;
+
+    /* Ensure that the allocated buffer is longer than the string being
+     * searched for. Otherwise it's not possible for the buffer to 
+     * contain a string fully matching the pattern. */
+    int pattern_len = strlen(priv->content_pattern);
+    int buf_size = pattern_len > 4095 ? pattern_len : 4095;
+    int bytes_to_read;
+
+    buf = g_new(char, buf_size + 1); /* +1 for terminating null char. */
+    bytes_to_read = buf_size;
+    pbuf = buf;
+    for(;;)
+    {
+        char* found;
+        size = g_input_stream_read(stream, pbuf, bytes_to_read, cancellable, error);
+        if(size <=0) /* EOF or error */
+            break;
+        pbuf[size] = '\0'; /* make the string null terminated */
+
+        found = strstr(buf, priv->content_pattern);
+        if(found) /* the string is found in the buffer */
+        {
+            ret = TRUE;
+            break;
+        }
+        else if(size == bytes_to_read) /* if size < bytes_to_read, we're at EOF and there are no further data. */
+        {
+            /* Preserve the last <pattern_len-1> bytes and move them to 
+             * the beginning of the buffer.
+             * Append further data after this chunk of data at next read. */
+            int preserve_len = pattern_len - 1;
+            char* buf_end = buf + buf_size;
+            memmove(buf, buf_end - preserve_len, preserve_len);
+            pbuf = buf + preserve_len;
+            bytes_to_read = buf_size - preserve_len;
+        }
+    }
+    g_free(buf);
+    return ret;
+}
+
+static gboolean fm_search_job_match_content(FmVfsSearchEnumerator* priv,
+                                            GFileInfo* info, GFile* parent,
+                                            GCancellable* cancellable,
+                                            GError** error)
+{
+    gboolean ret;
+    if(priv->content_pattern || priv->content_regex)
+    {
+        ret = FALSE;
+        if(g_file_info_get_file_type(info) == G_FILE_TYPE_REGULAR && g_file_info_get_size(info) > 0)
+        {
+            GFile* file = g_file_get_child(parent, g_file_info_get_name(info));
+            /* NOTE: I disabled mmap-based search since this could cause
+             * unexpected crashes sometimes if the mapped files are
+             * removed or changed during the search. */
+            GFileInputStream * stream = g_file_read(file, cancellable, error);
+            g_object_unref(file);
+
+            if(stream)
+            {
+                if(priv->content_pattern && !priv->content_case_insensitive)
+                {
+                    /* stream based search optimized for case sensitive
+                     * exact match. */
+                    ret = fm_search_job_match_content_exact(priv, info,
+                                                        G_INPUT_STREAM(stream),
+                                                        cancellable, error);
+                }
+                else
+                {
+                    /* grep-like regexp search and case insensitive search
+                     * are line-based. */
+                    ret = fm_search_job_match_content_line_based(priv, info,
+                                                        G_INPUT_STREAM(stream),
+                                                        cancellable, error);
+                }
+
+                g_input_stream_close(G_INPUT_STREAM(stream), cancellable, NULL);
+                g_object_unref(stream);
+            }
+        }
+    }
+    else
+        ret = TRUE;
+    return ret;
+}
+
+static gboolean fm_search_job_match_file_type(FmVfsSearchEnumerator* priv, GFileInfo* info)
+{
+    gboolean ret;
+    if(priv->mime_types)
+    {
+        const char* file_type = g_file_info_get_content_type(info);
+        char** pmime_type;
+        ret = FALSE;
+        for(pmime_type = priv->mime_types; *pmime_type; ++pmime_type)
+        {
+            const char* mime_type = *pmime_type;
+            /* For mime_type patterns such as image/* and audio/*,
+             * we move the trailing '*' to begining of the string
+             * as a measure of optimization. We can know it's a
+             * pattern not a full type name by checking the first char. */
+            if(mime_type[0] == '*')
+            {
+                if(g_str_has_prefix(file_type, mime_type + 1))
+                {
+                    ret = TRUE;
+                    break;
+                }
+            }
+            else if(g_content_type_is_a(file_type, mime_type))
+            {
+                ret = TRUE;
+                break;
+            }
+        }
+    }
+    else
+        ret = TRUE;
+    return ret;
+}
+
+static gboolean fm_search_job_match_size(FmVfsSearchEnumerator* priv, GFileInfo* info)
+{
+    guint64 size = g_file_info_get_size(info);
+    gboolean ret = TRUE;
+    if(priv->min_size > 0 && size < priv->min_size)
+        ret = FALSE;
+    else if(priv->max_size > 0 && size > priv->max_size)
+        ret = FALSE;
+    else if ((priv->min_size > 0 || priv->max_size > 0) && g_file_info_get_file_type(info) == G_FILE_TYPE_DIRECTORY)
+        ret = FALSE;
+    return ret;
+}
+
+static gboolean fm_search_job_match_mtime(FmVfsSearchEnumerator* priv, GFileInfo* info)
+{
+    gboolean ret = TRUE;
+    if(priv->min_mtime || priv->max_mtime)
+    {
+        guint64 mtime = g_file_info_get_attribute_uint64(info, G_FILE_ATTRIBUTE_TIME_MODIFIED);
+        /* g_print("file mtime: %llu, min_mtime=%llu, max_mtime=%llu\n", mtime, priv->min_mtime, priv->max_mtime); */
+        if(priv->min_mtime > 0 && mtime < priv->min_mtime)
+            ret = FALSE; /* earlier than min_mtime */
+        else if(priv->max_mtime > 0 && mtime > priv->max_mtime)
+            ret = FALSE; /* later than max_mtime */
+    }
+    return ret;
+}
+
+static gboolean fm_search_job_match_file(FmVfsSearchEnumerator * priv,
+                                         GFileInfo * info, GFile * parent,
+                                         GCancellable *cancellable,
+                                         GError **error)
+{
+    //g_print("matching file %s\n", g_file_info_get_name(info));
+
+    if(!priv->show_hidden && g_file_info_get_is_hidden(info))
+        return FALSE;
+
+    if(!fm_search_job_match_filename(priv, info))
+        return FALSE;
+
+    if(!fm_search_job_match_file_type(priv, info))
+        return FALSE;
+
+    if(!fm_search_job_match_size(priv, info))
+        return FALSE;
+
+    if(!fm_search_job_match_mtime(priv, info))
+        return FALSE;
+
+    if(!fm_search_job_match_content(priv, info, parent, cancellable, error))
+        return FALSE;
+
+    return TRUE;
+}
+
+
+/* end of rule functions */
+
+/* ---- FmSearchVFile class ---- */
+static void fm_search_g_file_init(GFileIface *iface);
+static void fm_search_fm_file_init(FmFileInterface *iface);
+
+G_DEFINE_TYPE_WITH_CODE(FmSearchVFile, fm_vfs_search_file, G_TYPE_OBJECT,
+                        G_IMPLEMENT_INTERFACE(G_TYPE_FILE, fm_search_g_file_init)
+                        G_IMPLEMENT_INTERFACE(FM_TYPE_FILE, fm_search_fm_file_init))
+
+static void fm_vfs_search_file_finalize(GObject *object)
+{
+    FmSearchVFile *item = FM_SEARCH_VFILE(object);
+
+    g_free(item->path);
+    if(item->current)
+        g_object_unref(item->current);
+
+    G_OBJECT_CLASS(fm_vfs_search_file_parent_class)->finalize(object);
+}
+
+static void fm_vfs_search_file_class_init(FmSearchVFileClass *klass)
+{
+    GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+
+    gobject_class->finalize = fm_vfs_search_file_finalize;
+}
+
+static void fm_vfs_search_file_init(FmSearchVFile *item)
+{
+    /* nothing */
+}
+
+static FmSearchVFile *_fm_search_vfile_new(void)
+{
+    return (FmSearchVFile*)g_object_new(FM_TYPE_SEARCH_VFILE, NULL);
+}
+
+
+/* ---- GFile implementation ---- */
+#define ERROR_UNSUPPORTED(err) g_set_error_literal(err, G_IO_ERROR, \
+                        G_IO_ERROR_NOT_SUPPORTED, _("Operation not supported"))
+
+static GFile *_fm_vfs_search_dup(GFile *file)
+{
+    FmSearchVFile *item, *new_item;
+
+    item = FM_SEARCH_VFILE(file);
+    new_item = _fm_search_vfile_new();
+    if(item->path)
+        new_item->path = g_strdup(item->path);
+    return (GFile*)new_item;
+}
+
+static guint _fm_vfs_search_hash(GFile *file)
+{
+    return g_str_hash(FM_SEARCH_VFILE(file)->path);
+}
+
+static gboolean _fm_vfs_search_equal(GFile *file1, GFile *file2)
+{
+    char *path1 = FM_SEARCH_VFILE(file1)->path;
+    char *path2 = FM_SEARCH_VFILE(file2)->path;
+
+    return g_str_equal(path1, path2);
+}
+
+static gboolean _fm_vfs_search_is_native(GFile *file)
+{
+    return FALSE;
+}
+
+static gboolean _fm_vfs_search_has_uri_scheme(GFile *file, const char *uri_scheme)
+{
+    return g_ascii_strcasecmp(uri_scheme, "search") == 0;
+}
+
+static char *_fm_vfs_search_get_uri_scheme(GFile *file)
+{
+    return g_strdup("search");
+}
+
+static char *_fm_vfs_search_get_basename(GFile *file)
+{
+    return g_strdup("/");
+}
+
+static char *_fm_vfs_search_get_path(GFile *file)
+{
+    return NULL;
+}
+
+static char *_fm_vfs_search_get_uri(GFile *file)
+{
+    FmSearchVFile *item = FM_SEARCH_VFILE(file);
+
+    if(item->current)
+        return g_file_get_uri(item->current);
+    return g_strdup(item->path);
+}
+
+static char *_fm_vfs_search_get_parse_name(GFile *file)
+{
+    /* FIXME: need name to be converted to UTF-8? */
+    return g_strdup(_("Search"));
+}
+
+static GFile *_fm_vfs_search_get_parent(GFile *file)
+{
+    return NULL;
+}
+
+static gboolean _fm_vfs_search_prefix_matches(GFile *prefix, GFile *file)
+{
+    return FALSE;
+}
+
+static char *_fm_vfs_search_get_relative_path(GFile *parent, GFile *descendant)
+{
+    return NULL;
+}
+
+static GFile *_fm_vfs_search_resolve_relative_path(GFile *file, const char *relative_path)
+{
+    return NULL;
+}
+
+static GFile *_fm_vfs_search_get_child_for_display_name(GFile *file,
+                                                        const char *display_name,
+                                                        GError **error)
+{
+    FmSearchVFile *new_item;
+
+    g_return_val_if_fail(file != NULL, NULL);
+
+    if (display_name == NULL || *display_name == '\0')
+        return g_object_ref(file);
+    /* just append "/"display_name to file->path */
+    new_item = _fm_search_vfile_new();
+    new_item->path = g_strdup_printf("%s/%s", FM_SEARCH_VFILE(file)->path, display_name);
+    return (GFile*)new_item;
+}
+
+static GFileEnumerator *_fm_vfs_search_enumerate_children(GFile *file,
+                                                          const char *attributes,
+                                                          GFileQueryInfoFlags flags,
+                                                          GCancellable *cancellable,
+                                                          GError **error)
+{
+    const char *path = FM_SEARCH_VFILE(file)->path;
+
+    return _fm_vfs_search_enumerator_new(file, path, attributes, flags, error);
+}
+
+static GFileInfo *_fm_vfs_search_query_info(GFile *file,
+                                            const char *attributes,
+                                            GFileQueryInfoFlags flags,
+                                            GCancellable *cancellable,
+                                            GError **error)
+{
+    GFileInfo *fileinfo = g_file_info_new();
+    GIcon* icon;
+
+    /* g_debug("_fm_vfs_search_query_info on %s", FM_SEARCH_VFILE(file)->path); */
+    /* FIXME: use matcher to set only requested data */
+    g_file_info_set_name(fileinfo, FM_SEARCH_VFILE(file)->path);
+    g_file_info_set_display_name(fileinfo, _("Search Results"));
+    icon = g_themed_icon_new("search");
+    g_file_info_set_icon(fileinfo, icon);
+    g_object_unref(icon);
+    g_file_info_set_file_type(fileinfo, G_FILE_TYPE_DIRECTORY);
+    return fileinfo;
+}
+
+static GFileInfo *_fm_vfs_search_query_filesystem_info(GFile *file,
+                                                       const char *attributes,
+                                                       GCancellable *cancellable,
+                                                       GError **error)
+{
+    /* FIXME: set some info on it */
+    ERROR_UNSUPPORTED(error);
+    return NULL;
+}
+
+static GMount *_fm_vfs_search_find_enclosing_mount(GFile *file,
+                                                   GCancellable *cancellable,
+                                                   GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return NULL;
+}
+
+static GFile *_fm_vfs_search_set_display_name(GFile *file,
+                                              const char *display_name,
+                                              GCancellable *cancellable,
+                                              GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return NULL;
+}
+
+static GFileAttributeInfoList *_fm_vfs_search_query_settable_attributes(GFile *file,
+                                                                        GCancellable *cancellable,
+                                                                        GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return NULL;
+}
+
+static GFileAttributeInfoList *_fm_vfs_search_query_writable_namespaces(GFile *file,
+                                                                        GCancellable *cancellable,
+                                                                        GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return NULL;
+}
+
+static gboolean _fm_vfs_search_set_attribute(GFile *file,
+                                             const char *attribute,
+                                             GFileAttributeType type,
+                                             gpointer value_p,
+                                             GFileQueryInfoFlags flags,
+                                             GCancellable *cancellable,
+                                             GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return FALSE;
+}
+
+static gboolean _fm_vfs_search_set_attributes_from_info(GFile *file,
+                                                        GFileInfo *info,
+                                                        GFileQueryInfoFlags flags,
+                                                        GCancellable *cancellable,
+                                                        GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return FALSE;
+}
+
+static GFileInputStream *_fm_vfs_search_read_fn(GFile *file,
+                                                GCancellable *cancellable,
+                                                GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return NULL;
+}
+
+static GFileOutputStream *_fm_vfs_search_append_to(GFile *file,
+                                                   GFileCreateFlags flags,
+                                                   GCancellable *cancellable,
+                                                   GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return NULL;
+}
+
+static GFileOutputStream *_fm_vfs_search_create(GFile *file,
+                                                GFileCreateFlags flags,
+                                                GCancellable *cancellable,
+                                                GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return NULL;
+}
+
+static GFileOutputStream *_fm_vfs_search_replace(GFile *file,
+                                                 const char *etag,
+                                                 gboolean make_backup,
+                                                 GFileCreateFlags flags,
+                                                 GCancellable *cancellable,
+                                                 GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return NULL;
+}
+
+static gboolean _fm_vfs_search_delete_file(GFile *file,
+                                           GCancellable *cancellable,
+                                           GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return FALSE;
+}
+
+static gboolean _fm_vfs_search_trash(GFile *file,
+                                     GCancellable *cancellable,
+                                     GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return FALSE;
+}
+
+static gboolean _fm_vfs_search_make_directory(GFile *file,
+                                              GCancellable *cancellable,
+                                              GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return FALSE;
+}
+
+static gboolean _fm_vfs_search_make_symbolic_link(GFile *file,
+                                                  const char *symlink_value,
+                                                  GCancellable *cancellable,
+                                                  GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return FALSE;
+}
+
+static gboolean _fm_vfs_search_copy(GFile *source,
+                                    GFile *destination,
+                                    GFileCopyFlags flags,
+                                    GCancellable *cancellable,
+                                    GFileProgressCallback progress_callback,
+                                    gpointer progress_callback_data,
+                                    GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return FALSE;
+}
+
+static gboolean _fm_vfs_search_move(GFile *source,
+                                    GFile *destination,
+                                    GFileCopyFlags flags,
+                                    GCancellable *cancellable,
+                                    GFileProgressCallback progress_callback,
+                                    gpointer progress_callback_data,
+                                    GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return FALSE;
+}
+
+static GFileMonitor *_fm_vfs_search_monitor_dir(GFile *file,
+                                                GFileMonitorFlags flags,
+                                                GCancellable *cancellable,
+                                                GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return NULL;
+}
+
+static GFileMonitor *_fm_vfs_search_monitor_file(GFile *file,
+                                                 GFileMonitorFlags flags,
+                                                 GCancellable *cancellable,
+                                                 GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return NULL;
+}
+
+#if GLIB_CHECK_VERSION(2, 22, 0)
+static GFileIOStream *_fm_vfs_search_open_readwrite(GFile *file,
+                                                    GCancellable *cancellable,
+                                                    GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return NULL;
+}
+
+static GFileIOStream *_fm_vfs_search_create_readwrite(GFile *file,
+                                                      GFileCreateFlags flags,
+                                                      GCancellable *cancellable,
+                                                      GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return NULL;
+}
+
+static GFileIOStream *_fm_vfs_search_replace_readwrite(GFile *file,
+                                                       const char *etag,
+                                                       gboolean make_backup,
+                                                       GFileCreateFlags flags,
+                                                       GCancellable *cancellable,
+                                                       GError **error)
+{
+    ERROR_UNSUPPORTED(error);
+    return NULL;
+}
+#endif /* Glib >= 2.22 */
+
+static void fm_search_g_file_init(GFileIface *iface)
+{
+    iface->dup = _fm_vfs_search_dup;
+    iface->hash = _fm_vfs_search_hash;
+    iface->equal = _fm_vfs_search_equal;
+    iface->is_native = _fm_vfs_search_is_native;
+    iface->has_uri_scheme = _fm_vfs_search_has_uri_scheme;
+    iface->get_uri_scheme = _fm_vfs_search_get_uri_scheme;
+    iface->get_basename = _fm_vfs_search_get_basename;
+    iface->get_path = _fm_vfs_search_get_path;
+    iface->get_uri = _fm_vfs_search_get_uri;
+    iface->get_parse_name = _fm_vfs_search_get_parse_name;
+    iface->get_parent = _fm_vfs_search_get_parent;
+    iface->prefix_matches = _fm_vfs_search_prefix_matches;
+    iface->get_relative_path = _fm_vfs_search_get_relative_path;
+    iface->resolve_relative_path = _fm_vfs_search_resolve_relative_path;
+    iface->get_child_for_display_name = _fm_vfs_search_get_child_for_display_name;
+    iface->enumerate_children = _fm_vfs_search_enumerate_children;
+    iface->query_info = _fm_vfs_search_query_info;
+    iface->query_filesystem_info = _fm_vfs_search_query_filesystem_info;
+    iface->find_enclosing_mount = _fm_vfs_search_find_enclosing_mount;
+    iface->set_display_name = _fm_vfs_search_set_display_name;
+    iface->query_settable_attributes = _fm_vfs_search_query_settable_attributes;
+    iface->query_writable_namespaces = _fm_vfs_search_query_writable_namespaces;
+    iface->set_attribute = _fm_vfs_search_set_attribute;
+    iface->set_attributes_from_info = _fm_vfs_search_set_attributes_from_info;
+    iface->read_fn = _fm_vfs_search_read_fn;
+    iface->append_to = _fm_vfs_search_append_to;
+    iface->create = _fm_vfs_search_create;
+    iface->replace = _fm_vfs_search_replace;
+    iface->delete_file = _fm_vfs_search_delete_file;
+    iface->trash = _fm_vfs_search_trash;
+    iface->make_directory = _fm_vfs_search_make_directory;
+    iface->make_symbolic_link = _fm_vfs_search_make_symbolic_link;
+    iface->copy = _fm_vfs_search_copy;
+    iface->move = _fm_vfs_search_move;
+    iface->monitor_dir = _fm_vfs_search_monitor_dir;
+    iface->monitor_file = _fm_vfs_search_monitor_file;
+#if GLIB_CHECK_VERSION(2, 22, 0)
+    iface->open_readwrite = _fm_vfs_search_open_readwrite;
+    iface->create_readwrite = _fm_vfs_search_create_readwrite;
+    iface->replace_readwrite = _fm_vfs_search_replace_readwrite;
+    iface->supports_thread_contexts = TRUE;
+#endif /* Glib >= 2.22 */
+}
+
+
+/* ---- FmFile implementation ---- */
+static gboolean _fm_vfs_search_wants_incremental(GFile* file)
+{
+    return TRUE;
+}
+
+static void fm_search_fm_file_init(FmFileInterface *iface)
+{
+    iface->wants_incremental = _fm_vfs_search_wants_incremental;
+}
+
+
+/* ---- interface for loading ---- */
+GFile *_fm_vfs_search_new_for_uri(const char *uri)
+{
+    FmSearchVFile *item;
+    g_return_val_if_fail(uri != NULL, NULL);
+    item = _fm_search_vfile_new();
+    item->path = g_strdup(uri);
+    return (GFile*)item;
+}

--- a/libfm-qt/core/volumemanager.cpp
+++ b/libfm-qt/core/volumemanager.cpp
@@ -1,0 +1,111 @@
+#include "volumemanager.h"
+
+namespace Fm {
+
+std::mutex VolumeManager::mutex_;
+std::weak_ptr<VolumeManager> VolumeManager::globalInstance_;
+
+VolumeManager::VolumeManager():
+    QObject(),
+    monitor_{g_volume_monitor_get(), false} {
+
+    // connect gobject signal handlers
+    g_signal_connect(monitor_.get(), "volume-added", G_CALLBACK(_onGVolumeAdded), this);
+    g_signal_connect(monitor_.get(), "volume-removed", G_CALLBACK(_onGVolumeRemoved), this);
+    g_signal_connect(monitor_.get(), "volume-changed", G_CALLBACK(_onGVolumeChanged), this);
+
+    g_signal_connect(monitor_.get(), "mount-added", G_CALLBACK(_onGMountAdded), this);
+    g_signal_connect(monitor_.get(), "mount-removed", G_CALLBACK(_onGMountRemoved), this);
+    g_signal_connect(monitor_.get(), "mount-changed", G_CALLBACK(_onGMountChanged), this);
+
+    // g_get_volume_monitor() is a slow blocking call, so call it in a low priority thread
+    auto job = new GetGVolumeMonitorJob();
+    job->setAutoDelete(true);
+    connect(job, &GetGVolumeMonitorJob::finished, this, &VolumeManager::onGetGVolumeMonitorFinished, Qt::BlockingQueuedConnection);
+    job->runAsync(QThread::LowPriority);
+}
+
+VolumeManager::~VolumeManager() {
+    if(monitor_) {
+        g_signal_handlers_disconnect_by_data(monitor_.get(), this);
+    }
+}
+
+std::shared_ptr<VolumeManager> VolumeManager::globalInstance() {
+    std::lock_guard<std::mutex> lock{mutex_};
+    auto mon = globalInstance_.lock();
+    if(mon == nullptr) {
+        mon = std::make_shared<VolumeManager>();
+        globalInstance_ = mon;
+    }
+    return mon;
+}
+
+void VolumeManager::onGetGVolumeMonitorFinished() {
+    auto job = static_cast<GetGVolumeMonitorJob*>(sender());
+    monitor_ = std::move(job->monitor_);
+    GList* vols = g_volume_monitor_get_volumes(monitor_.get());
+    for(GList* l = vols; l != nullptr; l = l->next) {
+        volumes_.push_back(Volume{G_VOLUME(l->data), false});
+        Q_EMIT volumeAdded(volumes_.back());
+    }
+    g_list_free(vols);
+
+    GList* mnts = g_volume_monitor_get_mounts(monitor_.get());
+    for(GList* l = mnts; l != nullptr; l = l->next) {
+        mounts_.push_back(Mount{G_MOUNT(l->data), false});
+        Q_EMIT mountAdded(mounts_.back());
+    }
+    g_list_free(mnts);
+}
+
+void VolumeManager::onGVolumeAdded(GVolume* vol) {
+    if(std::find(volumes_.cbegin(), volumes_.cend(), vol) != volumes_.cend())
+        return;
+    volumes_.push_back(Volume{vol, true});
+    Q_EMIT volumeAdded(volumes_.back());
+}
+
+void VolumeManager::onGVolumeRemoved(GVolume* vol) {
+    auto it = std::find(volumes_.begin(), volumes_.end(), vol);
+    if(it == volumes_.end())
+        return;
+    Q_EMIT volumeRemoved(*it);
+    volumes_.erase(it);
+}
+
+void VolumeManager::onGVolumeChanged(GVolume* vol) {
+    auto it = std::find(volumes_.begin(), volumes_.end(), vol);
+    if(it == volumes_.end())
+        return;
+    Q_EMIT volumeChanged(*it);
+}
+
+void VolumeManager::onGMountAdded(GMount* mnt) {
+    if(std::find(mounts_.cbegin(), mounts_.cend(), mnt) != mounts_.cend())
+        return;
+    mounts_.push_back(Mount{mnt, true});
+    Q_EMIT mountAdded(mounts_.back());
+}
+
+void VolumeManager::onGMountRemoved(GMount* mnt) {
+    auto it = std::find(mounts_.begin(), mounts_.end(), mnt);
+    if(it == mounts_.end())
+        return;
+    Q_EMIT mountRemoved(*it);
+    mounts_.erase(it);
+}
+
+void VolumeManager::onGMountChanged(GMount* mnt) {
+    auto it = std::find(mounts_.begin(), mounts_.end(), mnt);
+    if(it == mounts_.end())
+        return;
+    Q_EMIT mountChanged(*it);
+}
+
+void VolumeManager::GetGVolumeMonitorJob::exec() {
+    monitor_ = GVolumeMonitorPtr{g_volume_monitor_get(), false};
+}
+
+
+} // namespace Fm

--- a/libfm-qt/core/volumemanager.h
+++ b/libfm-qt/core/volumemanager.h
@@ -1,0 +1,237 @@
+#ifndef FM2_VOLUMEMANAGER_H
+#define FM2_VOLUMEMANAGER_H
+
+#include "../libfmqtglobals.h"
+#include <QObject>
+#include <gio/gio.h>
+#include "gioptrs.h"
+#include "filepath.h"
+#include "iconinfo.h"
+#include "job.h"
+#include <vector>
+#include <mutex>
+
+namespace Fm {
+
+class LIBFM_QT_API Volume: public GVolumePtr {
+public:
+
+    explicit Volume(GVolume* gvol, bool addRef): GVolumePtr{gvol, addRef} {
+    }
+
+    explicit Volume(GVolumePtr gvol): GVolumePtr{std::move(gvol)} {
+    }
+
+    CStrPtr name() const {
+        return CStrPtr{g_volume_get_name(get())};
+    }
+
+    CStrPtr uuid() const {
+        return CStrPtr{g_volume_get_uuid(get())};
+    }
+
+    std::shared_ptr<const IconInfo> icon() const {
+        return IconInfo::fromGIcon(GIconPtr{g_volume_get_icon(get()), false});
+    }
+
+    // GDrive *	g_volume_get_drive(get());
+    GMountPtr mount() const {
+        return GMountPtr{g_volume_get_mount(get()), false};
+    }
+
+    bool canMount() const {
+        return g_volume_can_mount(get());
+    }
+
+    bool shouldAutoMount() const {
+        return g_volume_should_automount(get());
+    }
+
+    FilePath activationRoot() const {
+        return FilePath{g_volume_get_activation_root(get()), false};
+    }
+
+    /*
+    void	g_volume_mount(get());
+    gboolean	g_volume_mount_finish(get());
+    */
+    bool canEject() const {
+        return g_volume_can_eject(get());
+    }
+
+    /*
+    void	g_volume_eject(get());
+    gboolean	g_volume_eject_finish(get());
+    void	g_volume_eject_with_operation(get());
+    gboolean	g_volume_eject_with_operation_finish(get());
+    char **	g_volume_enumerate_identifiers(get());
+    char *	g_volume_get_identifier(get());
+    const gchar *	g_volume_get_sort_key(get());
+    */
+
+    CStrPtr device() const {
+        return CStrPtr{g_volume_get_identifier(get(), G_VOLUME_IDENTIFIER_KIND_UNIX_DEVICE)};
+    }
+
+    CStrPtr label() const {
+        return CStrPtr{g_volume_get_identifier(get(), G_VOLUME_IDENTIFIER_KIND_LABEL)};
+    }
+
+};
+
+
+class LIBFM_QT_API Mount: public GMountPtr {
+public:
+
+    explicit Mount(GMount* mnt, bool addRef): GMountPtr{mnt, addRef} {
+    }
+
+    explicit Mount(GMountPtr gmnt): GMountPtr{std::move(gmnt)} {
+    }
+
+    CStrPtr name() const {
+        return CStrPtr{g_mount_get_name(get())};
+    }
+
+    CStrPtr uuid() const {
+        return CStrPtr{g_mount_get_uuid(get())};
+    }
+
+    std::shared_ptr<const IconInfo> icon() const {
+        return IconInfo::fromGIcon(GIconPtr{g_mount_get_icon(get()), false});
+    }
+
+    // GIcon *	g_mount_get_symbolic_icon(get());
+    // GDrive *	g_mount_get_drive(get());
+    FilePath root() const {
+        return FilePath{g_mount_get_root(get()), false};
+    }
+
+    GVolumePtr volume() const {
+        return GVolumePtr{g_mount_get_volume(get()), false};
+    }
+
+    FilePath defaultLocation() const {
+        return FilePath{g_mount_get_default_location(get()), false};
+    }
+
+    bool canUnmount() const {
+        return g_mount_can_unmount(get());
+    }
+
+/*
+    void	g_mount_unmount(get());
+    gboolean	g_mount_unmount_finish(get());
+    void	g_mount_unmount_with_operation(get());
+    gboolean	g_mount_unmount_with_operation_finish(get());
+    void	g_mount_remount(get());
+    gboolean	g_mount_remount_finish(get());
+*/
+    bool canEject() const {
+        return g_mount_can_eject(get());
+    }
+
+/*
+    void	g_mount_eject(get());
+    gboolean	g_mount_eject_finish(get());
+    void	g_mount_eject_with_operation(get());
+    gboolean	g_mount_eject_with_operation_finish(get());
+*/
+    // void	g_mount_guess_content_type(get());
+    // gchar **	g_mount_guess_content_type_finish(get());
+    // gchar **	g_mount_guess_content_type_sync(get());
+
+    bool isShadowed() const {
+        return g_mount_is_shadowed(get());
+    }
+
+    // void	g_mount_shadow(get());
+    // void	g_mount_unshadow(get());
+    // const gchar *	g_mount_get_sort_key(get());
+};
+
+
+
+class LIBFM_QT_API VolumeManager : public QObject {
+    Q_OBJECT
+public:
+    explicit VolumeManager();
+
+    ~VolumeManager() override;
+
+    const std::vector<Volume>& volumes() const {
+        return volumes_;
+    }
+
+    const std::vector<Mount>& mounts() const {
+        return mounts_;
+    }
+
+    static std::shared_ptr<VolumeManager> globalInstance();
+
+Q_SIGNALS:
+    void volumeAdded(const Volume& vol);
+    void volumeRemoved(const Volume& vol);
+    void volumeChanged(const Volume& vol);
+
+    void mountAdded(const Mount& mnt);
+    void mountRemoved(const Mount& mnt);
+    void mountChanged(const Mount& mnt);
+
+public Q_SLOTS:
+
+    void onGetGVolumeMonitorFinished();
+
+private:
+
+    class GetGVolumeMonitorJob: public Job {
+    public:
+        GetGVolumeMonitorJob() {}
+        GVolumeMonitorPtr monitor_;
+    protected:
+        void exec() override;
+    };
+
+    static void _onGVolumeAdded(GVolumeMonitor* /*mon*/, GVolume* vol, VolumeManager* _this) {
+        _this->onGVolumeAdded(vol);
+    }
+    void onGVolumeAdded(GVolume* vol);
+
+    static void _onGVolumeRemoved(GVolumeMonitor* /*mon*/, GVolume* vol, VolumeManager* _this) {
+        _this->onGVolumeRemoved(vol);
+    }
+    void onGVolumeRemoved(GVolume* vol);
+
+    static void _onGVolumeChanged(GVolumeMonitor* /*mon*/, GVolume* vol, VolumeManager* _this) {
+        _this->onGVolumeChanged(vol);
+    }
+    void onGVolumeChanged(GVolume* vol);
+
+    static void _onGMountAdded(GVolumeMonitor* /*mon*/, GMount* mnt, VolumeManager* _this) {
+        _this->onGMountAdded(mnt);
+    }
+    void onGMountAdded(GMount* mnt);
+
+    static void _onGMountRemoved(GVolumeMonitor* /*mon*/, GMount* mnt, VolumeManager* _this) {
+        _this->onGMountRemoved(mnt);
+    }
+    void onGMountRemoved(GMount* mnt);
+
+    static void _onGMountChanged(GVolumeMonitor* /*mon*/, GMount* mnt, VolumeManager* _this) {
+        _this->onGMountChanged(mnt);
+    }
+    void onGMountChanged(GMount* mnt);
+
+private:
+    GVolumeMonitorPtr monitor_;
+
+    std::vector<Volume> volumes_;
+    std::vector<Mount> mounts_;
+
+    static std::mutex mutex_;
+    static std::weak_ptr<VolumeManager> globalInstance_;
+};
+
+} // namespace Fm
+
+#endif // FM2_VOLUMEMANAGER_H

--- a/libfm-qt/customactions/fileaction.cpp
+++ b/libfm-qt/customactions/fileaction.cpp
@@ -1,0 +1,616 @@
+#include "fileaction.h"
+#include <unordered_map>
+#include <QDebug>
+
+using namespace std;
+
+namespace Fm {
+
+static const char* desktop_env = nullptr; // current desktop environment
+static bool actions_loaded = false; // all actions are loaded?
+static unordered_map<const char*, shared_ptr<FileActionObject>, CStrHash, CStrEqual> all_actions; // cache all loaded actions
+
+FileActionObject::FileActionObject() {
+}
+
+FileActionObject::FileActionObject(GKeyFile* kf) {
+    name = CStrPtr{g_key_file_get_locale_string(kf, "Desktop Entry", "Name", nullptr, nullptr)};
+    tooltip = CStrPtr{g_key_file_get_locale_string(kf, "Desktop Entry", "Tooltip", nullptr, nullptr)};
+    icon = CStrPtr{g_key_file_get_locale_string(kf, "Desktop Entry", "Icon", nullptr, nullptr)};
+    desc = CStrPtr{g_key_file_get_locale_string(kf, "Desktop Entry", "Description", nullptr, nullptr)};
+    GErrorPtr err;
+    enabled = g_key_file_get_boolean(kf, "Desktop Entry", "Enabled", &err);
+    if(err) { // key not found, default to true
+        err.reset();
+        enabled = true;
+    }
+    hidden = g_key_file_get_boolean(kf, "Desktop Entry", "Hidden", nullptr);
+    suggested_shortcut = CStrPtr{g_key_file_get_string(kf, "Desktop Entry", "SuggestedShortcut", nullptr)};
+
+    condition = unique_ptr<FileActionCondition> {new FileActionCondition(kf, "Desktop Entry")};
+
+    has_parent = false;
+}
+
+FileActionObject::~FileActionObject() {
+}
+
+//static
+bool FileActionObject::is_plural_exec(const char* exec) {
+    if(!exec) {
+        return false;
+    }
+    // the first relevent code encountered in Exec parameter
+    // determines whether the command accepts singular or plural forms
+    for(int i = 0; exec[i]; ++i) {
+        char ch = exec[i];
+        if(ch == '%') {
+            ++i;
+            ch = exec[i];
+            switch(ch) {
+            case 'B':
+            case 'D':
+            case 'F':
+            case 'M':
+            case 'O':
+            case 'U':
+            case 'W':
+            case 'X':
+                return true;	// plural
+            case 'b':
+            case 'd':
+            case 'f':
+            case 'm':
+            case 'o':
+            case 'u':
+            case 'w':
+            case 'x':
+                return false;	// singular
+            default:
+                // irrelevent code, skip
+                break;
+            }
+        }
+    }
+    return false; // singular form by default
+}
+
+std::string FileActionObject::expand_str(const char* templ, const FileInfoList& files, bool for_display, std::shared_ptr<const FileInfo> first_file) {
+    if(!templ) {
+        return string{};
+    }
+    string result;
+
+    if(!first_file) {
+        first_file = files.front();
+    }
+
+    for(int i = 0; templ[i]; ++i) {
+        char ch = templ[i];
+        if(ch == '%') {
+            ++i;
+            ch = templ[i];
+            switch(ch) {
+            case 'b':	// (first) basename
+                if(for_display) {
+                    result += first_file->name();
+                }
+                else {
+                    CStrPtr quoted{g_shell_quote(first_file->name().c_str())};
+                    result += quoted.get();
+                }
+                break;
+            case 'B':	// space-separated list of basenames
+                for(auto& fi : files) {
+                    if(for_display) {
+                        result += fi->name();
+                    }
+                    else {
+                        CStrPtr quoted{g_shell_quote(fi->name().c_str())};
+                        result += quoted.get();
+                    }
+                    result += ' ';
+                }
+                if(result[result.length() - 1] == ' ') { // remove trailing space
+                    result.erase(result.length() - 1);
+                }
+                break;
+            case 'c':	// count of selected items
+                result += to_string(files.size());
+                break;
+            case 'd': {	// (first) base directory
+                // FIXME: should the base dir be a URI?
+                auto base_dir = first_file->dirPath();
+                auto str = base_dir.toString();
+                if(for_display) {
+                    // FIXME: str = Filename.display_name(str);
+                }
+                CStrPtr quoted{g_shell_quote(str.get())};
+                result += quoted.get();
+                break;
+            }
+            case 'D':	// space-separated list of base directory of each selected items
+                for(auto& fi : files) {
+                    auto base_dir = fi->dirPath();
+                    auto str = base_dir.toString();
+                    if(for_display) {
+                        // str = Filename.display_name(str);
+                    }
+                    CStrPtr quoted{g_shell_quote(str.get())};
+                    result += quoted.get();
+                    result += ' ';
+                }
+                if(result[result.length() - 1] == ' ') { // remove trailing space
+                    result.erase(result.length() - 1);
+                }
+                break;
+            case 'f': {	// (first) file name
+                auto filename = first_file->path().toString();
+                if(for_display) {
+                    // filename = Filename.display_name(filename);
+                }
+                CStrPtr quoted{g_shell_quote(filename.get())};
+                result += quoted.get();
+                break;
+            }
+            case 'F':	// space-separated list of selected file names
+                for(auto& fi : files) {
+                    auto filename = fi->path().toString();
+                    if(for_display) {
+                        // filename = Filename.display_name(filename);
+                    }
+                    CStrPtr quoted{g_shell_quote(filename.get())};
+                    result += quoted.get();
+                    result += ' ';
+                }
+                if(result[result.length() - 1] == ' ') { // remove trailing space
+                    result.erase(result.length() - 1);
+                }
+                break;
+            case 'h':	// hostname of the (first) URI
+                // FIXME: how to support this correctly?
+                // FIXME: currently we pass g_get_host_name()
+                result += g_get_host_name();
+                break;
+            case 'm':	// mimetype of the (first) selected item
+                result += first_file->mimeType()->name();
+                break;
+            case 'M':	// space-separated list of the mimetypes of the selected items
+                for(auto& fi : files) {
+                    result += fi->mimeType()->name();
+                    result += ' ';
+                }
+                break;
+            case 'n':	// username of the (first) URI
+                // FIXME: how to support this correctly?
+                result += g_get_user_name();
+                break;
+            case 'o':	// no-op operator which forces a singular form of execution when specified as first parameter,
+            case 'O':	// no-op operator which forces a plural form of execution when specified as first parameter,
+                break;
+            case 'p':	// port number of the (first) URI
+                // FIXME: how to support this correctly?
+                // result.append("0");
+                break;
+            case 's':	// scheme of the (first) URI
+                result += first_file->path().uriScheme().get();
+                break;
+            case 'u':	// (first) URI
+                result += first_file->path().uri().get();
+                break;
+            case 'U':	// space-separated list of selected URIs
+                for(auto& fi : files) {
+                    result += fi->path().uri().get();
+                    result += ' ';
+                }
+                if(result[result.length() - 1] == ' ') { // remove trailing space
+                    result.erase(result.length() - 1);
+                }
+                break;
+            case 'w': {	// (first) basename without the extension
+                auto basename = first_file->name();
+                int pos = basename.rfind('.');
+                // FIXME: handle non-UTF8 filenames
+                if(pos != -1) {
+                    basename.erase(pos, string::npos);
+                }
+                CStrPtr quoted{g_shell_quote(basename.c_str())};
+                result += quoted.get();
+                break;
+            }
+            case 'W':	// space-separated list of basenames without their extension
+                for(auto& fi : files) {
+                    auto basename = fi->name();
+                    int pos = basename.rfind('.');
+                    // FIXME: for_display ? Shell.quote(str) : str);
+                    if(pos != -1) {
+                        basename.erase(pos, string::npos);
+                    }
+                    CStrPtr quoted{g_shell_quote(basename.c_str())};
+                    result += quoted.get();
+                    result += ' ';
+                }
+                if(result[result.length() - 1] == ' ') { // remove trailing space
+                    result.erase(result.length() - 1);
+                }
+                break;
+            case 'x': {	// (first) extension
+                auto basename = first_file->name();
+                int pos = basename.rfind('.');
+                const char* ext = "";
+                if(pos >= 0) {
+                    ext = basename.c_str() + pos + 1;
+                }
+                CStrPtr quoted{g_shell_quote(ext)};
+                result += quoted.get();
+                break;
+            }
+            case 'X':	// space-separated list of extensions
+                for(auto& fi : files) {
+                    auto basename = fi->name();
+                    int pos = basename.rfind('.');
+                    const char* ext = "";
+                    if(pos >= 0) {
+                        ext = basename.c_str() + pos + 1;
+                    }
+                    CStrPtr quoted{g_shell_quote(ext)};
+                    result += quoted.get();
+                    result += ' ';
+                }
+                if(result[result.length() - 1] == ' ') { // remove trailing space
+                    result.erase(result.length() - 1);
+                }
+                break;
+            case '%':	// the % character
+                result += '%';
+                break;
+            case '\0':
+                break;
+            }
+        }
+        else {
+            result += ch;
+        }
+    }
+    return result;
+}
+
+FileAction::FileAction(GKeyFile* kf): FileActionObject{kf}, target{FILE_ACTION_TARGET_CONTEXT} {
+    type = FileActionType::ACTION;
+
+    GErrorPtr err;
+    if(g_key_file_get_boolean(kf, "Desktop Entry", "TargetContext", &err)) { // default to true
+        target |= FILE_ACTION_TARGET_CONTEXT;
+    }
+    else if(!err) { // error means the key is abscent
+        target &= ~FILE_ACTION_TARGET_CONTEXT;
+    }
+    if(g_key_file_get_boolean(kf, "Desktop Entry", "TargetLocation", nullptr)) {
+        target |= FILE_ACTION_TARGET_LOCATION;
+    }
+    if(g_key_file_get_boolean(kf, "Desktop Entry", "TargetToolbar", nullptr)) {
+        target |= FILE_ACTION_TARGET_TOOLBAR;
+    }
+    toolbar_label = CStrPtr{g_key_file_get_locale_string(kf, "Desktop Entry", "ToolbarLabel", nullptr, nullptr)};
+
+    auto profile_names = CStrArrayPtr{g_key_file_get_string_list(kf, "Desktop Entry", "Profiles", nullptr, nullptr)};
+    if(profile_names != nullptr) {
+        for(auto profile_name = profile_names.get(); *profile_name; ++profile_name) {
+            // stdout.printf("%s", profile);
+            profiles.push_back(make_shared<FileActionProfile>(kf, *profile_name));
+        }
+    }
+}
+
+std::shared_ptr<FileActionProfile> FileAction::match(const FileInfoList& files) const {
+    //qDebug() << "FileAction.match: " << id.get();
+    if(hidden || !enabled) {
+        return nullptr;
+    }
+
+    if(!condition->match(files)) {
+        return nullptr;
+    }
+    for(const auto& profile : profiles) {
+        if(profile->match(files)) {
+            //qDebug() << "  profile matched!\n\n";
+            return profile;
+        }
+    }
+    // stdout.printf("\n");
+    return nullptr;
+}
+
+FileActionMenu::FileActionMenu(GKeyFile* kf): FileActionObject{kf} {
+    type = FileActionType::MENU;
+    items_list = CStrArrayPtr{g_key_file_get_string_list(kf, "Desktop Entry", "ItemsList", nullptr, nullptr)};
+}
+
+bool FileActionMenu::match(const FileInfoList& files) const {
+    // stdout.printf("FileActionMenu.match: %s\n", id);
+    if(hidden || !enabled) {
+        return false;
+    }
+    if(!condition->match(files)) {
+        return false;
+    }
+    // stdout.printf("menu matched!: %s\n\n", id);
+    return true;
+}
+
+void FileActionMenu::cache_children(const FileInfoList& files, const char** items_list) {
+    for(; *items_list; ++items_list) {
+        const char* item_id_prefix = *items_list;
+        size_t len = strlen(item_id_prefix);
+        if(item_id_prefix[0] == '[' && item_id_prefix[len - 1] == ']') {
+            // runtime dynamic item list
+            char* output;
+            int exit_status;
+            string prefix{item_id_prefix + 1, len - 2}; // skip [ and ]
+            auto command = expand_str(prefix.c_str(), files);
+            if(g_spawn_command_line_sync(command.c_str(), &output, nullptr, &exit_status, nullptr) && exit_status == 0) {
+                CStrArrayPtr item_ids{g_strsplit(output, ";", -1)};
+                g_free(output);
+                cache_children(files, (const char**)item_ids.get());
+            }
+        }
+        else if(strcmp(item_id_prefix, "SEPARATOR") == 0) {
+            // separator item
+            cached_children.push_back(nullptr);
+        }
+        else {
+            CStrPtr item_id{g_strconcat(item_id_prefix, ".desktop", nullptr)};
+            auto it = all_actions.find(item_id.get());
+            if(it != all_actions.end()) {
+                auto child_action = it->second;
+                child_action->has_parent = true;
+                cached_children.push_back(child_action);
+                // stdout.printf("add child: %s to menu: %s\n", item_id, id);
+            }
+        }
+    }
+}
+
+std::shared_ptr<FileActionItem> FileActionItem::fromActionObject(std::shared_ptr<FileActionObject> action_obj, const FileInfoList& files) {
+    std::shared_ptr<FileActionItem> item;
+    if(action_obj->type == FileActionType::MENU) {
+        auto menu = static_pointer_cast<FileActionMenu>(action_obj);
+        if(menu->match(files)) {
+            item = make_shared<FileActionItem>(menu, files);
+            // eliminate empty menus
+            if(item->children.empty()) {
+                item = nullptr;
+            }
+        }
+    }
+    else {
+        // handle profiles here
+        auto action = static_pointer_cast<FileAction>(action_obj);
+        auto profile = action->match(files);
+        if(profile) {
+            item = make_shared<FileActionItem>(action, profile, files);
+        }
+    }
+    return item;
+}
+
+FileActionItem::FileActionItem(std::shared_ptr<FileAction> _action, std::shared_ptr<FileActionProfile> _profile, const FileInfoList& files):
+    FileActionItem{static_pointer_cast<FileActionObject>(_action), files} {
+    profile = _profile;
+}
+
+FileActionItem::FileActionItem(std::shared_ptr<FileActionMenu> menu, const FileInfoList& files):
+    FileActionItem{static_pointer_cast<FileActionObject>(menu), files} {
+    for(auto& action_obj : menu->cached_children) {
+        if(action_obj == nullptr) { // separator
+            children.push_back(nullptr);
+        }
+        else { // action item or menu
+            auto subitem = fromActionObject(action_obj, files);
+            if(subitem != nullptr) {
+                children.push_back(subitem);
+            }
+        }
+    }
+}
+
+FileActionItem::FileActionItem(std::shared_ptr<FileActionObject> _action, const FileInfoList& files) {
+    action = std::move(_action);
+    name = FileActionObject::expand_str(action->name.get(), files, true);
+    desc = FileActionObject::expand_str(action->desc.get(), files, true);
+    icon = FileActionObject::expand_str(action->icon.get(), files, false);
+}
+
+bool FileActionItem::launch(GAppLaunchContext* ctx, const FileInfoList& files, CStrPtr& output) const {
+    if(action->type == FileActionType::ACTION) {
+        if(profile != nullptr) {
+            profile->launch(ctx, files, output);
+        }
+        return true;
+    }
+    return false;
+}
+
+static void load_actions_from_dir(const char* dirname, const char* id_prefix) {
+    //qDebug() << "loading from: " << dirname << endl;
+    auto dir = g_dir_open(dirname, 0, nullptr);
+    if(dir != nullptr) {
+        for(;;) {
+            const char* name = g_dir_read_name(dir);
+            if(name == nullptr) {
+                break;
+            }
+            // found a file in file-manager/actions dir, get its full path
+            CStrPtr full_path{g_build_filename(dirname, name, nullptr)};
+            // stdout.printf("\nfound %s\n", full_path);
+
+            // see if it's a sub dir
+            if(g_file_test(full_path.get(), G_FILE_TEST_IS_DIR)) {
+                // load sub dirs recursively
+                CStrPtr new_id_prefix;
+                if(id_prefix) {
+                    new_id_prefix = CStrPtr{g_strconcat(id_prefix, "-", name, nullptr)};
+                }
+                load_actions_from_dir(full_path.get(), id_prefix ? new_id_prefix.get() : name);
+            }
+            else if(g_str_has_suffix(name, ".desktop")) {
+                CStrPtr new_id_prefix;
+                if(id_prefix) {
+                    new_id_prefix = CStrPtr{g_strconcat(id_prefix, "-", name, nullptr)};
+                }
+                const char* id = id_prefix ? new_id_prefix.get() : name;
+                // ensure that it's not already in the cache
+                if(all_actions.find(id) == all_actions.cend()) {
+                    auto kf = g_key_file_new();
+                    if(g_key_file_load_from_file(kf, full_path.get(), G_KEY_FILE_NONE, nullptr)) {
+                        auto type = CStrPtr{g_key_file_get_string(kf, "Desktop Entry", "Type", nullptr)};
+                        if(!type) {
+                            continue;
+                        }
+                        std::shared_ptr<FileActionObject> action;
+                        if(strcmp(type.get(), "Action") == 0) {
+                            action = static_pointer_cast<FileActionObject>(make_shared<FileAction>(kf));
+                            // stdout.printf("load action: %s\n", id);
+                        }
+                        else if(strcmp(type.get(), "Menu") == 0) {
+                            action = static_pointer_cast<FileActionObject>(make_shared<FileActionMenu>(kf));
+                            // stdout.printf("load menu: %s\n", id);
+                        }
+                        else {
+                            continue;
+                        }
+                        action->setId(id);
+                        all_actions.insert(make_pair(action->id.get(), action)); // add the id/action pair to hash table
+                        // stdout.printf("add to cache %s\n", id);
+                    }
+                    g_key_file_free(kf);
+                }
+                else {
+                    // stdout.printf("cache found for action: %s\n", id);
+                }
+            }
+        }
+        g_dir_close(dir);
+    }
+}
+
+void file_actions_set_desktop_env(const char* env) {
+    desktop_env = env;
+}
+
+static void load_all_actions() {
+    all_actions.clear();
+    auto dirs = g_get_system_data_dirs();
+    for(auto dir = dirs; *dir; ++dir) {
+        CStrPtr dir_path{g_build_filename(*dir, "file-manager/actions", nullptr)};
+        load_actions_from_dir(dir_path.get(), nullptr);
+    }
+    CStrPtr dir_path{g_build_filename(g_get_user_data_dir(), "file-manager/actions", nullptr)};
+    load_actions_from_dir(dir_path.get(), nullptr);
+    actions_loaded = true;
+}
+
+bool FileActionItem::compare_items(std::shared_ptr<const FileActionItem> a, std::shared_ptr<const FileActionItem> b)
+{
+    // first get the list of level-zero item names (http://www.nautilus-actions.org/?q=node/377)
+    static QStringList itemNamesList;
+    static bool level_zero_checked = false;
+    if(!level_zero_checked) {
+        level_zero_checked = true;
+        auto level_zero = CStrPtr{g_build_filename(g_get_user_data_dir(),
+                                                   "file-manager/actions/level-zero.directory", nullptr)};
+        if(g_file_test(level_zero.get(), G_FILE_TEST_IS_REGULAR)) {
+            GKeyFile* kf = g_key_file_new();
+            if(g_key_file_load_from_file(kf, level_zero.get(), G_KEY_FILE_NONE, nullptr)) {
+                auto itemsList = CStrArrayPtr{g_key_file_get_string_list(kf,
+                                                                         "Desktop Entry",
+                                                                         "ItemsList", nullptr, nullptr)};
+                if(itemsList) {
+                    for(uint i = 0; i < g_strv_length(itemsList.get()); ++i) {
+                        CStrPtr desktop_file_name{g_strconcat(itemsList.get()[i], ".desktop", nullptr)};
+                        auto desktop_file = CStrPtr{g_build_filename(g_get_user_data_dir(),
+                                                                     "file-manager/actions",
+                                                                     desktop_file_name.get(), nullptr)};
+                        GKeyFile* desktop_file_key = g_key_file_new();
+                        if(g_key_file_load_from_file(desktop_file_key, desktop_file.get(), G_KEY_FILE_NONE, nullptr)) {
+                            auto actionName = CStrPtr{g_key_file_get_locale_string(desktop_file_key,
+                                                                                   "Desktop Entry",
+                                                                                   "Name",
+                                                                                   nullptr, nullptr)};
+                            if(actionName) {
+                                itemNamesList << QString::fromUtf8(actionName.get());
+                            }
+                        }
+                        g_key_file_free(desktop_file_key);
+                    }
+                }
+            }
+            g_key_file_free(kf);
+        }
+    }
+    if(!itemNamesList.isEmpty()) {
+        int first = itemNamesList.indexOf(QString::fromStdString(a->get_name()));
+        int second = itemNamesList.indexOf(QString::fromStdString(b->get_name()));
+        if(first > -1) {
+            if(second > -1) {
+                return (first < second);
+            }
+            else {
+                return true; // list items have priority
+            }
+        }
+        else if(second > -1) {
+            return false;
+        }
+    }
+    return (a->get_name().compare(b->get_name()) < 0);
+}
+
+FileActionItemList FileActionItem::get_actions_for_files(const FileInfoList& files) {
+    if(!actions_loaded) {
+        load_all_actions();
+    }
+
+    // Iterate over all actions to establish association between parent menu
+    // and children actions, and to find out toplevel ones which are not
+    // attached to any parent menu
+    for(auto& item : all_actions) {
+        auto& action_obj = item.second;
+        // stdout.printf("id = %s\n", action_obj.id);
+        if(action_obj->type == FileActionType::MENU) { // this is a menu
+            auto menu = static_pointer_cast<FileActionMenu>(action_obj);
+            // stdout.printf("menu: %s\n", menu.name);
+            // associate child items with menus
+            menu->cache_children(files, (const char**)menu->items_list.get());
+        }
+    }
+
+    // Output the menus
+    FileActionItemList items;
+
+    for(auto& item : all_actions) {
+        auto& action_obj = item.second;
+        // only output toplevel items here
+        if(action_obj->has_parent == false) { // this is a toplevel item
+            auto item = FileActionItem::fromActionObject(action_obj, files);
+            if(item != nullptr) {
+                items.push_back(item);
+            }
+        }
+    }
+
+    // cleanup temporary data cached during menu generation
+    for(auto& item : all_actions) {
+        auto& action_obj = item.second;
+        action_obj->has_parent = false;
+        if(action_obj->type == FileActionType::MENU) {
+            auto menu = static_pointer_cast<FileActionMenu>(action_obj);
+            menu->cached_children.clear();
+        }
+    }
+
+    std::sort(items.begin(), items.end(), compare_items);
+    return items;
+}
+
+} // namespace Fm

--- a/libfm-qt/customactions/fileaction.h
+++ b/libfm-qt/customactions/fileaction.h
@@ -1,0 +1,156 @@
+#ifndef FILEACTION_H
+#define FILEACTION_H
+
+#include <glib.h>
+#include <string>
+
+#include "../core/fileinfo.h"
+#include "fileactioncondition.h"
+#include "fileactionprofile.h"
+
+namespace Fm {
+
+enum class FileActionType {
+    NONE,
+    ACTION,
+    MENU
+};
+
+
+enum FileActionTarget {
+    FILE_ACTION_TARGET_NONE,
+    FILE_ACTION_TARGET_CONTEXT = 1,
+    FILE_ACTION_TARGET_LOCATION = 1 << 1,
+    FILE_ACTION_TARGET_TOOLBAR = 1 << 2
+};
+
+
+class FileActionObject {
+public:
+    explicit FileActionObject();
+
+    explicit FileActionObject(GKeyFile* kf);
+
+    virtual ~FileActionObject();
+
+    void setId(const char* _id) {
+        id = CStrPtr{g_strdup(_id)};
+    }
+
+    static bool is_plural_exec(const char* exec);
+
+    static std::string expand_str(const char* templ, const FileInfoList& files, bool for_display = false, std::shared_ptr<const FileInfo> first_file = nullptr);
+
+    FileActionType type;
+    CStrPtr id;
+    CStrPtr name;
+    CStrPtr tooltip;
+    CStrPtr icon;
+    CStrPtr desc;
+    bool enabled;
+    bool hidden;
+    CStrPtr suggested_shortcut;
+    std::unique_ptr<FileActionCondition> condition;
+
+    // values cached during menu generation
+    bool has_parent;
+};
+
+
+class FileAction: public FileActionObject {
+public:
+
+    FileAction(GKeyFile* kf);
+
+    std::shared_ptr<FileActionProfile> match(const FileInfoList& files) const;
+
+    int target; // bitwise or of FileActionTarget
+    CStrPtr toolbar_label;
+
+    // FIXME: currently we don't support dynamic profiles
+    std::vector<std::shared_ptr<FileActionProfile>> profiles;
+};
+
+
+class FileActionMenu : public FileActionObject {
+public:
+
+    FileActionMenu(GKeyFile* kf);
+
+    bool match(const FileInfoList &files) const;
+
+    // called during menu generation
+    void cache_children(const FileInfoList &files, const char** items_list);
+
+    CStrArrayPtr items_list;
+
+    // values cached during menu generation
+    std::vector<std::shared_ptr<FileActionObject>> cached_children;
+};
+
+
+class FileActionItem {
+public:
+
+    static std::shared_ptr<FileActionItem> fromActionObject(std::shared_ptr<FileActionObject> action_obj, const FileInfoList &files);
+
+    FileActionItem(std::shared_ptr<FileAction> _action, std::shared_ptr<FileActionProfile> _profile, const FileInfoList& files);
+
+    FileActionItem(std::shared_ptr<FileActionMenu> menu, const FileInfoList& files);
+
+    FileActionItem(std::shared_ptr<FileActionObject> _action, const FileInfoList& files);
+
+    const std::string& get_name() const {
+        return name;
+    }
+
+    const std::string& get_desc() const {
+        return desc;
+    }
+
+    const std::string& get_icon() const {
+        return icon;
+    }
+
+    const char* get_id() const {
+        return action->id.get();
+    }
+
+    FileActionTarget get_target() const {
+        if(action->type == FileActionType::ACTION) {
+            return FileActionTarget(static_cast<FileAction*>(action.get())->target);
+        }
+        return FILE_ACTION_TARGET_CONTEXT;
+    }
+
+    bool is_menu() const {
+        return (action->type == FileActionType::MENU);
+    }
+
+    bool is_action() const {
+        return (action->type == FileActionType::ACTION);
+    }
+
+    bool launch(GAppLaunchContext *ctx, const FileInfoList &files, CStrPtr &output) const;
+
+    const std::vector<std::shared_ptr<const FileActionItem>>& get_sub_items() const {
+        return children;
+    }
+
+    static bool compare_items(std::shared_ptr<const FileActionItem> a, std::shared_ptr<const FileActionItem> b);
+    static std::vector<std::shared_ptr<const FileActionItem>> get_actions_for_files(const FileInfoList& files);
+
+    std::string name;
+    std::string desc;
+    std::string icon;
+    std::shared_ptr<FileActionObject> action;
+    std::shared_ptr<FileActionProfile> profile; // only used by action item
+    std::vector<std::shared_ptr<const FileActionItem>> children; // only used by menu
+};
+
+typedef std::vector<std::shared_ptr<const FileActionItem>> FileActionItemList;
+
+} // namespace Fm
+
+
+#endif // FILEACTION_H

--- a/libfm-qt/customactions/fileactioncondition.cpp
+++ b/libfm-qt/customactions/fileactioncondition.cpp
@@ -1,0 +1,508 @@
+#include "fileactioncondition.h"
+#include "fileaction.h"
+#include <string>
+
+
+using namespace std;
+
+namespace Fm {
+
+FileActionCondition::FileActionCondition(GKeyFile *kf, const char* group) {
+    only_show_in = CStrArrayPtr{g_key_file_get_string_list(kf, group, "OnlyShowIn", nullptr, nullptr)};
+    not_show_in = CStrArrayPtr{g_key_file_get_string_list(kf, group, "NotShowIn", nullptr, nullptr)};
+    try_exec = CStrPtr{g_key_file_get_string(kf, group, "TryExec", nullptr)};
+    show_if_registered = CStrPtr{g_key_file_get_string(kf, group, "ShowIfRegistered", nullptr)};
+    show_if_true = CStrPtr{g_key_file_get_string(kf, group, "ShowIfTrue", nullptr)};
+    show_if_running = CStrPtr{g_key_file_get_string(kf, group, "ShowIfRunning", nullptr)};
+    mime_types = CStrArrayPtr{g_key_file_get_string_list(kf, group, "MimeTypes", nullptr, nullptr)};
+    base_names = CStrArrayPtr{g_key_file_get_string_list(kf, group, "Basenames", nullptr, nullptr)};
+    match_case = g_key_file_get_boolean(kf, group, "Matchcase", nullptr);
+
+    CStrPtr selection_count_str{g_key_file_get_string(kf, group, "SelectionCount", nullptr)};
+    if(selection_count_str != nullptr) {
+        switch(selection_count_str[0]) {
+        case '<':
+        case '>':
+        case '=':
+            selection_count_cmp = selection_count_str[0];
+            selection_count = atoi(selection_count_str.get() + 1);
+            break;
+        default:
+            selection_count_cmp = '>';
+            selection_count = 0;
+            break;
+        }
+    }
+    else {
+        selection_count_cmp = '>';
+        selection_count = 0;
+    }
+
+    schemes = CStrArrayPtr{g_key_file_get_string_list(kf, group, "Schemes", nullptr, nullptr)};
+    folders = CStrArrayPtr{g_key_file_get_string_list(kf, group, "Folders", nullptr, nullptr)};
+    auto caps = CStrArrayPtr{g_key_file_get_string_list(kf, group, "Capabilities", nullptr, nullptr)};
+
+    // FIXME: implement Capabilities support
+
+}
+
+bool FileActionCondition::match_try_exec(const FileInfoList& files) {
+    if(try_exec != nullptr) {
+        // stdout.printf("    TryExec: %s\n", try_exec);
+        CStrPtr exec_path{g_find_program_in_path(FileActionObject::expand_str(try_exec.get(), files).c_str())};
+        if(!g_file_test(exec_path.get(), G_FILE_TEST_IS_EXECUTABLE)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool FileActionCondition::match_show_if_registered(const FileInfoList& files) {
+    if(show_if_registered != nullptr) {
+        // stdout.printf("    ShowIfRegistered: %s\n", show_if_registered);
+        auto service = FileActionObject::expand_str(show_if_registered.get(), files);
+        // References:
+        // http://people.freedesktop.org/~david/eggdbus-20091014/eggdbus-interface-org.freedesktop.DBus.html#eggdbus-method-org.freedesktop.DBus.NameHasOwner
+        // glib source code: gio/tests/gdbus-names.c
+        auto con = g_bus_get_sync(G_BUS_TYPE_SESSION, nullptr, nullptr);
+        auto result = g_dbus_connection_call_sync(con,
+                                                  "org.freedesktop.DBus",
+                                                   "/org/freedesktop/DBus",
+                                                   "org.freedesktop.DBus",
+                                                   "NameHasOwner",
+                                                   g_variant_new("(s)", service.c_str()),
+                                                   g_variant_type_new("(b)"),
+                                                   G_DBUS_CALL_FLAGS_NONE,
+                                                  -1, nullptr, nullptr);
+        bool name_has_owner;
+        g_variant_get(result, "(b)", &name_has_owner);
+        g_variant_unref(result);
+        // stdout.printf("check if service: %s is in use: %d\n", service, (int)name_has_owner);
+        if(!name_has_owner) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool FileActionCondition::match_show_if_true(const FileInfoList& files) {
+    if(show_if_true != nullptr) {
+        auto cmd = FileActionObject::expand_str(show_if_true.get(), files);
+        int exit_status;
+        // FIXME: Process.spawn cannot handle shell commands. Use Posix.system() instead.
+        //if(!Process.spawn_command_line_sync(cmd, nullptr, nullptr, out exit_status)
+        //	|| exit_status != 0)
+        //	return false;
+        exit_status = system(cmd.c_str());
+        if(exit_status != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool FileActionCondition::match_show_if_running(const FileInfoList& files) {
+    if(show_if_running != nullptr) {
+        auto process_name = FileActionObject::expand_str(show_if_running.get(), files);
+        CStrPtr pgrep{g_find_program_in_path("pgrep")};
+        bool running = false;
+        // pgrep is not fully portable, but we don't have better options here
+        if(pgrep != nullptr) {
+            int exit_status;
+            // cmd = "$pgrep -x '$process_name'"
+            string cmd = pgrep.get();
+            cmd += " -x \'";
+            cmd += process_name;
+            cmd += "\'";
+            if(g_spawn_command_line_sync(cmd.c_str(), nullptr, nullptr, &exit_status, nullptr)) {
+                if(exit_status == 0) {
+                    running = true;
+                }
+            }
+        }
+        if(!running) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool FileActionCondition::match_mime_type(const FileInfoList& files, const char* type, bool negated) {
+    // stdout.printf("match_mime_type: %s, neg: %d\n", type, (int)negated);
+
+    if(strcmp(type, "all/all") == 0 || strcmp(type, "*") == 0) {
+        return negated ? false : true;
+    }
+    else if(strcmp(type, "all/allfiles") == 0) {
+        // see if all fileinfos are files
+        if(negated) { // all fileinfos should not be files
+            for(auto& fi: files) {
+                if(!fi->isDir()) { // at least 1 of the fileinfos is a file.
+                    return false;
+                }
+            }
+        }
+        else { // all fileinfos should be files
+            for(auto& fi: files) {
+                if(fi->isDir()) { // at least 1 of the fileinfos is a file.
+                    return false;
+                }
+            }
+        }
+    }
+    else if(g_str_has_suffix(type, "/*")) {
+        // check if all are subtypes of allowed_type
+        string prefix{type};
+        prefix.erase(prefix.length() - 1); // remove the last char
+        if(negated) { // all files should not have the prefix
+            for(auto& fi: files) {
+                if(g_str_has_prefix(fi->mimeType()->name(), prefix.c_str())) {
+                    return false;
+                }
+            }
+        }
+        else { // all files should have the prefix
+            for(auto& fi: files) {
+                if(!g_str_has_prefix(fi->mimeType()->name(), prefix.c_str())) {
+                    return false;
+                }
+            }
+        }
+    }
+    else {
+        if(negated) { // all files should not be of the type
+            for(auto& fi: files) {
+                if(strcmp(fi->mimeType()->name(),type) == 0) {
+                    // if(ContentType.is_a(type, fi.get_mime_type().get_type())) {
+                    return false;
+                }
+            }
+        }
+        else { // all files should be of the type
+            for(auto& fi: files) {
+                // stdout.printf("get_type: %s, type: %s\n", fi.get_mime_type().get_type(), type);
+                if(strcmp(fi->mimeType()->name(),type) != 0) {
+                    // if(!ContentType.is_a(type, fi.get_mime_type().get_type())) {
+                    return false;
+                }
+            }
+        }
+    }
+    return true;
+}
+
+bool FileActionCondition::match_mime_types(const FileInfoList& files) {
+    if(mime_types != nullptr) {
+        bool allowed = false;
+        // FIXME: this is inefficient, but easier to implement
+        // check if all of the mime_types are allowed
+        for(auto mime_type = mime_types.get(); *mime_type; ++mime_type) {
+            const char* allowed_type = *mime_type;
+            const char* type;
+            bool negated;
+            if(allowed_type[0] == '!') {
+                type = allowed_type + 1;
+                negated = true;
+            }
+            else {
+                type = allowed_type;
+                negated = false;
+            }
+
+            if(negated) { // negated mime_type rules are ANDed
+                bool type_is_allowed = match_mime_type(files, type, negated);
+                if(!type_is_allowed) { // so any mismatch is not allowed
+                    return false;
+                }
+            }
+            else { // other mime_type rules are ORed
+                // matching any one of the mime_type is enough
+                if(!allowed) { // if no rule is matched yet
+                    allowed = match_mime_type(files, type, false);
+                }
+            }
+        }
+        return allowed;
+    }
+    return true;
+}
+
+bool FileActionCondition::match_base_name(const FileInfoList& files, const char* base_name, bool negated) const {
+    // see if all files has the base_name
+    // FIXME: this is inefficient, some optimization is needed later
+    GPatternSpec* pattern;
+    if(match_case) {
+        pattern = g_pattern_spec_new(base_name);
+    }
+    else {
+        CStrPtr case_fold{g_utf8_casefold(base_name, -1)};
+        pattern = g_pattern_spec_new(case_fold.get());    // FIXME: is this correct?
+    }
+    for(auto& fi: files) {
+        const char* name = fi->name().c_str();
+        if(match_case) {
+            if(g_pattern_match_string(pattern, name)) {
+                // at least 1 file has the base_name
+                if(negated) {
+                    return false;
+                }
+            }
+            else {
+                // at least 1 file does not has the scheme
+                if(!negated) {
+                    return false;
+                }
+            }
+        }
+        else {
+            CStrPtr case_fold{g_utf8_casefold(name, -1)};
+            if(g_pattern_match_string(pattern, case_fold.get())) {
+                // at least 1 file has the base_name
+                if(negated) {
+                    return false;
+                }
+            }
+            else {
+                // at least 1 file does not has the scheme
+                if(!negated) {
+                    return false;
+                }
+            }
+        }
+    }
+    return true;
+}
+
+bool FileActionCondition::match_base_names(const FileInfoList& files) {
+    if(base_names != nullptr) {
+        bool allowed = false;
+        // FIXME: this is inefficient, but easier to implement
+        // check if all of the base_names are allowed
+        for(auto it = base_names.get(); *it; ++it) {
+            auto allowed_name = *it;
+            const char* name;
+            bool negated;
+            if(allowed_name[0] == '!') {
+                name = allowed_name + 1;
+                negated = true;
+            }
+            else {
+                name = allowed_name;
+                negated = false;
+            }
+
+            if(negated) { // negated base_name rules are ANDed
+                bool name_is_allowed = match_base_name(files, name, negated);
+                if(!name_is_allowed) { // so any mismatch is not allowed
+                    return false;
+                }
+            }
+            else { // other base_name rules are ORed
+                // matching any one of the base_name is enough
+                if(!allowed) { // if no rule is matched yet
+                    allowed = match_base_name(files, name, false);
+                }
+            }
+        }
+        return allowed;
+    }
+    return true;
+}
+
+bool FileActionCondition::match_scheme(const FileInfoList& files, const char* scheme, bool negated) {
+    // FIXME: this is inefficient, some optimization is needed later
+    // see if all files has the scheme
+    for(auto& fi: files) {
+        if(fi->path().hasUriScheme(scheme)) {
+            // at least 1 file has the scheme
+            if(negated) {
+                return false;
+            }
+        }
+        else {
+            // at least 1 file does not has the scheme
+            if(!negated) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool FileActionCondition::match_schemes(const FileInfoList& files) {
+    if(schemes != nullptr) {
+        bool allowed = false;
+        // FIXME: this is inefficient, but easier to implement
+        // check if all of the schemes are allowed
+        for(auto it = schemes.get(); *it; ++it) {
+            auto allowed_scheme = *it;
+            const char* scheme;
+            bool negated;
+            if(allowed_scheme[0] == '!') {
+                scheme = allowed_scheme + 1;
+                negated = true;
+            }
+            else {
+                scheme = allowed_scheme;
+                negated = false;
+            }
+
+            if(negated) { // negated scheme rules are ANDed
+                bool scheme_is_allowed = match_scheme(files, scheme, negated);
+                if(!scheme_is_allowed) { // so any mismatch is not allowed
+                    return false;
+                }
+            }
+            else { // other scheme rules are ORed
+                // matching any one of the scheme is enough
+                if(!allowed) { // if no rule is matched yet
+                    allowed = match_scheme(files, scheme, false);
+                }
+            }
+        }
+        return allowed;
+    }
+    return true;
+}
+
+bool FileActionCondition::match_folder(const FileInfoList& files, const char* folder, bool negated) {
+    // trailing /* should always be implied.
+    // FIXME: this is inefficient, some optimization is needed later
+    GPatternSpec* pattern;
+    if(g_str_has_suffix(folder, "/*")) {
+        pattern = g_pattern_spec_new(folder);
+    }
+    else {
+        auto pat_str = g_str_has_suffix(folder, "/") ? string(folder) + "*" // be tolerant
+                                                     : string(folder) + "/*";
+        pattern = g_pattern_spec_new(pat_str.c_str());
+    }
+    for(auto& fi: files) {
+        auto dirname = fi->isDir() ? fi->path().toString() // also match "folder" itself
+                                   : fi->dirPath().toString();
+        // Since the pattern ends with "/*", if the directory path is equal to "folder",
+        // it should end with "/" to be found as a match. Adding "/" is always harmless.
+        auto path_str = string(dirname.get()) + "/";
+        if(g_pattern_match_string(pattern, path_str.c_str())) { // at least 1 file is in the folder
+            if(negated) {
+                return false;
+            }
+        }
+        else {
+            if(!negated) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool FileActionCondition::match_folders(const FileInfoList& files) {
+    if(folders != nullptr) {
+        bool allowed = false;
+        // FIXME: this is inefficient, but easier to implement
+        // check if all of the schemes are allowed
+        for(auto it = folders.get(); *it; ++it) {
+            auto allowed_folder = *it;
+            const char* folder;
+            bool negated;
+            if(allowed_folder[0] == '!') {
+                folder = allowed_folder + 1;
+                negated = true;
+            }
+            else {
+                folder = allowed_folder;
+                negated = false;
+            }
+
+            if(negated) { // negated folder rules are ANDed
+                bool folder_is_allowed = match_folder(files, folder, negated);
+                if(!folder_is_allowed) { // so any mismatch is not allowed
+                    return false;
+                }
+            }
+            else { // other folder rules are ORed
+                // matching any one of the folder is enough
+                if(!allowed) { // if no rule is matched yet
+                    allowed = match_folder(files, folder, false);
+                }
+            }
+        }
+        return allowed;
+    }
+    return true;
+}
+
+bool FileActionCondition::match_selection_count(const FileInfoList& files) const {
+    const int n_files = files.size();
+    switch(selection_count_cmp) {
+    case '<':
+        if(n_files >= selection_count) {
+            return false;
+        }
+        break;
+    case '=':
+        if(n_files != selection_count) {
+            return false;
+        }
+        break;
+    case '>':
+        if(n_files <= selection_count) {
+            return false;
+        }
+        break;
+    }
+    return true;
+}
+
+bool FileActionCondition::match_capabilities(const FileInfoList& /*files*/) {
+    // TODO
+    return true;
+}
+
+bool FileActionCondition::match(const FileInfoList& files) {
+    // all of the condition are combined with AND
+    // So, if any one of the conditions is not matched, we quit.
+
+    // TODO: OnlyShowIn, NotShowIn
+    if(!match_try_exec(files)) {
+        return false;
+    }
+
+    if(!match_mime_types(files)) {
+        return false;
+    }
+    if(!match_base_names(files)) {
+        return false;
+    }
+    if(!match_selection_count(files)) {
+        return false;
+    }
+    if(!match_schemes(files)) {
+        return false;
+    }
+    if(!match_folders(files)) {
+        return false;
+    }
+    // TODO: Capabilities
+    // currently, due to limitations of Fm.FileInfo, this cannot
+    // be implemanted correctly.
+    if(!match_capabilities(files)) {
+        return false;
+    }
+
+    if(!match_show_if_registered(files)) {
+        return false;
+    }
+    if(!match_show_if_true(files)) {
+        return false;
+    }
+    if(!match_show_if_running(files)) {
+        return false;
+    }
+
+    return true;
+}
+
+
+} // namespace Fm

--- a/libfm-qt/customactions/fileactioncondition.h
+++ b/libfm-qt/customactions/fileactioncondition.h
@@ -1,0 +1,123 @@
+#ifndef FILEACTIONCONDITION_H
+#define FILEACTIONCONDITION_H
+
+#include <glib.h>
+#include "../core/gioptrs.h"
+#include "../core/fileinfo.h"
+
+namespace Fm {
+
+// FIXME: we can use getgroups() to get groups of current process
+// then, call stat() and stat.st_gid to handle capabilities
+// in this way, we don't have to call euidaccess
+
+enum class FileActionCapability {
+    OWNER = 0,
+    READABLE = 1 << 1,
+    WRITABLE = 1 << 2,
+    EXECUTABLE = 1 << 3,
+    LOCAL = 1 << 4
+};
+
+
+class FileActionCondition {
+public:
+    explicit FileActionCondition(GKeyFile* kf, const char* group);
+
+#if 0
+    bool match_base_name_(const FileInfoList& files, const char* allowed_base_name) {
+        // all files should match the base_name pattern.
+        bool allowed = true;
+        if(allowed_base_name.index_of_char('*') >= 0) {
+            string allowed_base_name_ci;
+            if(!match_case) {
+                allowed_base_name_ci = allowed_base_name.casefold(); // FIXME: is this ok?
+                allowed_base_name = allowed_base_name_ci;
+            }
+            var pattern = new PatternSpec(allowed_base_name);
+            foreach(unowned FileInfo fi in files) {
+                unowned string name = fi.get_name();
+                if(match_case) {
+                    if(!pattern.match_string(name)) {
+                        allowed = false;
+                        break;
+                    }
+                }
+                else {
+                    if(!pattern.match_string(name.casefold())) {
+                        allowed = false;
+                        break;
+                    }
+                }
+            }
+        }
+        else {
+            foreach(unowned FileInfo fi in files) {
+                unowned string name = fi.get_name();
+                if(match_case) {
+                    if(allowed_base_name != name) {
+                        allowed = false;
+                        break;
+                    }
+                }
+                else {
+                    if(allowed_base_name.collate(name) != 0) {
+                        allowed = false;
+                        break;
+                    }
+                }
+            }
+        }
+        return allowed;
+    }
+#endif
+
+    bool match_try_exec(const FileInfoList& files);
+
+    bool match_show_if_registered(const FileInfoList& files);
+
+    bool match_show_if_true(const FileInfoList& files);
+
+    bool match_show_if_running(const FileInfoList& files);
+
+    static bool match_mime_type(const FileInfoList& files, const char* type, bool negated);
+
+    bool match_mime_types(const FileInfoList& files);
+
+    bool match_base_name(const FileInfoList& files, const char* base_name, bool negated) const;
+
+    bool match_base_names(const FileInfoList& files);
+
+    static bool match_scheme(const FileInfoList& files, const char* scheme, bool negated);
+
+    bool match_schemes(const FileInfoList& files);
+
+    static bool match_folder(const FileInfoList& files, const char* folder, bool negated);
+
+    bool match_folders(const FileInfoList& files);
+
+    bool match_selection_count(const FileInfoList &files) const;
+
+    bool match_capabilities(const FileInfoList& files);
+
+    bool match(const FileInfoList& files);
+
+    CStrArrayPtr only_show_in;
+    CStrArrayPtr not_show_in;
+    CStrPtr try_exec;
+    CStrPtr show_if_registered;
+    CStrPtr show_if_true;
+    CStrPtr show_if_running;
+    CStrArrayPtr mime_types;
+    CStrArrayPtr base_names;
+    bool match_case;
+    char selection_count_cmp;
+    int selection_count;
+    CStrArrayPtr schemes;
+    CStrArrayPtr folders;
+    FileActionCapability capabilities;
+};
+
+}
+
+#endif // FILEACTIONCONDITION_H

--- a/libfm-qt/customactions/fileactionprofile.cpp
+++ b/libfm-qt/customactions/fileactionprofile.cpp
@@ -1,0 +1,124 @@
+#include "fileactionprofile.h"
+#include "fileaction.h"
+#include <QDebug>
+
+using namespace std;
+
+namespace Fm {
+
+FileActionProfile::FileActionProfile(GKeyFile *kf, const char* profile_name) {
+    id = profile_name;
+    std::string group_name = "X-Action-Profile " + id;
+    name = CStrPtr{g_key_file_get_string(kf, group_name.c_str(), "Name", nullptr)};
+    exec = CStrPtr{g_key_file_get_string(kf, group_name.c_str(), "Exec", nullptr)};
+    // stdout.printf("id: %s, Exec: %s\n", id, exec);
+
+    path = CStrPtr{g_key_file_get_string(kf, group_name.c_str(), "Path", nullptr)};
+    auto s = CStrPtr{g_key_file_get_string(kf, group_name.c_str(), "ExecutionMode", nullptr)};
+    if(s) {
+        if(strcmp(s.get(), "Normal") == 0) {
+            exec_mode = FileActionExecMode::NORMAL;
+        }
+        else if(strcmp(s.get(), "Terminal") == 0) {
+            exec_mode = FileActionExecMode::TERMINAL;
+        }
+        else if(strcmp(s.get(), "Embedded") == 0) {
+            exec_mode = FileActionExecMode::EMBEDDED;
+        }
+        else if(strcmp(s.get(), "DisplayOutput") == 0) {
+            exec_mode = FileActionExecMode::DISPLAY_OUTPUT;
+        }
+        else {
+            exec_mode = FileActionExecMode::NORMAL;
+        }
+    }
+    else {
+        exec_mode = FileActionExecMode::NORMAL;
+    }
+
+    startup_notify = g_key_file_get_boolean(kf, group_name.c_str(), "StartupNotify", nullptr);
+    startup_wm_class = CStrPtr{g_key_file_get_string(kf, group_name.c_str(), "StartupWMClass", nullptr)};
+    exec_as = CStrPtr{g_key_file_get_string(kf, group_name.c_str(), "ExecuteAs", nullptr)};
+
+    condition = make_shared<FileActionCondition>(kf, group_name.c_str());
+}
+
+
+bool FileActionProfile::launch_once(GAppLaunchContext* /*ctx*/, std::shared_ptr<const FileInfo> first_file, const FileInfoList& files, CStrPtr& output) {
+    if(exec == nullptr) {
+        return false;
+    }
+    auto exec_cmd = FileActionObject::expand_str(exec.get(), files, false, first_file);
+    bool ret = false;
+    if(exec_mode == FileActionExecMode::DISPLAY_OUTPUT) {
+        int exit_status;
+        char* output_buf = nullptr;
+        ret = g_spawn_command_line_sync(exec_cmd.c_str(), &output_buf, nullptr, &exit_status, nullptr);
+        if(ret) {
+            ret = (exit_status == 0);
+        }
+        output = CStrPtr{output_buf};
+    }
+    else {
+        /*
+        AppInfoCreateFlags flags = AppInfoCreateFlags.NONE;
+        if(startup_notify)
+            flags |= AppInfoCreateFlags.SUPPORTS_STARTUP_NOTIFICATION;
+        if(exec_mode == FileActionExecMode::TERMINAL ||
+           exec_mode == FileActionExecMode::EMBEDDED)
+            flags |= AppInfoCreateFlags.NEEDS_TERMINAL;
+        GLib.AppInfo app = Fm.AppInfo.create_from_commandline(exec, nullptr, flags);
+        stdout.printf("Execute command line: %s\n\n", exec);
+        ret = app.launch(nullptr, ctx);
+        */
+
+        // NOTE: we cannot use GAppInfo here since GAppInfo does
+        // command line parsing which involving %u, %f, and other
+        // code defined in desktop entry spec.
+        // This may conflict with DES EMA parameters.
+        // FIXME: so how to handle this cleaner?
+        // Maybe we should leave all %% alone and don't translate
+        // them to %. Then GAppInfo will translate them to %, not
+        // codes specified in DES.
+        ret = g_spawn_command_line_async(exec_cmd.c_str(), nullptr);
+    }
+    return ret;
+}
+
+
+bool FileActionProfile::launch(GAppLaunchContext* ctx, const FileInfoList& files, CStrPtr& output) {
+    bool plural_form = FileActionObject::is_plural_exec(exec.get());
+    bool ret;
+    if(plural_form) { // plural form command, handle all files at a time
+        ret = launch_once(ctx, files.front(), files, output);
+    }
+    else { // singular form command, run once for each file
+        GString* all_output = g_string_sized_new(1024);
+        bool show_output = false;
+        for(auto& fi: files) {
+            CStrPtr one_output;
+            launch_once(ctx, fi, files, one_output);
+            if(one_output) {
+                show_output = true;
+                // FIXME: how to handle multiple output std::strings properly?
+                g_string_append(all_output, one_output.get());
+                g_string_append(all_output, "\n");
+            }
+        }
+        if(show_output) {
+            output = CStrPtr{g_string_free(all_output, false)};
+        }
+        else {
+            g_string_free(all_output, true);
+        }
+        ret = true;
+    }
+    return ret;
+}
+
+bool FileActionProfile::match(FileInfoList files) {
+    // stdout.printf("  match profile: %s\n", id);
+    return condition->match(files);
+}
+
+}

--- a/libfm-qt/customactions/fileactionprofile.h
+++ b/libfm-qt/customactions/fileactionprofile.h
@@ -1,0 +1,45 @@
+#ifndef FILEACTIONPROFILE_H
+#define FILEACTIONPROFILE_H
+
+
+#include <string>
+#include <glib.h>
+#include <gio/gio.h>
+
+#include "../core/fileinfo.h"
+#include "fileactioncondition.h"
+
+namespace Fm {
+
+enum class FileActionExecMode {
+    NORMAL,
+    TERMINAL,
+    EMBEDDED,
+    DISPLAY_OUTPUT
+};
+
+class FileActionProfile {
+public:
+    explicit FileActionProfile(GKeyFile* kf, const char* profile_name);
+
+    bool launch_once(GAppLaunchContext* ctx, std::shared_ptr<const FileInfo> first_file, const FileInfoList& files, CStrPtr& output);
+
+    bool launch(GAppLaunchContext* ctx, const FileInfoList& files, CStrPtr& output);
+
+    bool match(FileInfoList files);
+
+    std::string id;
+    CStrPtr name;
+    CStrPtr exec;
+    CStrPtr path;
+    FileActionExecMode exec_mode;
+    bool startup_notify;
+    CStrPtr startup_wm_class;
+    CStrPtr exec_as;
+
+    std::shared_ptr<FileActionCondition> condition;
+};
+
+} // namespace Fm
+
+#endif // FILEACTIONPROFILE_H

--- a/libfm-qt/folderview.cpp
+++ b/libfm-qt/folderview.cpp
@@ -185,6 +185,8 @@ FolderViewTreeView::FolderViewTreeView(QWidget* parent):
   setIndentation(0);
 
   connect(this, &QTreeView::activated, this, &FolderViewTreeView::activation);
+
+  this->setAlternatingRowColors(true); // probono
 }
 
 FolderViewTreeView::~FolderViewTreeView() {

--- a/libfm-qt/tests/test-filedialog.cpp
+++ b/libfm-qt/tests/test-filedialog.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2017  Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+#include <QApplication>
+#include <QMainWindow>
+#include <QToolBar>
+#include <QDebug>
+#include "../core/folder.h"
+#include "../foldermodel.h"
+#include "../folderview.h"
+#include "../cachedfoldermodel.h"
+#include "../proxyfoldermodel.h"
+#include "../pathedit.h"
+#include "../filedialog.h"
+#include "libfmqt.h"
+
+
+int main(int argc, char** argv) {
+    QApplication app(argc, argv);
+
+    Fm::LibFmQt contex;
+
+    /*
+    QFileDialog dlg0;
+    dlg0.setFileMode(QFileDialog::ExistingFiles);
+
+    dlg0.setNameFilters(QStringList() << "Txt (*.txt)");
+    QObject::connect(&dlg0, &QFileDialog::currentChanged, [](const QString& path) {
+        qDebug() << "currentChanged:" << path;
+    });
+    QObject::connect(&dlg0, &QFileDialog::fileSelected, [](const QString& path) {
+        qDebug() << "fileSelected:" << path;
+    });
+    QObject::connect(&dlg0, &QFileDialog::filesSelected, [](const QStringList& paths) {
+        qDebug() << "filesSelected:" << paths;
+    });
+
+    dlg0.exec();
+    */
+
+    Fm::FileDialog dlg;
+    // dlg.setFileMode(QFileDialog::ExistingFile);
+    dlg.setFileMode(QFileDialog::ExistingFiles);
+    // dlg.setFileMode(QFileDialog::Directory);
+    dlg.setNameFilters(QStringList() << QStringLiteral("All (*)") << QStringLiteral("Text (*.txt)") << QStringLiteral("Images (*.gif *.jpeg *.jpg)"));
+
+    dlg.exec();
+    qDebug() << "selected files:" << dlg.selectedFiles();
+
+    return 0;
+}

--- a/libfm-qt/tests/test-folder.cpp
+++ b/libfm-qt/tests/test-folder.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2017  Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+#include <QApplication>
+#include <QDebug>
+#include "../core/folder.h"
+
+int main(int argc, char** argv) {
+    QApplication app(argc, argv);
+
+    auto home = Fm::FilePath::homeDir();
+    auto folder = Fm::Folder::fromPath(home);
+
+    QObject::connect(folder.get(), &Fm::Folder::startLoading, [=]() {
+        qDebug("start loading");
+    });
+    QObject::connect(folder.get(), &Fm::Folder::finishLoading, [=]() {
+        qDebug("finish loading");
+    });
+
+    QObject::connect(folder.get(), &Fm::Folder::filesAdded, [=](Fm::FileInfoList& files) {
+        qDebug("files added");
+        for(auto& item: files) {
+            qDebug() << item->displayName();
+        }
+    });
+    QObject::connect(folder.get(), &Fm::Folder::filesRemoved, [=](Fm::FileInfoList& files) {
+        qDebug("files removed");
+        for(auto& item: files) {
+            qDebug() << item->displayName();
+        }
+    });
+    QObject::connect(folder.get(), &Fm::Folder::filesChanged, [=](std::vector<Fm::FileInfoPair>& file_pairs) {
+        qDebug("files changed");
+        for(auto& pair: file_pairs) {
+            auto& item = pair.second;
+            qDebug() << item->displayName();
+        }
+    });
+
+    for(auto& item: folder->files()) {
+        qDebug() << item->displayName();
+    }
+    qDebug() << "here";
+
+    return app.exec();
+}

--- a/libfm-qt/tests/test-folderview.cpp
+++ b/libfm-qt/tests/test-folderview.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2017  Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+#include <QApplication>
+#include <QMainWindow>
+#include <QToolBar>
+#include <QDebug>
+#include "../core/folder.h"
+#include "../foldermodel.h"
+#include "../folderview.h"
+#include "../cachedfoldermodel.h"
+#include "../proxyfoldermodel.h"
+#include "../pathedit.h"
+#include "libfmqt.h"
+
+int main(int argc, char** argv) {
+    QApplication app(argc, argv);
+
+    Fm::LibFmQt contex;
+    QMainWindow win;
+
+    Fm::FolderView folder_view;
+    win.setCentralWidget(&folder_view);
+
+    auto home = Fm::FilePath::homeDir();
+    Fm::CachedFolderModel* model = Fm::CachedFolderModel::modelFromPath(home);
+    auto proxy_model = new Fm::ProxyFolderModel();
+    proxy_model->sort(Fm::FolderModel::ColumnFileName, Qt::AscendingOrder);
+    proxy_model->setSourceModel(model);
+
+    proxy_model->setThumbnailSize(64);
+    proxy_model->setShowThumbnails(true);
+
+    folder_view.setModel(proxy_model);
+
+    QToolBar toolbar;
+    win.addToolBar(Qt::TopToolBarArea, &toolbar);
+    Fm::PathEdit edit;
+    edit.setText(QString::fromUtf8(home.toString().get()));
+    toolbar.addWidget(&edit);
+    auto action = new QAction(QStringLiteral("Go"), nullptr);
+    toolbar.addAction(action);
+    QObject::connect(action, &QAction::triggered, [&]() {
+        auto path = Fm::FilePath::fromPathStr(edit.text().toLocal8Bit().constData());
+        auto new_model = Fm::CachedFolderModel::modelFromPath(path);
+        proxy_model->setSourceModel(new_model);
+    });
+
+    win.show();
+    return app.exec();
+}

--- a/libfm-qt/tests/test-placesview.cpp
+++ b/libfm-qt/tests/test-placesview.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2017  Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+#include <QApplication>
+#include <QMainWindow>
+#include <QToolBar>
+#include <QDir>
+#include <QDebug>
+#include "../placesview.h"
+#include "libfmqt.h"
+
+int main(int argc, char** argv) {
+    QApplication app(argc, argv);
+
+    Fm::LibFmQt contex;
+    QMainWindow win;
+
+    Fm::PlacesView view;
+    win.setCentralWidget(&view);
+
+    win.show();
+    return app.exec();
+}

--- a/libfm-qt/tests/test-volumemanager.cpp
+++ b/libfm-qt/tests/test-volumemanager.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2017  Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+#include <QApplication>
+#include <QDir>
+#include <QDebug>
+#include "../core/volumemanager.h"
+
+int main(int argc, char** argv) {
+    QApplication app(argc, argv);
+
+    auto vm = Fm::VolumeManager::globalInstance();
+
+    QObject::connect(vm.get(), &Fm::VolumeManager::volumeAdded, [=](const Fm::Volume& vol) {
+        qDebug() << "volume added:" << vol.name().get();
+    });
+    QObject::connect(vm.get(), &Fm::VolumeManager::volumeRemoved, [=](const Fm::Volume& vol) {
+        qDebug() << "volume removed:" << vol.name().get();
+    });
+
+    for(auto& item: vm->volumes()) {
+        auto name = item.name();
+        qDebug() << "list volume:" << name.get();
+    }
+
+    return app.exec();
+}


### PR DESCRIPTION
These files are taken directly from <https://github.com/lxqt/libfm-qt>, and contain C++ files and headers for handling file operations.

Somehow @probonopd managed to compile Filer without them, I'm assuming that's because he had the files already in /usr/include.

Anyway, these can now be modified to help fix issue #53.