### PR TITLE
Application: fix check for environment variable on Linux

### DIFF
--- a/filer/application.cpp
+++ b/filer/application.cpp
@@ -109,8 +109,8 @@ Application::Application(int& argc, char** argv):
     // probono: On systems that are supposed to have a global menu bar, wait for the
     // global menu bar service to appear on D-Bus before we do anything in order to
     // prevent Filer from launching the desktop before the global menu is ready
-    QByteArray globalMenuEnv  = qgetenv("UBUNTU_MENUPROXY");
-    if (globalMenuEnv.data()!=NULL) {
+    QString globalMenuEnv  = QString::fromLocal8Bit(qgetenv("UBUNTU_MENUPROXY"));
+    if ( ! globalMenuEnv.isEmpty() ) {
         qDebug("Waiting for global menu to appear on D-Bus...");
         while(true) {
             QDBusInterface* menuIface = new QDBusInterface(


### PR DESCRIPTION
Seemed to return a non-NULL value for the `QByteArray` on Linux when the
environment variable wasn't set. Changed so we instead put it into a
`QString` and check if `isEmpty()`, which returns true for NULL and also
empty strings ("").

Signed-off-by: Chris Moore <chris@mooreonline.org>

@probonopd please review