### PR TITLE
Application: fix initialisation of sigaction struct

### DIFF
--- a/filer/application.cpp
+++ b/filer/application.cpp
@@ -837,7 +837,7 @@ void Application::installSigtermHandler() {
     QSocketNotifier* notifier = new QSocketNotifier(sigterm_fd[1], QSocketNotifier::Read, this);
     connect(notifier, &QSocketNotifier::activated, this, &Application::onSigtermNotified);
 
-    struct sigaction action;
+    struct sigaction action = {};
     action.sa_handler = sigtermHandler;
     ::sigemptyset(&action.sa_mask);
     action.sa_flags |= SA_RESTART;


### PR DESCRIPTION
valgrind complained that `sa_flags` wasn't initialised - could have possibly caused
problems depending on compiler/toolchain. Fixed by initialising the struct before use.

Signed-off-by: Chris Moore <chris@mooreonline.org>

@probonopd please review